### PR TITLE
Fix bug in getDerivedStateFromProps example

### DIFF
--- a/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
+++ b/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
@@ -155,8 +155,8 @@ If `key` doesn't work for some reason (perhaps the component is very expensive t
 ```js
 class EmailInput extends Component {
   state = {
-    email: this.props.defaultEmail,
-    prevPropsUserID: this.props.userID
+    email: null,
+    prevPropsUserID: null
   };
 
   static getDerivedStateFromProps(props, state) {


### PR DESCRIPTION
prevPropsUserID needs to be null to be set properly when the component is mounted, due to the conditional check in getDerivedStateFromProps. The conditional would otherwise be 'false' on mount, and thus no state would be given.

email should probably also be null, for consistency, even though it won't make a practical difference here.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
