### PR TITLE
Add back the explanation of React's onChange vs. DOM "input" event.

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -66,7 +66,7 @@ class NameForm extends React.Component {
 
 [Try it on CodePen.](https://codepen.io/gaearon/pen/VmmPgp?editors=0010)
 
-Since the `value` attribute is set on our form element, the displayed value will always be `this.state.value`, making the React state the source of truth. Since `handleChange` runs on every keystroke to update the React state, the displayed value will update as the user types.
+Since the `value` attribute is set on our form element, the displayed value will always be `this.state.value`, making the React state the source of truth. In React, the `onChange` event handler is used to listen to changes to form elements of all types. For a text field, React's `onChange` is called on every keystroke, like the [DOM `input` event](https://developer.mozilla.org/en-US/docs/Web/Events/input) and unlike the [DOM `change` event](https://developer.mozilla.org/en-US/docs/Web/Events/change), which normally does not fire until the text field loses focus. Thus, with every keystroke, `handleChange` will update the React state and the displayed value will reflect what the user typed.
 
 With a controlled component, every state mutation will have an associated handler function. This makes it straightforward to modify or validate user input. For example, if we wanted to enforce that names are written with all uppercase letters, we could write `handleChange` as:
 

--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -52,7 +52,7 @@ Since `for` is a reserved word in JavaScript, React elements use `htmlFor` inste
 
 ### onChange
 
-The `onChange` event behaves as you would expect it to: whenever a form field is changed, this event is fired. We intentionally do not use the existing browser behavior because `onChange` is a misnomer for its behavior and React relies on this event to handle user input in real time.
+The `onChange` event behaves as you would expect it to: whenever a form field is changed, this event is fired. For some form field types, React's `onChange` event is similar to the [DOM `input` event](https://developer.mozilla.org/en-US/docs/Web/Events/input) and unlike the [DOM `change` event](https://developer.mozilla.org/en-US/docs/Web/Events/change), which does not fire until a change is "committed". We intentionally do not use the existing browser behavior because `onChange` is a misnomer for its behavior and React relies on this event to handle user input in real time.
 
 ### selected
 


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/3964 again after the
information was lost in 809e282.

FWIW, re the necessity of this change, as a new React user reading the [Forms page](https://reactjs.org/docs/forms.html), I didn't understand how the example could possibly work until I searched the web for the relationship between `onChange` and `onInput` and found [this thread](https://stackoverflow.com/questions/38256332/in-react-whats-the-difference-between-onchange-and-oninput), which links to the issue.