### PR TITLE
Fix code explanation of setState({…}) behavior

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -459,9 +459,10 @@ This form of `setState()` is also asynchronous, and multiple calls during the sa
 
 ```javaScript
 Object.assign(
+  {},
   previousState,
-  {quantity: state.quantity + 1},
-  {quantity: state.quantity + 1},
+  {quantity: previousState.quantity + 1},
+  {quantity: previousState.quantity + 1},
   ...
 )
 ```


### PR DESCRIPTION
- The example mutates `previousState`. Fixed by prepending `{}` to the argument list.
- Two different variables (previousState, state) are used, which may cause confusion, fixed by always using the name `previousState`.
