### PR TITLE
setState callback semantics

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -362,8 +362,8 @@ To fix it, use a second form of `setState()` that accepts a function rather than
 
 ```js
 // Correct
-this.setState((prevState, props) => ({
-  counter: prevState.counter + props.increment
+this.setState((currentState, currentProps) => ({
+  counter: currentState.counter + currentProps.increment
 }));
 ```
 
@@ -371,9 +371,9 @@ We used an [arrow function](https://developer.mozilla.org/en/docs/Web/JavaScript
 
 ```js
 // Correct
-this.setState(function(prevState, props) {
+this.setState(function(currentState, currentProps) {
   return {
-    counter: prevState.counter + props.increment
+    counter: currentState.counter + currentProps.increment
   };
 });
 ```


### PR DESCRIPTION
The `setState` callback does not pass previousState as an argument, it passes the current state, and uses it to set the next state.

I brought this up to Dan on [twitter](https://twitter.com/dan_abramov/status/964296359758221312) and I think we agreed that the rename of the props here is correct in the documentation.

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

NA
