### PR TITLE
hooks-rules: eslint plugin included in CRA

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -46,7 +46,7 @@ npm install eslint-plugin-react-hooks --save-dev
 }
 ```
 
-In the future, we intend to include this plugin by default into Create React App and similar toolkits.
+This plugin is included in Create React App as of version 3.0.0.
 
 **You can skip to the next page explaining how to write [your own Hooks](/docs/hooks-custom.html) now.** On this page, we'll continue by explaining the reasoning behind these rules.
 


### PR DESCRIPTION
This PR changes an outdated reference to create-react-app < 3.0.0, as it now ships with the hooks eslint plugin.
