### PR TITLE
Standardization of colon use in yellow blockquote heading text.

### DIFF
--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -104,7 +104,7 @@ Commonly, you might want to display React components in multiple places on the H
 
 [Download the full example (2KB zipped)](https://gist.github.com/gaearon/faa67b76a6c47adbab04f739cba7ceda/archive/9d0dd0ee941fea05fd1357502e5aa348abb84c12.zip)
 
->Note
+>Note:
 >
 >This strategy is mostly useful while React-powered parts of the page are isolated from each other. Inside React code, it's easier to use [component composition](/docs/components-and-props.html#composing-components) instead.
 
@@ -187,7 +187,7 @@ Create a folder called `src` and run this terminal command:
 npx babel --watch src --out-dir . --presets react-app/prod 
 ```
 
->Note
+>Note:
 >
 >`npx` is not a typo -- it's a [package runner tool that comes with npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 >

--- a/content/docs/addons-perf.md
+++ b/content/docs/addons-perf.md
@@ -83,7 +83,7 @@ Perf.getLastMeasurements()
 
 Get the opaque data structure describing measurements from the last start-stop session. You can save it and pass it to the other print methods in [`Perf`](#printing-results) to analyze past measurements.
 
-> Note
+> Note:
 >
 > Don't rely on the exact format of the return value because it may change in minor releases. We will update the documentation if the return value format becomes a supported part of the public API.
 

--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -83,7 +83,7 @@ ReactTestUtils.Simulate.change(node);
 ReactTestUtils.Simulate.keyDown(node, {key: "Enter", keyCode: 13, which: 13});
 ```
 
-> Note
+> Note:
 >
 > You will have to provide any event property that you're using in your component (e.g. keyCode, which, etc...) as React is not creating any of these for you.
 

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -133,7 +133,7 @@ All consumers that are descendants of a Provider will re-render whenever the Pro
 
 Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description). 
 
