### PR TITLE
Add an example with propTypes on functional component

### DIFF
--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -32,6 +32,24 @@ Greeting.propTypes = {
 
 `PropTypes` exports a range of validators that can be used to make sure the data you receive is valid. In this example, we're using `PropTypes.string`. When an invalid value is provided for a prop, a warning will be shown in the JavaScript console. For performance reasons, `propTypes` is only checked in development mode.
 
+#### PropTypes on functional components
+
+There is a misconception in JavaScript community, mostly among beginners, that `propTypes` can only be set to class components. But it is not true, in fact `propTypes` can be set to any functional component even if you use arrow functions:
+
+```javascript
+import PropTypes from 'prop-types';
+
+const Greeting = (props) => {
+  return (
+    <h1>Hello, {props.name}</h1>
+  );
+}
+
+Greeting.propTypes = {
+  name: PropTypes.string
+};
+```
+
 ### PropTypes
 
 Here is an example documenting the different validators provided:


### PR DESCRIPTION
I mentioned a misconception among JavaScript developers(mostly beginners, but not limiting with them) - they tend to think that properties can be assigned only to classes and there is no way(at least it won't work) if you assign them to functions. This translates to React too, so some developers think that functional components can't have propTypes set to them.

In order to break this misconception, I've added an example of setting propTypes to functional component(I used arrow function, so that they can be sure that it also be used with arrow functions).

If you feel I am write, I will be happy if you merge it.

And of course, any feedback is welcomed.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
