### PR TITLE
Add explanation for optional argument of TestRenderer.create

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -104,6 +104,8 @@ TestRenderer.create(element, options);
 
 Create a `TestRenderer` instance with the passed React element. It doesn't use the real DOM, but it still fully renders the component tree into memory so you can make assertions about it. The returned instance has the following methods and properties.
 
+You may pass an optional argument, `createNodeMock` function, to mock refs for Jest [snapshot testing](http://facebook.github.io/jest/docs/en/snapshot-testing.html#snapshot-testing-with-jest). Check [this article](https://reactjs.org/blog/2016/11/16/react-v15.4.0.html#mocking-refs-for-snapshot-testing) for detailed usage.
+
 ### `testRenderer.toJSON()`
 
 ```javascript


### PR DESCRIPTION
In API reference of [react-test-renderer](https://reactjs.org/docs/test-renderer.html#testrenderercreate), I couldn't figure how to use the `options` argument of `TestRenderer.create()` method to mock refs for Jest snapshop testing.

I found [this article](https://reactjs.org/blog/2016/11/16/react-v15.4.0.html#mocking-refs-for-snapshot-testing) explains how, so added a link to the article on the API reference page.