### PR TITLE
Add info to Children.toArray docs about invalid elements

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -198,7 +198,7 @@ Verifies that `children` has only one child (a React element) and returns it. Ot
 React.Children.toArray(children)
 ```
 
-Returns the `children` opaque data structure as a flat array with keys assigned to each child. Useful if you want to manipulate collections of children in your render methods, especially if you want to reorder or slice `this.props.children` before passing it down.
+Returns the `children` opaque data structure as a flat array with keys assigned to each child, filtering out invalid elements such as `undefined`, `null` and `boolean` values. Useful if you want to manipulate collections of children in your render methods, especially if you want to reorder or slice `this.props.children` before passing it down.
 
 > Note:
 >


### PR DESCRIPTION
This adds to the `React.Children.toArray` documentation to mention that it will filter out invalid elements.

I needed to filter out invalid child elements in an application I am working on. When searching for the best approach, I came across an old github issue https://github.com/facebook/react/issues/2956, and found that the discussion led to the creation of `React.Children.toArray`. I didn't realize that `toArray` would do this, even after reading the docs for it. I thought it would be helpful to add, so I decided to open a PR. Feel free to suggest any changes to the wording, or close if you think it's not necessary.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
