### PR TITLE
Added a comma for making the much more sensible

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -146,7 +146,7 @@ constructor(props)
 
 The constructor for a React component is called before it is mounted. When implementing the constructor for a `React.Component` subclass, you should call `super(props)` before any other statement. Otherwise, `this.props` will be undefined in the constructor, which can lead to bugs.
 
-Typically, in React constructors are only used for two purposes:
+Typically, in React, constructors are only used for two purposes:
 
 * Initializing [local state](/docs/state-and-lifecycle.html) by assigning an object to `this.state`.
 * Binding [event handler](/docs/handling-events.html) methods to an instance.

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -146,7 +146,7 @@ constructor(props)
 
 The constructor for a React component is called before it is mounted. When implementing the constructor for a `React.Component` subclass, you should call `super(props)` before any other statement. Otherwise, `this.props` will be undefined in the constructor, which can lead to bugs.
 
-Typically, in React, constructors are only used for two purposes:
+Typically in React, constructors are only used for two purposes:
 
 * Initializing [local state](/docs/state-and-lifecycle.html) by assigning an object to `this.state`.
 * Binding [event handler](/docs/handling-events.html) methods to an instance.


### PR DESCRIPTION
Added a comma in the statement which was confusing the readers like me because of the word 'Typically'. Now it makes much more sense about 'Typically, in React components'.