### PR TITLE
Length of useEffect second argument

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -153,7 +153,7 @@ Passing in an empty array `[]` of inputs tells React that your effect doesn't de
 
 > Note
 >
-> The array of inputs is not passed as arguments to the effect function. Conceptually, though, that's what they represent: every value referenced inside the effect function should also appear in the inputs array. In the future, a sufficiently advanced compiler could create this array automatically.
+> The array of inputs is not passed as arguments to the effect function. Conceptually, though, that's what they represent: every value referenced inside the effect function should also appear in the inputs array. Similarly, the array should be a static length (i.e. you cannot change what inputs the effect depends upon during runtime). In the future, a sufficiently advanced compiler could create this array automatically.
 
 ### `useContext`
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

[From this issue](https://github.com/facebook/react/issues/14090), adds a note to the docs that the second argument to `useEffect` must have a static length.