### PR TITLE
WIP: Support linking to anchor tags in sidebar

### DIFF
--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -85,6 +85,9 @@
       subitems:
         - id: react-component
           title: React.Component
+        - id: react-component
+          anchor: render
+          title: render
     - id: react-dom
       title: ReactDOM
     - id: react-dom-server

--- a/src/utils/createLink.js
+++ b/src/utils/createLink.js
@@ -67,7 +67,7 @@ const createLinkDocs = ({
   return (
     <Link
       css={[linkCss, isActive && activeLinkCss]}
-      to={slugify(item.id, section.directory)}>
+      to={slugify(item.id, section.directory) + `${item.anchor ? ('#' + item.anchor) : ''}`}>
       {isActive && <span css={activeLinkBefore} />}
       {item.title}
     </Link>

--- a/src/utils/createLink.js
+++ b/src/utils/createLink.js
@@ -15,8 +15,16 @@ import type {Node} from 'react';
 
 type CreateLinkBaseProps = {
   isActive: boolean,
-  item: Object,
-  section: Object,
+  item: {
+    id: string,
+    title: string,
+    anchor?: string,
+    href?: string,
+    subitems: Object[],
+  },
+  section: {
+    directory: string,
+  },
 };
 
 const createLinkBlog = ({
@@ -67,7 +75,10 @@ const createLinkDocs = ({
   return (
     <Link
       css={[linkCss, isActive && activeLinkCss]}
-      to={slugify(item.id, section.directory) + `${item.anchor ? ('#' + item.anchor) : ''}`}>
+      to={
+        slugify(item.id, section.directory) +
+        (item.anchor ? `#${item.anchor}` : '')
+      }>
       {isActive && <span css={activeLinkBefore} />}
       {item.title}
     </Link>


### PR DESCRIPTION
https://twitter.com/jimmycallin/status/1005919344264609792

Can probably pull out the logic into the `createLinkDocs` function

TODO:
- [ ] Only highlight active anchor instead of all links with same base route
- [ ] Link to the rest of the lifecycle methods
- [x] update Flow types
- [ ] Pull hash-concatenation logic into `utils/createLinks`
- [ ] Maybe: Use object format for React-Router Link `to` prop instead of string: https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md#to-object

---

Fixes #950 

---

➡️ If anyone wants to claim this issue feel free to continue a PR off this branch