### PR TITLE
Update hooks-effect.md

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -333,7 +333,7 @@ function FriendStatusWithCounter(props) {
 
 ### Explanation: Why Effects Run on Each Update
 
-If you're used to classes, you might be wondering why the effect cleanup phase happens after every re-render, and not just once during unmounting. Let's look at a practical example to see why this design helps us create components with fewer bugs.
+If you're used to classes, you might be wondering why the effect cleanup phase happens before every re-render, and not just once during unmounting. Let's look at a practical example to see why this design helps us create components with fewer bugs.
 
 [Earlier on this page](#example-using-classes-1), we introduced an example `FriendStatus` component that displays whether a friend is online or not. Our class reads `friend.id` from `this.props`, subscribes to the friend status after the component mounts, and unsubscribes during unmounting:
 


### PR DESCRIPTION
What I understand, these are the effects which run *after* every re-render, on the contrary, cleanup run *before* every re-render.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
