### PR TITLE
Docs: Add warning about promise in useEffect

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -47,6 +47,8 @@ There are two common kinds of side effects in React components: those that don't
 
 Sometimes, we want to **run some additional code after React has updated the DOM.** Network requests, manual DOM mutations, and logging are common examples of effects that don't require a cleanup. We say that because we can run them and immediately forget about them. Let's compare how classes and Hooks let us express such side effects.
 
+**Warning: An Effect function must not return anything besides a function, which is used for clean-up.**
+
 ### Example Using Classes {#example-using-classes}
 
 In React class components, the `render` method itself shouldn't cause side effects. It would be too early -- we typically want to perform our effects *after* React has updated the DOM.


### PR DESCRIPTION
Docs: Add warning about promise in useEffect to hooks-effect.md

I have seen too many developers that don't understand why curly braces inside useEffect can't be omitted, when you don't need clean up, and I couldn't find that warning in the docs, which is disappointing.

Doesn't work, shows warning in react, and unfriendly error in React Native
```
  useEffect(() => 
    fetch('https://example.com')
  )
```
Does work
```
  useEffect(() => { 
    fetch('https://example.com')
  })
```

Example code: https://stackblitz.com/edit/react-t91ssb

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
