### PR TITLE
Mark Xes on X's turn and Os on O's turn

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -611,7 +611,7 @@ Each time a player moves, `xIsNext` (a boolean) will be flipped to determine whi
 ```javascript{3,6}
   handleClick(i) {
     const squares = this.state.squares.slice();
-    squares[i] = this.state.xIsNext ? 'X' : 'O';
+    squares[i] = this.state.xIsNext ? 'O' : 'X';
     this.setState({
       squares: squares,
       xIsNext: !this.state.xIsNext,
@@ -645,7 +645,7 @@ class Board extends React.Component {
 
   handleClick(i) {
     const squares = this.state.squares.slice();
-    squares[i] = this.state.xIsNext ? 'X' : 'O';
+    squares[i] = this.state.xIsNext ? 'O' : 'X';
     this.setState({
       squares: squares,
       xIsNext: !this.state.xIsNext,
@@ -742,7 +742,7 @@ We can now change the Board's `handleClick` function to return early by ignoring
     if (calculateWinner(squares) || squares[i]) {
       return;
     }
-    squares[i] = this.state.xIsNext ? 'X' : 'O';
+    squares[i] = this.state.xIsNext ? 'O' : 'X';
     this.setState({
       squares: squares,
       xIsNext: !this.state.xIsNext,
@@ -849,7 +849,7 @@ class Board extends React.Component {
     if (calculateWinner(squares) || squares[i]) {
       return;
     }
-    squares[i] = this.state.xIsNext ? 'X' : 'O';
+    squares[i] = this.state.xIsNext ? 'O' : 'X';
     this.setState({
       squares: squares,
       xIsNext: !this.state.xIsNext,
@@ -966,7 +966,7 @@ Finally, we need to move the `handleClick` method from the Board component to th
     if (calculateWinner(squares) || squares[i]) {
       return;
     }
-    squares[i] = this.state.xIsNext ? 'X' : 'O';
+    squares[i] = this.state.xIsNext ? 'O' : 'X';
     this.setState({
       history: history.concat([{
         squares: squares,
@@ -1159,7 +1159,7 @@ We will also replace reading `this.state.history` with `this.state.history.slice
     if (calculateWinner(squares) || squares[i]) {
       return;
     }
-    squares[i] = this.state.xIsNext ? 'X' : 'O';
+    squares[i] = this.state.xIsNext ? 'O' : 'X';
     this.setState({
       history: history.concat([{
         squares: squares


### PR DESCRIPTION
The current code seems to have its logic backwards: when X plays next, it marks Xes, but it should be marking Os because if X's turn is _next_ then the current turn is O. An alternative way to address this would be to adjust the status text to say something like "Current player: " rather than "Next player: ". I'm happy to adjust this PR or close it if that would be a preferable solution.

I think I've found all the spots in the document that contain this code snippet, but if this is accepted it would also require updates to the Codepen, which I don't have access to. It might also be good to add a note explaining the logic; I'm happy to include that here if someone will point me to the best place to put it.