### PR TITLE
remove stub function in gatsby-browser

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -11,7 +11,3 @@ require('normalize.css');
 require('./src/css/reset.css');
 require('./src/prism-styles');
 require('./src/css/algolia.css');
-
-// A stub function is needed because gatsby won't load this file otherwise
-// (https://github.com/gatsbyjs/gatsby/issues/6759)
-exports.onClientEntry = () => {};


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The stub function in gatsby-browser is no longer needed since the [issue](https://github.com/gatsbyjs/gatsby/issues/6759) has been [fixed](https://github.com/gatsbyjs/gatsby/pull/7011).
