### PR TITLE
difference in document vs code in code pen

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1057,7 +1057,7 @@ Then update `stepNumber` when a new move is made by adding `stepNumber: history.
 
 ```javascript{2,13}
   handleClick(i) {
-    const history = this.state.history.slice(0, this.state.stepNumber + 1);
+    const history = this.state.history;
     const current = history[history.length - 1];
     const squares = current.squares.slice();
     if (calculateWinner(squares) || squares[i]) {


### PR DESCRIPTION
Changing this from    const history = this.state.history.slice(0, this.state.stepNumber + 1); to     const history = this.state.history; 
As slicing the history leads to losing the list elements and inability to go back to current state



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
