### PR TITLE
When use Class.contextType, React.createContext should be call in separate files

### DIFF
--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -72,7 +72,7 @@ class MyClass extends React.Component {
 
 > Note:
 >
-> Context creation should be Moved in a separated file, that both the parent component (that holds the Provider), and the child component (that consumes) imports from. This can avoid circular reference problem.([Check out this example on CodeSandBox.](https://codesandbox.io/s/6x0w7vyozw))
+> Context creation should be moved in a separated file, that both the parent component (that holds the Provider), and the child component (that consumes) imports from. This can avoid circular reference problem.([Check out this example on CodeSandBox.](https://codesandbox.io/s/6x0w7vyozw))
 
 ## [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror)
 

--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -72,7 +72,7 @@ class MyClass extends React.Component {
 
 > Note:
 >
-> When use `Class.contextType`, `React.createContext` should be call in separate files, and not in same file as `Provider/parent`,that will cause circular dependency problem.
+> Context creation should be Moved in a separated file, that both the parent component (that holds the Provider), and the child component (that consumes) imports from. This can avoid circular reference problem.([Check out this example on CodeSandBox.](https://codesandbox.io/s/6x0w7vyozw))
 
 ## [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror)
 

--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -70,6 +70,10 @@ class MyClass extends React.Component {
 }
 ```
 
+> Note:
+>
+> When use `Class.contextType`, `React.createContext` should be call in separate files, and not in same file as `Provider/parent`,that will cause circular dependency problem.
+
 ## [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror)
 
 React 16 introduced [Error Boundaries](/blog/2017/07/26/error-handling-in-react-16.html) for handling errors thrown in React renders. We already had the `componentDidCatch` lifecycle method which gets fired after an error has already happened. It's great for logging errors to the server. It also lets you show a different UI to the user by calling `setState`.

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -169,7 +169,7 @@ The `contextType` property on a class can be assigned a Context object created b
 >
 > If you are using the experimental [public class fields syntax](https://babeljs.io/docs/plugins/transform-class-properties/), you can use a **static** class field to initialize your `contextType`.
 >
-> When use `Class.contextType`, `React.createContext` should be call in separate files, and not in same file as `Provider/parent`,that will cause circular dependency problem.
+> Context creation should be Moved in a separated file, that both the parent component (that holds the Provider), and the child component (that consumes) imports from. This can avoid circular reference problem.([Check out this example on CodeSandBox.](https://codesandbox.io/s/6x0w7vyozw))
 
 
 ```js

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -168,6 +168,8 @@ The `contextType` property on a class can be assigned a Context object created b
 > You can only subscribe to a single context using this API. If you need to read more than one see [Consuming Multiple Contexts](#consuming-multiple-contexts).
 >
 > If you are using the experimental [public class fields syntax](https://babeljs.io/docs/plugins/transform-class-properties/), you can use a **static** class field to initialize your `contextType`.
+>
+> When use `Class.contextType`, `React.createContext` should be call in separate files, and not in same file as `Provider/parent`,that will cause circular dependency problem.
 
 
 ```js

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -169,7 +169,7 @@ The `contextType` property on a class can be assigned a Context object created b
 >
 > If you are using the experimental [public class fields syntax](https://babeljs.io/docs/plugins/transform-class-properties/), you can use a **static** class field to initialize your `contextType`.
 >
-> Context creation should be Moved in a separated file, that both the parent component (that holds the Provider), and the child component (that consumes) imports from. This can avoid circular reference problem.([Check out this example on CodeSandBox.](https://codesandbox.io/s/6x0w7vyozw))
+> Context creation should be moved in a separated file, that both the parent component (that holds the Provider), and the child component (that consumes) imports from. This can avoid circular reference problem.([Check out this example on CodeSandBox.](https://codesandbox.io/s/6x0w7vyozw))
 
 
 ```js


### PR DESCRIPTION
16.6 Context API not working in class component,Issus,[13969](https://github.com/facebook/react/issues/13969),the Class.contextType is a greet improve,but the documentation is easy to guide developers to make mistakes. 
