### PR TITLE
Replaced nonexistent document.root

### DIFF
--- a/examples/context/theme-detailed-app.js
+++ b/examples/context/theme-detailed-app.js
@@ -46,4 +46,4 @@ class App extends React.Component {
   }
 }
 
-ReactDOM.render(<App />, document.root);
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/context/updating-nested-context-app.js
+++ b/examples/context/updating-nested-context-app.js
@@ -42,4 +42,4 @@ function Content() {
   );
 }
 
-ReactDOM.render(<App />, document.root);
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
In the "Context" guide, `document.root` is specified as the second argument to `ReactDOM.render()`. However, `document.root` seems to be undefined and I couldn't find anything about it on the web. So, I thought this was an error and I replaced `document.root` with `document.getElementById('root')`, which is consistent with what other guides in the docs specify as the second argument to `ReactDOM.render()`.