### PR TITLE
React.cloneElement => props are objects not arrays

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -104,7 +104,7 @@ Code written with [JSX](/docs/introducing-jsx.html) will be converted to use `Re
 ```
 React.cloneElement(
   element,
-  [props],
+  {props},
   [...children]
 )
 ```


### PR DESCRIPTION
Changing brackets to squiggly brackets because props being passed into cloned elements should be objects and not arrays. This can be confusing.