### PR TITLE
Add note to code splitting doc clarifying use of lazy and Suspense

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -115,7 +115,7 @@ parse the dynamic import syntax but is not transforming it. For that you will ne
 
 > Note:
 >
-> `React.lazy` and Suspense is not yet available for server-side rendering. If you want to do code-splitting in a server rendered app, we recommend [Loadable Components](https://github.com/smooth-code/loadable-components). It has a nice [guide for bundle splitting with server-side rendering](https://github.com/smooth-code/loadable-components/blob/master/packages/server/README.md).
+> `React.lazy` and `Suspense` are not yet available for server-side rendering. If you want to do code-splitting in a server rendered app, we recommend [Loadable Components](https://github.com/smooth-code/loadable-components). It has a nice [guide for bundle splitting with server-side rendering](https://github.com/smooth-code/loadable-components/blob/master/packages/server/README.md).
 
 The `React.lazy` function lets you render a dynamic import as a regular component.
 
@@ -188,6 +188,10 @@ function MyComponent() {
   );
 }
 ```
+
+> Note:
+>
+> `React.lazy` and `Suspense` should be used together. If no fallback UI is specified with `Suspense` when using a `React.lazy` component, an error will occur.
 
 ### Error boundaries {#error-boundaries}
 


### PR DESCRIPTION
When using React.lazy without Suspense, I run into an error:

![screenshot 2019-02-20 at 11 00 44](https://user-images.githubusercontent.com/16747320/53084906-0fa21d00-3502-11e9-965e-f6ae46c00866.png)

This error can be superseded by other errors that stem from this error when working with a larger codebase with more complex Component selection logic.

It should be specified in the docs that React.lazy needs Suspense to specify a fallback UI.

Also, small format and grammar fix
