### PR TITLE
Clarify when componentDidUpdate() is invoked

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -207,7 +207,7 @@ You **may call `setState()` immediately** in `componentDidMount()`. It will trig
 componentDidUpdate(prevProps, prevState, snapshot)
 ```
 
-`componentDidUpdate()` is invoked immediately after updating occurs. This method is not called for the initial render.
+`componentDidUpdate()` is invoked immediately after a `render()` occurs,  including in cases where no change is made to the DOM. This method is not called for the initial render.
 
 Use this as an opportunity to operate on the DOM when the component has been updated. This is also a good place to do network requests as long as you compare the current props to previous props (e.g. a network request may not be necessary if the props have not changed).
 


### PR DESCRIPTION
There have been several requests to clarify when `componentDidUpdate()` is called, most recently [issue #1135](https://github.com/reactjs/reactjs.org/issues/1135). This change provides the level of specificity folks are asking for and may head off questions like, "Why is `componentDidUpdate()` firing when I didn't update the DOM?"