### PR TITLE
Fixed component name on render-props page

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -215,7 +215,7 @@ More concretely, **a render prop is a function prop that a component uses to kno
 
 This technique makes the behavior that we need to share extremely portable. To get that behavior, render a `<Mouse>` with a `render` prop that tells it what to render with the current (x, y) of the cursor.
 
-One interesting thing to note about render props is that you can implement most [higher-order components](/docs/higher-order-components.html) (HOC) using a regular component with a render prop. For example, if you would prefer to have a `withMouse` HOC instead of a `<Mouse>` component, you could easily create one using a regular `<Mouse>` with a render prop:
+One interesting thing to note about render props is that you can implement most [higher-order components](/docs/higher-order-components.html) (HOC) using a regular component with a render prop. For example, if you would prefer to have a `withMouse` HOC instead of a `<MouseTracker>` component, you could easily create one using a regular `<Mouse>` with a render prop:
 
 ```js
 // If you really want a HOC for some reason, you can easily


### PR DESCRIPTION
The docs say you can use a HOC that uses the `<Mouse>` "instead of a `<Mouse>` component". Seems like it should say "instead of a `<MouseTracker>` component"
