### PR TITLE
Updated docs to mention .eslintrc WITH extension

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -247,7 +247,7 @@ yarn upgrade eslint@3.x babel-eslint@7
 npm update eslint@3.x babel-eslint@7
 ```
 
-Ensure you have the following line inside your `.eslintrc`:
+Ensure you have the following line inside your `.eslintrc.json`:
 
 ```json
 "parser": "babel-eslint"

--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -447,7 +447,7 @@ The [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) 
 IDE's allow you to integrate these findings directly into code analysis and source code windows.
 
 [Create React App](https://github.com/facebookincubator/create-react-app) has this plugin with a subset of rules activated. If you want to enable even more accessibility rules,
-you can create an `.eslintrc` file in the root of your project with this content:
+you can create an `.eslintrc.json` file in the root of your project with this content:
 
   ```json
   {


### PR DESCRIPTION
Given that .eslintrc without extension is [deprecated](https://eslint.org/docs/user-guide/configuring#configuration-file-formats), it would be better if the docs suggest to use the file with extension.

This PR adds the `.json` extension where `.eslintrc` is mentioned  

