### PR TITLE
Adding `getDerivedStateFromProps` to "react-without-es6" section

### DIFF
--- a/content/docs/react-without-es6.md
+++ b/content/docs/react-without-es6.md
@@ -223,3 +223,22 @@ ReactDOM.render(
 ```
 
 If a component is using multiple mixins and several mixins define the same lifecycle method (i.e. several mixins want to do some cleanup when the component is destroyed), all of the lifecycle methods are guaranteed to be called. Methods defined on mixins run in the order mixins were listed, followed by a method call on the component.
+
+## getDerivedStateFromProps
+
+If you need to add the static [`getDerivedStateFromProps`](/docs/react-component.html#static-getderivedstatefromprops) lifecycle, you can do it by adding the method `getDerivedStateFromProps()` under the `statics` key like:
+
+```js{2-5}
+var Component = createReactClass({
+  statics: {
+    getDerivedStateFromProps(props, state) {
+      // ...
+    },
+    render() {
+      <div>I am a component</div>
+    }
+  }
+});
+```
+
+**Note:** Note `getDerivedStateFromProps` is generally meant to be last resort and not recommended except a few edge cases. You can read more about it in [this blog post](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html)


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Adding `getDerivedStateFromProps` to `React Without ES6 section`.

Closes https://github.com/reactjs/reactjs.org/issues/1214

Let me know if I any update is needed, thanks!