### PR TITLE
Add false to conditional-rendering

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -190,7 +190,7 @@ Just like in JavaScript, it is up to you to choose an appropriate style based on
 
 ### Preventing Component from Rendering
 
-In rare cases you might want a component to hide itself even though it was rendered by another component. To do this return `null` instead of its render output.
+In rare cases you might want a component to hide itself even though it was rendered by another component. To do this return `null` or `false` instead of its render output.
 
 In the example below, the `<WarningBanner />` is rendered depending on the value of the prop called `warn`. If the value of the prop is `false`, then the component does not render:
 
@@ -238,6 +238,18 @@ ReactDOM.render(
 );
 ```
 
+In this refactored version of `<WarningBanner />` (below), you can see the benefits of returning `false` over `null`. Here we use a logical AND to return either `false` or the rendered warning.
+
+```javascript
+const WarningBanner = ({ warn }) => (
+  warn && (
+    <div className="warning">
+      Warning!
+    </div>
+  )
+);
+```
+
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/Xjoqwm?editors=0010)
 
-Returning `null` from a component's `render` method does not affect the firing of the component's lifecycle methods. For instance `componentDidUpdate` will still be called.
+Returning `null` or `false` from a component's `render` method does not affect the firing of the component's lifecycle methods. For instance `componentDidUpdate` will still be called.


### PR DESCRIPTION
Conditional rendering can return `null` or `false`. Add the `false` condition and show an example that benefits from using `false` over `null`.

Here's the current example:
```js
function WarningBanner(props) {
  if (!props.warn) {
    return null;
  }

  return (
    <div className="warning">
      Warning!
    </div>
  );
}
```

But by returning `false`, you can do this:
```javascript
const WarningBanner = ({ warn }) => (
  warn && (
    <div className="warning">
      Warning!
    </div>
  )
);
```