### PR TITLE
Idea: Expand all nav sections by default

### DIFF
--- a/src/templates/components/Sidebar/Sidebar.js
+++ b/src/templates/components/Sidebar/Sidebar.js
@@ -52,7 +52,7 @@ class Sidebar extends Component {
         {sectionList.map((section, index) => (
           <SectionComponent
             createLink={createLink}
-            isActive={activeSection === section || sectionList.length === 1}
+            isActive={true}
             key={index}
             location={location}
             onLinkClick={closeParentMenu}


### PR DESCRIPTION
Closes #1477

**What**

Expands the right navigation section in the docs, like the tutorial page and some other docs sites.

**Why**

To make it easier to discover other sections.

<img width="1292" alt="screen shot 2018-12-08 at 10 07 53 pm" src="https://user-images.githubusercontent.com/1571667/49693988-273e4c00-fb36-11e8-8bd6-d3485de274cc.png">
