### PR TITLE
Removes unused code from useReducer example

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -193,7 +193,7 @@ function reducer(state, action) {
   }
 }
 
-function Counter({initialCount}) {
+function Counter() {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <>


### PR DESCRIPTION
`initialCount` isn't used in the first `useReducer` example and could be removed.
