### PR TITLE
Changes check order in 'Tutorial - Decalring a Winner'

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -767,7 +767,7 @@ Now the whole Board component looks like this:
 class Board extends React.Component {
   handleClick(i) {
     const squares = this.state.squares.slice();
-    if (calculateWinner(squares) || squares[i]) {
+    if (squares[i] || calculateWinner(squares)) {
       return;
     }
     squares[i] = this.state.xIsNext ? 'X' : 'O';
@@ -886,7 +886,7 @@ We also need to change it a little, since Game state is structured differently. 
     const history = this.state.history;
     const current = history[history.length - 1];
     const squares = current.squares.slice();
-    if (calculateWinner(squares) || squares[i]) {
+    if (squares[i] || calculateWinner(squares)) {
       return;
     }
     squares[i] = this.state.xIsNext ? 'X' : 'O';
@@ -1060,7 +1060,7 @@ Then update `stepNumber` when a new move is made by adding `stepNumber: history.
     const history = this.state.history.slice(0, this.state.stepNumber + 1);
     const current = history[history.length - 1];
     const squares = current.squares.slice();
-    if (calculateWinner(squares) || squares[i]) {
+    if (squares[i] || calculateWinner(squares)) {
       return;
     }
     squares[i] = this.state.xIsNext ? 'X' : 'O';

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -677,12 +677,12 @@ Replace the `status` declaration in Board's `render` with this code:
       // the rest has not changed
 ```
 
-You can now change `handleClick` in Board to return early and ignore the click if someone has already won the game or if a square is already filled:
+You can now change `handleClick` in Board to return early and ignore the click if a square is already filled or if someone has already won the game:
 
 ```javascript{3-5}
   handleClick(i) {
     const squares = this.state.squares.slice();
-    if (calculateWinner(squares) || squares[i]) {
+    if (squares[i] || calculateWinner(squares)) {
       return;
     }
     squares[i] = this.state.xIsNext ? 'X' : 'O';


### PR DESCRIPTION
It looks like it's better to check whether square is already filled before checking for winner with much heavier function. No big deal here, but seems like common courtesy.