### PR TITLE
Issue solution added

### DIFF
--- a/content/docs/addons-create-fragment.md
+++ b/content/docs/addons-create-fragment.md
@@ -66,3 +66,7 @@ function Swapper(props) {
 The keys of the passed object (that is, `left` and `right`) are used as keys for the entire set of children, and the order of the object's keys is used to determine the order of the rendered children. With this change, the two sets of children will be properly reordered in the DOM without unmounting.
 
 The return value of `createFragment` should be treated as an opaque object; you can use the [`React.Children`](/docs/react-api.html#react.children) helpers to loop through a fragment but should not access it directly. Note also that we're relying on the JavaScript engine preserving object enumeration order here, which is not guaranteed by the spec but is implemented by all major browsers and VMs for objects with non-numeric keys.
+
+## Short Syntax and Keyed Fragments
+
+Currently the [Short Syntax](/docs/fragments.html#short-syntax) `<> </>` does not support keys. Review the [Keyed Fragments](/docs/fragments.html#keyed-fragments) section for solutions.


### PR DESCRIPTION
As this is still the current Google Search result for Keyed Fragments, a link to the reason why the short syntax can't be used should be added.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
