### PR TITLE
docs: document ShallowRenderer.createRenderer

### DIFF
--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -36,7 +36,7 @@ Then you can assert:
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 // in your test:
-const renderer = new ShallowRenderer();
+const renderer = ShallowRenderer().createRenderer();
 renderer.render(<MyComponent />);
 const result = renderer.getRenderOutput();
 


### PR DESCRIPTION
by  https://github.com/facebook/react/blob/9f78913b20d52a5849dd26aafebfbc3caf190812/packages/react-test-renderer/src/ReactShallowRenderer.js#L23
a shallow renderer is created with `.createRenderer()` and not with the `new` keyword as currently stated by https://reactjs.org/docs/shallow-renderer.html

