### PR TITLE
Updated reference-react-component.md

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -260,7 +260,7 @@ Use `shouldComponentUpdate()` to let React know if a component's output is not a
 
 This method only exists as a **[performance optimization](/docs/optimizing-performance.html).** Do not rely on it to "prevent" a rendering, as this can lead to bugs. **Consider using the built-in [`PureComponent`](/docs/react-api.html#reactpurecomponent)** instead of writing `shouldComponentUpdate()` by hand. `PureComponent` performs a shallow comparison of props and state, and reduces the chance that you'll skip a necessary update.
 
-If you are confident you want to write it by hand, you may compare `this.props` with `nextProps` and `this.state` with `nextState` and return `false` to tell React the update can be skipped. Note that returning `false` does not prevent child components from re-rendering when *their* state changes.
+If you are confident you want to write it by hand, you may compare `this.props` with `nextProps` and `this.state` with `nextState` and return `false` to tell React the update can be skipped. Note that returning `false` prevents child components from re-rendering when the props values are updated however it does not prevent child components from re-rendering when *their* state changes.
 
 We do not recommend doing deep equality checks or using `JSON.stringify()` in `shouldComponentUpdate()`. It is very inefficient and will harm performance.
 


### PR DESCRIPTION
When going through the documentation, I got confused when I came across this statement:

"Note that returning false does not prevent child components from re-rendering when their state changes"

Confusion is around the fact that what are the conditions where the component is not allowed to re-rendered. I wanted to propose the updation of following lines to: 

"Note that returning `false` prevents child components from re-rendering when the props values are updated however it does not prevent child components from re-rendering when *their* state changes."

This makes it more explicit that only the "props" change is restricted from re-rendering in case "shouldComponentUpdate" returns false

Thanks & Regards
Mayank Gupta



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
