### PR TITLE
Set a context for the external example.

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -142,7 +142,7 @@ As a last resort, you can pass an item's index in the array as a key. This can w
 
 Reorders can also cause issues with component state when indexes are used as keys. Component instances are updated and reused based on their key. If the key is an index, moving an item changes it. As a result, component state for things like uncontrolled inputs can get mixed up and updated in unexpected ways.
 
-[Here](codepen://reconciliation/index-used-as-key) is an example of the issues that can be caused by using indexes as keys on CodePen, and [here](codepen://reconciliation/no-index-used-as-key) is an updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues.
+[Here](codepen://reconciliation/index-used-as-key) is an example of the issues that can be caused by using indexes as keys on CodePen. Try playing around, create a couple of entries, add some text to the input generated. Notice that sorting the entries does not move the corresponding text around. [Here](codepen://reconciliation/no-index-used-as-key) is an updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues.
 
 ## Tradeoffs {#tradeoffs}
 


### PR DESCRIPTION
Previously, the text mentioned - here is a problematic codepen link. Here is a codepen link that solves the problem.

As a developer, I had to figure out the real problem with the first codepen link. Which was to actually add some text to the input fields and then try to sort the output.

Added a short description along with the link to the example.

This is an important topic to understand and the examples need to be understood well be developers to write bug-free code with `keys`.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
