### PR TITLE
Remove references to deprecated APIs

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -69,9 +69,7 @@ After handling the DOM node, React then recurses on the children.
 
 ### Component Elements Of The Same Type
 
-When a component updates, the instance stays the same, so that state is maintained across renders. React then updates the props of the underlying component instance to match the new element. If the component implements the `getDerivedStateFromProps()` static method, React will similarly update the component instance with any changed state.
-
-Next, the `render()` method is called and the diff algorithm recurses on the previous result and the new result.
+When a component updates, the instance stays the same, so that state is maintained across renders. React then updates the props of the underlying component instance to match the new element. Next, the `render()` method is called and the diff algorithm recurses on the previous result and the new result.
 
 ### Recursing On Children
 

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -69,7 +69,7 @@ After handling the DOM node, React then recurses on the children.
 
 ### Component Elements Of The Same Type
 
-When a component updates, the instance stays the same, so that state is maintained across renders. React updates the props of the underlying component instance to match the new element, and calls `componentWillReceiveProps()` and `componentWillUpdate()` on the underlying instance.
+When a component updates, the instance stays the same, so that state is maintained across renders. React then updates the props of the underlying component instance to match the new element. If the component implements the `getDerivedStateFromProps()` static method, React will similarly update the component instance with any changed state.
 
 Next, the `render()` method is called and the diff algorithm recurses on the previous result and the new result.
 


### PR DESCRIPTION
The docs reference `componentWillReceiveProps()` and `componentWillUpdate()`, but these are now prefixed with `UNSAFE`, and I doubt we want the official documentation referring to them. I removed the offending line and replaced it with a reference to `getDerivedStateFromProps()` though I'm not sure that mentioning this lifecycle method offers much in the context of this doc.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
