### PR TITLE
Introduce useReducer with the simpler function signature, defer lazy initialization signature to it's section.

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -288,7 +288,7 @@ function reducer(state, action) {
 }
 
 function Counter({initialCount}) {
-  const [state, dispatch] = useReducer(reducer, {count: initialCount}, init);
+  const [state, dispatch] = useReducer(reducer, initialCount, init);
   return (
     <>
       Count: {state.count}

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -282,7 +282,7 @@ function reducer(state, action) {
 }
 
 function Counter({initialCount}) {
-  const [state, dispatch] = useReducer(reducer, initialCount, init);
+  const [state, dispatch] = useReducer(reducer, {count: initialCount}, init);
   return (
     <>
       Count: {state.count}

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -203,10 +203,10 @@ The following Hooks are either variants of the basic ones from the previous sect
 ### `useReducer` {#usereducer}
 
 ```js
-const [state, dispatch] = useReducer(reducer, initialArg, init);
+const [state, dispatch] = useReducer(reducer, initialState);
 ```
 
-An alternative to [`useState`](#usestate). Accepts a reducer of type `(state, action) => newState`, and returns the current state paired with a `dispatch` method. (If you're familiar with Redux, you already know how this works.)
+An alternative to [`useState`](#usestate). Accepts a reducer of type `(state, action) => newState` and an initial state, and returns the current state paired with a `dispatch` method. (If you're familiar with Redux, you already know how this works.)
 
 `useReducer` is usually preferable to `useState` when you have complex state logic that involves multiple sub-values or when the next state depends on the previous one. `useReducer` also lets you optimize performance for components that trigger deep updates because [you can pass `dispatch` down instead of callbacks](/docs/hooks-faq.html#how-to-avoid-passing-callbacks-down).
 
@@ -259,7 +259,13 @@ There’s two different ways to initialize `useReducer` state. You may choose ei
 
 #### Lazy initialization {#lazy-initialization}
 
-You can also create the initial state lazily. To do this, you can pass an `init` function as the third argument. The initial state will be set to `init(initialArg)`.
+You can also create the initial state lazily. To do this, you can pass an `init` function as the third argument. 
+
+```js
+const [state, dispatch] = useReducer(reducer, initialArg, init);
+```
+
+The initial state will be set to `init(initialArg)`.
 
 It lets you extract the logic for calculating the initial state outside the reducer. This is also handy for resetting the state later in response to an action:
 


### PR DESCRIPTION
**Update:**
I got confused by the changing role of the second argument to `useReducer` from `initialState` to `initialArg` if a third argument is provided. Pull request is updated to instead reduce this risk of confusion.

In the first commit I changed 
from:
```js
function Counter({initialCount}) {
  const [state, dispatch] = useReducer(reducer, initialCount, init);
```
to:
```js
function Counter({initialCount}) {
  const [state, dispatch] = useReducer(reducer, {count: initialCount}, init);
```
as the second argument was used as `initialState` in the previous examples.

In the updated pull request, the `useReducer` hook is no longer introduced with the signature:
```js
const [state, dispatch] = useReducer(reducer, initialArg, init);
```
but with the simpler form used in the first example:
```js
const [state, dispatch] = useReducer(reducer, initialState);
```
The lazy initialization signature is instead moved down under the lazy initialization section where the connection between `init` and `initialArg` is first explained and exemplified.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
