### PR TITLE
Add constructor usage example for Class.contextType

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -141,6 +141,12 @@ Changes are determined by comparing the new and old values using the same algori
 
 ```js
 class MyClass extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    
+    let value = this.context;
+    /* access the value of MyContext in a constructor */
+  }
   componentDidMount() {
     let value = this.context;
     /* perform a side-effect at mount using the value of MyContext */


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Adds an example for accessing `this.context` inside of a constructor using the new `Class.contextType` introduced in `16.6`. It didn't seem necessary to document it beyond just including example constructor access in the existing `Class.contextType` code snippet.

Adding to the documentation based on the conversation here: https://github.com/facebook/react/issues/13944

Thanks!