### PR TITLE
Fix non-cancelable action.

### DIFF
--- a/content/blog/2015-12-16-ismounted-antipattern.md
+++ b/content/blog/2015-12-16-ismounted-antipattern.md
@@ -43,12 +43,12 @@ If you use ES6 promises, you may need to wrap your promise in order to make it c
 
 ```js
 const cancelablePromise = makeCancelable(
-  new Promise(r => component.setState({...}))
+  new Promise(r => setTimeout(() => r({data: 'newVal'}), 1000))
 );
 
 cancelablePromise
   .promise
-  .then(() => console.log('resolved'))
+  .then(update => component.setState(update))
   .catch((reason) => console.log('isCanceled', reason.isCanceled));
 
 cancelablePromise.cancel(); // Cancel the promise


### PR DESCRIPTION
`setState` must be called after long running task is resolved and cancelable not canceled. Before fix cancel had no effect on `setState` taking effect.