### PR TITLE
Update hooks-reference.md

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -60,7 +60,7 @@ function Counter({initialCount}) {
   const [count, setCount] = useState(initialCount);
   return (
     <>
-      Счёт: {count}
+      Count: {count}
       <button onClick={() => setCount(initialCount)}>Сбросить</button>
       <button onClick={() => setCount(count + 1)}>+</button>
       <button onClick={() => setCount(count - 1)}>-</button>

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -51,7 +51,25 @@ During subsequent re-renders, the first value returned by `useState` will always
 
 #### Functional updates {#functional-updates}
 
-If the new state is computed using the previous state, you can pass a function to `setState`. The function will receive the previous value, and return an updated value. Here's an example of a counter component that uses both forms of `setState`:
+If the new state is computed using the previous state, you can pass a function to `setState`. The function will receive the previous value, and return an updated value. 
+
+Example without `setState`:
+
+```js
+function Counter({initialCount}) {
+  const [count, setCount] = useState(initialCount);
+  return (
+    <>
+      Счёт: {count}
+      <button onClick={() => setCount(initialCount)}>Сбросить</button>
+      <button onClick={() => setCount(count + 1)}>+</button>
+      <button onClick={() => setCount(count - 1)}>-</button>
+    </>
+  );
+}
+```
+
+Here's an example of a counter component that uses both forms of `setState`:
 
 ```js
 function Counter({initialCount}) {

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -61,7 +61,7 @@ function Counter({initialCount}) {
   return (
     <>
       Count: {count}
-      <button onClick={() => setCount(initialCount)}>Сбросить</button>
+      <button onClick={() => setCount(initialCount)}>Reset</button>
       <button onClick={() => setCount(count + 1)}>+</button>
       <button onClick={() => setCount(count - 1)}>-</button>
     </>


### PR DESCRIPTION
Add example without `setState` before using `setState`. Before at docs never showing and little bit confusing without real example before and after.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
