### PR TITLE
Update tutorial.md

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1043,6 +1043,7 @@ Add a method called `jumpTo` to the Game class:
 
   jumpTo(step) {
     this.setState({
+      history: this.state.history.slice(0, step + 1),
       stepNumber: step,
       xIsNext: (step % 2) === 0,
     });


### PR DESCRIPTION
Update `jumpTo` method, so the **Showing the Moves** list will be update immediately after click `Go to move #...`, not after click some squares.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
