### PR TITLE
Updated input text field state value field name to avoid confusion

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -35,18 +35,18 @@ For example, if we want to make the previous example log the name when it is sub
 class NameForm extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {value: ''};
+    this.state = {textValue: ''};
 
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handleChange(event) {
-    this.setState({value: event.target.value});
+    this.setState({textValue: event.target.value});
   }
 
   handleSubmit(event) {
-    alert('A name was submitted: ' + this.state.value);
+    alert('A name was submitted: ' + this.state.textValue);
     event.preventDefault();
   }
 
@@ -55,7 +55,7 @@ class NameForm extends React.Component {
       <form onSubmit={this.handleSubmit}>
         <label>
           Name:
-          <input type="text" value={this.state.value} onChange={this.handleChange} />
+          <input type="text" value={this.state.textValue} onChange={this.handleChange} />
         </label>
         <input type="submit" value="Submit" />
       </form>
@@ -66,13 +66,13 @@ class NameForm extends React.Component {
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/VmmPgp?editors=0010)
 
-Since the `value` attribute is set on our form element, the displayed value will always be `this.state.value`, making the React state the source of truth. Since `handleChange` runs on every keystroke to update the React state, the displayed value will update as the user types.
+Since the `textValue` attribute is set on our form element, the displayed value will always be `this.state.textValue`, making the React state the source of truth. Since `handleChange` runs on every keystroke to update the React state, the displayed value will update as the user types.
 
 With a controlled component, every state mutation will have an associated handler function. This makes it straightforward to modify or validate user input. For example, if we wanted to enforce that names are written with all uppercase letters, we could write `handleChange` as:
 
 ```javascript{2}
 handleChange(event) {
-  this.setState({value: event.target.value.toUpperCase()});
+  this.setState({textValue: event.target.value.toUpperCase()});
 }
 ```
 


### PR DESCRIPTION
When the word 'value' is used as the state field name, it is possible that the reader will get confused and assume that they need to use the same variable name in the event.target.x field when this is not the case.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
