### PR TITLE
added skip `friendID` effect in `useFriendStatus` to prevent constant…

### DIFF
--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -88,7 +88,7 @@ function useFriendStatus(friendID) {
     return () => {
       ChatAPI.unsubscribeFromFriendStatus(friendID, handleStatusChange);
     };
-  });
+  }, [friendID]);
 
   return isOnline;
 }


### PR DESCRIPTION
…ly re-render `FriendListItem`

Without skip same `[friendID]` statement, the simple page quickly took over couple GB of memory, and then Chrome  freezed. Using the performance logging tool, I found this list is constantly updating.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
