### PR TITLE
fixing typos. should be below instead of above

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -27,7 +27,7 @@ April 12, 2019 in Amsterdam, The Netherlands
 
 [Website](https://react.amsterdam) - [Twitter](https://twitter.com/reactamsterdam) - [Facebook](https://www.facebook.com/reactamsterdam)
 
-### ReactJS Girls Conference 
+### ReactJS Girls Conference {#reactjs-girls-conference}
 May 3, 2019 in London, UK
 
 [Website](https://reactjsgirls.com/) - [Twitter](https://twitter.com/reactjsgirls)

--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -263,7 +263,7 @@ With the example above, the `Post` component can read `props.id`, but not `props
 
 ### Embedding map() in JSX {#embedding-map-in-jsx}
 
-In the examples above we declared a separate `listItems` variable and included it in JSX:
+In the examples below we declared a separate `listItems` variable and included it in JSX:
 
 ```js{3-6}
 function NumberList(props) {


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
