### PR TITLE
Update Fragment support section in a blogpost regarding Create React App

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -163,7 +163,7 @@ Support for fragment syntax in JSX will vary depending on the tools you use to b
 
 ### Create React App {#create-react-app}
 
-Experimental support for fragment syntax will be added to Create React App within the next few days. A stable release may take a bit longer as we await adoption by upstream projects.
+Support for the fragment syntax is available in Create React App 2.0.
 
 ### Babel {#babel}
 


### PR DESCRIPTION
It's linked in for example in https://reactjs.org/docs/fragments.html#short-syntax and pretty confusing. We could consider just rewriting these whole "Many tools don't support support" section too.