### PR TITLE
Add Post component since unclear

### DIFF
--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -253,7 +253,7 @@ Keys serve as a hint to React but they don't get passed to your components. If y
 ```js{12,13}
 function Post(props) {
   return (
-    <div key={props.id}>
+    <div id={props.id}>
       <h3>{props.title}</h3>
       <p>{props.content}</p>
     </div>

--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -250,12 +250,22 @@ ReactDOM.render(
 
 Keys serve as a hint to React but they don't get passed to your components. If you need the same value in your component, pass it explicitly as a prop with a different name:
 
-```js{3,4}
+```js{12,13}
+function Post(props) {
+  return (
+    <div key={props.id}>
+      <h3>{props.title}</h3>
+      <p>{props.content}</p>
+    </div>
+  );
+}
+
 const content = posts.map((post) =>
   <Post
     key={post.id}
     id={post.id}
-    title={post.title} />
+    title={post.title}
+    content={post.content} />
 );
 ```
 


### PR DESCRIPTION
In the lists-and-keys.html document, was going to replace the _content_ variable but component did not exist and was unclear until creating it by hand.