### PR TITLE
modified outline on topic links for side navbar

### DIFF
--- a/src/templates/components/Sidebar/Section.js
+++ b/src/templates/components/Sidebar/Section.js
@@ -34,6 +34,10 @@ class Section extends React.Component {
             backgroundColor: 'transparent',
             border: 0,
             marginTop: 10,
+
+            ':focus': {
+              outline: '1px dotted black',
+            },
           }}
           onClick={onSectionTitleClick}>
           <MetaTitle


### PR DESCRIPTION
@AlmeroSteyn this one is in reference to #1066 . I changed it a bit as discussed in the issue. Below are the screenshots for the same. I tested it on chrome v66.0.3359.181, chrome on Android and firefox 61.0.1

![screenshot from 2018-07-20 15-28-20](https://user-images.githubusercontent.com/23500643/42996885-8daaaf6a-8c32-11e8-909d-7842e668e563.png)
![screenshot from 2018-07-20 15-28-20](https://user-images.githubusercontent.com/23500643/42996936-b346ee0a-8c32-11e8-97c2-42fc6ea42af1.png)

#1066 
