### PR TITLE
Clarify that you can't return early between Hooks

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -12,7 +12,7 @@ Hooks are JavaScript functions, but you need to follow two rules when using them
 
 ### Only Call Hooks at the Top Level
 
-**Don't call Hooks inside loops, conditions, or nested functions.** Instead, always use Hooks at the top level of your React function. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
+**Don't call Hooks inside loops, conditions, or nested functions, nor after conditional return statements.** Instead, always use Hooks at the top level of your React function and make sure every one is called. By following this rule, you ensure that the same number of Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
 
 ### Only Call Hooks from React Functions
 


### PR DESCRIPTION
...Otherwise you get an error like `Uncaught Error: Rendered fewer hooks than expected. This may be caused by an accidental early return statement.` in `finishHooks`.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
