### PR TITLE
Fix: "Warning: validateDOMNesting(...)" in Fragment Documentation

### DIFF
--- a/content/docs/fragments.md
+++ b/content/docs/fragments.md
@@ -29,9 +29,11 @@ class Table extends React.Component {
   render() {
     return (
       <table>
-        <tr>
-          <Columns />
-        </tr>
+        <tbody>
+          <tr>
+            <Columns />
+          </tr>
+        </tbody>
       </table>
     );
   }


### PR DESCRIPTION
This PR fixes the warning generated in code snippet addressed in issue #1373.