### PR TITLE
Amended the documentation about refs

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -97,6 +97,7 @@ class CustomTextInput extends React.Component {
         <input
           type="button"
           value="Focus the text input"
+          // Note: We do not pass "this.textInput.current.focus" here directly
           onClick={this.focusTextInput}
         />
       </div>
@@ -105,7 +106,7 @@ class CustomTextInput extends React.Component {
 }
 ```
 
-React will assign the `current` property with the DOM element when the component mounts, and assign it back to `null` when it unmounts. `ref` updates happen before `componentDidMount` or `componentDidUpdate` lifecycle methods.
+React will assign the `current` property with the DOM element when the component mounts, and assign it back to `null` when it unmounts. `ref` updates happen before `componentDidMount` or `componentDidUpdate` lifecycle methods. For this reason, we need to wrap `this.textInput.current.focus()` with focusTextInput, instead of passing `this.textInput.current.focus` directly to `onClick`handler.
 
 #### Adding a Ref to a Class Component
 


### PR DESCRIPTION
The motivation for adding a slight elaboration to the documentation was caused by me struggling to have refs working for several hours, hence creating this question: https://stackoverflow.com/questions/53023869/react-refs-cannot-read-property-focus-of-null



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
