### PR TITLE
updated docs on context rerender.

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -76,7 +76,9 @@ Requires a [function as a child](/docs/render-props.html#using-props-other-than-
 > 
 > For more information about the 'function as a child' pattern, see [render props](/docs/render-props.html).
 
-All Consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. The propagation from Provider to its descendant Consumers is not subject to the `shouldComponentUpdate` method, so the Consumer is updated even when an ancestor component bails out of the update.
+All Consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. Components which are first level consumers and have Consumers in their render functions get updated with new values, but do not actually re-render.
+
+The propagation from Provider to its descendant Consumers is not subject to the `shouldComponentUpdate` method, so the Consumer is updated even when an ancestor component bails out of the update.
 
 Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description). 
 

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -78,7 +78,7 @@ Requires a [function as a child](/docs/render-props.html#using-props-other-than-
 
 All Consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. The propagation from Provider to its descendant Consumers is not subject to the `shouldComponentUpdate` method, so the Consumer is updated even when an ancestor component bails out of the update.
 
-What this means is that Components which are not descendents of a Consumer but have Consumers in their render functions get updated with new values, but do not actually re-render. Components which have Consumer as their ascendent will re-render whenver the Providers value changes.
+What this means is that Components which are not descendents of a Consumer but have Consumers in their render functions get updated with new values, but do not actually re-render. Components which have Consumer as their ascendent will re-render whenever the Providers value changes.
 
 Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description). 
 

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -76,9 +76,9 @@ Requires a [function as a child](/docs/render-props.html#using-props-other-than-
 > 
 > For more information about the 'function as a child' pattern, see [render props](/docs/render-props.html).
 
-All Consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. Components which are first level consumers and have Consumers in their render functions get updated with new values, but do not actually re-render.
+All Consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. The propagation from Provider to its descendant Consumers is not subject to the `shouldComponentUpdate` method, so the Consumer is updated even when an ancestor component bails out of the update.
 
-The propagation from Provider to its descendant Consumers is not subject to the `shouldComponentUpdate` method, so the Consumer is updated even when an ancestor component bails out of the update.
+What this means is that Components which are not descendents of a Consumer but have Consumers in their render functions get updated with new values, but do not actually re-render. Components which have Consumer as their ascendent will re-render whenver the Providers value changes.
 
 Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description). 
 


### PR DESCRIPTION
While playing with context I realized that first level Consumers (components which have consumers inside their render method and none of their ascendents nodes are a consumer) do not actually rerender, but do react to the updated context value.

Would be good idea to mention this in the documentation.

eg - https://codesandbox.io/s/l2kx18n35z

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