-> Note
+> Note:
 > 
 > The way changes are determined can cause some issues when passing objects as `value`: see [Caveats](#caveats).
 
@@ -192,7 +192,7 @@ A React component that subscribes to context changes. This lets you subscribe to
 
 Requires a [function as a child](/docs/render-props.html#using-props-other-than-render). The function receives the current context value and returns a React node. The `value` argument passed to the function will be equal to the `value` prop of the closest Provider for this context above in the tree. If there is no Provider for this context above, the `value` argument will be equal to the `defaultValue` that was passed to `createContext()`.
 
-> Note
+> Note:
 > 
 > For more information about the 'function as a child' pattern, see [render props](/docs/render-props.html).
 
@@ -245,7 +245,7 @@ To get around this, lift the value into the parent's state:
 
 ## Legacy API
 
-> Note
+> Note:
 > 
 > React previously shipped with an experimental context API. The old API will be supported in all 16.x releases, but applications using it should migrate to the new version. The legacy API will be removed in a future major React version. Read the [legacy context docs here](/docs/legacy-context.html).
  

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -47,7 +47,7 @@ cd my-app
 npm start
 ```
 
->Note
+>Note:
 >
 >`npx` on the first line is not a typo -- it's a [package runner tool that comes with npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -13,7 +13,7 @@ A JavaScript error in a part of the UI shouldn’t break the whole app. To solve
 
 Error boundaries are React components that **catch JavaScript errors anywhere in their child component tree, log those errors, and display a fallback UI** instead of the component tree that crashed. Error boundaries catch errors during rendering, in lifecycle methods, and in constructors of the whole tree below them.
 
-> Note
+> Note:
 >
 > Error boundaries do **not** catch errors for:
 >
@@ -99,7 +99,7 @@ You can also see the filenames and line numbers in the component stack trace. Th
 
 If you don’t use Create React App, you can add [this plugin](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manually to your Babel configuration. Note that it’s intended only for development and **must be disabled in production**.
 
-> Note
+> Note:
 >
 > Component names displayed in the stack traces depend on the [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) property. If you support older browsers and devices which may not yet provide this natively (e.g. IE 11), consider including a `Function.name` polyfill in your bundled application, such as [`function.name-polyfill`](https://github.com/JamesMGreene/Function.name). Alternatively, you may explicitly set the [`displayName`](/docs/react-component.html#displayname) property on all your components.
 

--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -182,7 +182,7 @@ class FlavorForm extends React.Component {
 
 Overall, this makes it so that `<input type="text">`, `<textarea>`, and `<select>` all work very similarly - they all accept a `value` attribute that you can use to implement a controlled component.
 
-> Note
+> Note:
 >
 > You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag:
 >

--- a/content/docs/forwarding-refs.md
+++ b/content/docs/forwarding-refs.md
@@ -31,7 +31,7 @@ Here is a step-by-step explanation of what happens in the above example:
 1. We forward this `ref` argument down to `<button ref={ref}>` by specifying it as a JSX attribute.
 1. When the ref is attached, `ref.current` will point to the `<button>` DOM node.
 
->Note
+>Note:
 >
 >The second `ref` argument only exists when you define a component with `React.forwardRef` call. Regular function or class components don't receive the `ref` argument, and ref is not available in props either.
 >

--- a/content/docs/hello-world.md
+++ b/content/docs/hello-world.md
@@ -38,7 +38,7 @@ Every chapter in this guide builds on the knowledge introduced in earlier chapte
 
 React is a JavaScript library, and so we'll assume you have a basic understanding of the JavaScript language. **If you don't feel very confident, we recommend [going through a JavaScript tutorial](https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript) to check your knowledge level** and enable you to follow along this guide without getting lost. It might take you between 30 minutes and an hour, but as a result you won't have to feel like you're learning both React and JavaScript at the same time.
 
->Note
+>Note:
 >
 >This guide occasionally uses some of the newer JavaScript syntax in the examples. If you haven't worked with JavaScript in the last few years, [these three points](https://gist.github.com/gaearon/683e676101005de0add59e8bb345340c) should get you most of the way.
 

--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -20,7 +20,7 @@ In this document, we'll discuss why higher-order components are useful, and how 
 
 ## Use HOCs For Cross-Cutting Concerns
 
-> **Note**
+> **Note:**
 >
 > We previously recommended mixins as a way to handle cross-cutting concerns. We've since realized that mixins create more trouble than they are worth. [Read more](/blog/2016/07/13/mixins-considered-harmful.html) about why we've moved away from mixins and how you can transition your existing components.
 

--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -188,7 +188,7 @@ class FriendStatus extends React.Component {
 
 Notice how `componentDidMount` and `componentWillUnmount` need to mirror each other. Lifecycle methods force us to split this logic even though conceptually code in both of them is related to the same effect.
 
->Note
+>Note:
 >
 >Eagle-eyed readers may notice that this example also needs a `componentDidUpdate` method to be fully correct. We'll ignore this for now but will come back to it in a [later section](#explanation-why-effects-run-on-each-update) of this page.
 
@@ -227,7 +227,7 @@ function FriendStatus(props) {
 
 **When exactly does React clean up an effect?** React performs the cleanup when the component unmounts. However, as we learned earlier, effects run for every render and not just once. This is why React *also* cleans up effects from the previous render before running the effects next time. We'll discuss [why this helps avoid bugs](#explanation-why-effects-run-on-each-update) and [how to opt out of this behavior in case it creates performance issues](#tip-optimizing-performance-by-skipping-effects) later below.
 
->Note
+>Note:
 >
 >We don't have to return a named function from the effect. We called it `cleanup` here to clarify its purpose, but you could return an arrow function or call it something different.
 
@@ -460,7 +460,7 @@ useEffect(() => {
 
 In the future, the second argument might get added automatically by a build-time transformation.
 
->Note
+>Note:
 >
 >If you use this optimization, make sure the array includes **any values from the outer scope that change over time and that are used by the effect**. Otherwise, your code will reference stale values from previous renders. We'll also discuss other optimization options in the [Hooks API reference](/docs/hooks-reference.html).
 >

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -430,7 +430,7 @@ Note that you can still choose whether to pass the application *state* down as p
 
 ### How to read an often-changing value from `useCallback`?
 
->Note
+>Note:
 >
 >We recommend to [pass `dispatch` down in context](#how-to-avoid-passing-callbacks-down) rather than individual callbacks in props. The approach below is only mentioned here for completeness and as an escape hatch.
 >

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -65,7 +65,7 @@ function Counter({initialCount}) {
 
 The "+" and "-" buttons use the functional form, because the updated value is based on the previous value. But the "Reset" button uses the normal form, because it always sets the count back to 0.
 
-> Note
+> Note:
 >
 > Unlike the `setState` method found in class components, `useState` does not automatically merge update objects. You can replicate this behavior by combining the function updater form with object spread syntax:
 >
@@ -151,7 +151,7 @@ Now the subscription will only be recreated when `props.source` changes.
 
 Passing in an empty array `[]` of inputs tells React that your effect doesn't depend on any values from the component, so that effect would run only on mount and clean up on unmount; it won't run on updates.
 
-> Note
+> Note:
 >
 > The array of inputs is not passed as arguments to the effect function. Conceptually, though, that's what they represent: every value referenced inside the effect function should also appear in the inputs array. In the future, a sufficiently advanced compiler could create this array automatically.
 
@@ -274,7 +274,7 @@ Pass an inline callback and an array of inputs. `useCallback` will return a memo
 
 `useCallback(fn, inputs)` is equivalent to `useMemo(() => fn, inputs)`.
 
-> Note
+> Note:
 >
 > The array of inputs is not passed as arguments to the callback. Conceptually, though, that's what they represent: every value referenced inside the callback should also appear in the inputs array. In the future, a sufficiently advanced compiler could create this array automatically.
 
@@ -290,7 +290,7 @@ Pass a "create" function and an array of inputs. `useMemo` will only recompute t
 
 If no array is provided, a new value will be computed whenever a new function instance is passed as the first argument. (With an inline function, on every render.)
 
-> Note
+> Note:
 >
 > The array of inputs is not passed as arguments to the function. Conceptually, though, that's what they represent: every value referenced inside the function should also appear in the inputs array. In the future, a sufficiently advanced compiler could create this array automatically.
 
@@ -351,7 +351,7 @@ The signature is identical to `useEffect`, but it fires synchronously during the
 
 Prefer the standard `useEffect` when possible to avoid blocking visual updates.
 
->Note
+>Note:
 >
 >Avoid reading from the DOM in `useMutationEffect`. If you do, you can cause performance problems by introducing [layout thrash](https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing). When reading computed styles or layout information, `useLayoutEffect` is more appropriate.
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -58,7 +58,7 @@ class Example extends React.Component {
 
 The state starts as `{ count: 0 }`, and we increment `state.count` when the user clicks a button by calling `this.setState()`. We'll use snippets from this class throughout the page.
 
->Note
+>Note:
 >
 >You might be wondering why we're using a counter here instead of a more realistic example. This is to help us focus on the API while we're still making our first steps with Hooks.
 
@@ -148,7 +148,7 @@ function Example() {
 
 We declare a state variable called `count`, and set it to `0`. React will remember its current value between re-renders, and provide the most recent one to our function. If we want to update the current `count`, we can call `setCount`.
 
->Note
+>Note:
 >
 >You might be wondering: why is `useState` not named `createState` instead?
 >
@@ -242,7 +242,7 @@ This JavaScript syntax is called ["array destructuring"](https://developer.mozil
 
 When we declare a state variable with `useState`, it returns a pair — an array with two items. The first item is the current value, and the second is a function that lets us update it. Using `[0]` and `[1]` to access them is a bit confusing because they have a specific meaning. This is why we use array destructuring instead.
 
->Note
+>Note:
 >
 >You might be curious how React knows which component `useState` corresponds to since we're not passing anything like `this` back to React. We'll answer [this question](/docs/hooks-faq.html#how-does-react-associate-hook-calls-with-components) and many others in the FAQ section.
 

--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -195,7 +195,7 @@ If you haven't yet installed the React DevTools, you can find them here:
 - [Firefox Browser Extension](https://addons.mozilla.org/en-GB/firefox/addon/react-devtools/)
 - [Standalone Node Package](https://www.npmjs.com/package/react-devtools)
 
-> Note
+> Note:
 >
 > A production profiling bundle of `react-dom` is also available as `react-dom/profiling`.
 > Read more about how to use this bundle at [fb.me/react-profiling](https://fb.me/react-profiling)

--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -60,7 +60,7 @@ The `selected` attribute is supported by `<option>` components. You can use it t
 
 ### style
 
->Note
+>Note:
 >
 >Some examples in the documentation use `style` for convenience, but **using the `style` attribute as the primary means of styling elements is generally not recommended.** In most cases, [`className`](#classname) should be used to reference classes defined in an external CSS stylesheet. `style` is most often used in React applications to add dynamically-computed styles at render time. See also [FAQ: Styling and CSS](/docs/faq-styling.html).
 

--- a/content/docs/reference-pure-render-mixin.md
+++ b/content/docs/reference-pure-render-mixin.md
@@ -6,7 +6,7 @@ category: Reference
 permalink: docs/pure-render-mixin-old.html
 ---
 
-> Note
+> Note:
 
 > The `PureRenderMixin` mixin predates `React.PureComponent`. This reference doc is provided for legacy purposes, and you should consider using [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) instead.
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -131,7 +131,7 @@ The `render()` function should be pure, meaning that it does not modify componen
 
 If you need to interact with the browser, perform your work in `componentDidMount()` or the other lifecycle methods instead. Keeping `render()` pure makes components easier to think about.
 
-> Note
+> Note:
 >
 > `render()` will not be invoked if [`shouldComponentUpdate()`](#shouldcomponentupdate) returns false.
 
@@ -167,7 +167,7 @@ Constructor is the only place where you should assign `this.state` directly. In 
 
 Avoid introducing any side-effects or subscriptions in the constructor. For those use cases, use `componentDidMount()` instead.
 
->Note
+>Note:
 >
 >**Avoid copying props into state! This is a common mistake:**
 >

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -22,7 +22,7 @@ The `react-dom` package provides DOM-specific methods that can be used at the to
 
 React supports all popular browsers, including Internet Explorer 9 and above, although [some polyfills are required](/docs/javascript-environment-requirements.html) for older browsers such as IE 9 and IE 10.
 
-> Note
+> Note:
 >
 > We don't support older browsers that don't support ES5 methods, but you may find that your apps do work in older browsers if polyfills such as [es5-shim and es5-sham](https://github.com/es-shims/es5-shim) are included in the page. You're on your own if you choose to take this path.
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -84,7 +84,7 @@ See the [React.Component API Reference](/docs/react-component.html) for a list o
 
 If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases.
 
-> Note
+> Note:
 >
 > `React.PureComponent`'s `shouldComponentUpdate()` only shallowly compares the objects. If these contain complex data structures, it may produce false-negatives for deeper differences. Only extend `PureComponent` when you expect to have simple props and state, or use [`forceUpdate()`](/docs/react-component.html#forceupdate) when you know deep data structures have changed. Or, consider using [immutable objects](https://facebook.github.io/immutable-js/) to facilitate fast comparisons of nested data.
 >
@@ -122,7 +122,7 @@ export default React.memo(MyComponent, areEqual);
 
 This method only exists as a **[performance optimization](/docs/optimizing-performance.html).** Do not rely on it to "prevent" a render, as this can lead to bugs.
 
-> Note
+> Note:
 >
 > Unlike the [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate) method on class components, the `areEqual` function returns `true` if the props are equal and `false` if the props are not equal. This is the inverse from `shouldComponentUpdate`.
 
@@ -204,7 +204,7 @@ React.Children.map(children, function[(thisArg)])
 
 Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. If `children` is an array it will be traversed and the function will be called for each child in the array. If children is `null` or `undefined`, this method will return `null` or `undefined` rather than an array.
 
-> Note
+> Note:
 >
 > If `children` is a `Fragment` it will be treated as a single child and not traversed.
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -31,7 +31,7 @@ For example, instead of exposing `open()` and `close()` methods on a `Dialog` co
 
 Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/docs/lifting-state-up.html) guide for examples of this.
 
-> Note
+> Note:
 >
 > The examples below have been updated to use the `React.createRef()` API introduced in React 16.3. If you are using an earlier release of React, we recommend using [callback refs](#callback-refs) instead.
 
@@ -281,7 +281,7 @@ In the example above, `Parent` passes its ref callback as an `inputRef` prop to 
 
 If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. 
 
-> Note
+> Note:
 >
 > If you're currently using `this.refs.textInput` to access refs, we recommend using either the [callback pattern](#callback-refs) or the [`createRef` API](#creating-refs) instead.
 


### PR DESCRIPTION
I noticed that the React docs almost always use a colon after the heading text "Note" in yellow blockquote sections. However, there were a few instances where the colon was missing. This pull request serves to rectify this.