### PR TITLE
Link to relevant Context docs for useContext

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -178,7 +178,7 @@ The array of dependencies is not passed as arguments to the effect function. Con
 const value = useContext(MyContext);
 ```
 
-Accepts a context object (the value returned from `React.createContext`) and returns the current context value for that context. The current context value is determined by the `value` prop of the nearest `<MyContext.Provider>` above the calling component in the tree.
+Accepts a [context](/docs/context.html) object (the value returned from [`React.createContext`](/docs/context.html#reactcreatecontext)) and returns the current context value for that context. The current context value is determined by the `value` prop of the nearest [`<MyContext.Provider>`](/docs/context.html#contextprovider) above the calling component in the tree.
 
 When the nearest `<MyContext.Provider>` above the component updates, this Hook will trigger a rerender with the latest context `value` passed to that `MyContext` provider.
 


### PR DESCRIPTION
I'm not sure whether linking to the individual sections on `React.createContext` and `<MyContext.Provider>` is a bit too much (though you have to scroll pretty far down to get to them otherwise), but at least a link to the general Context documentation is helpful when learning about `useContext`.