### PR TITLE
Fix false description about how setState works.

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -276,7 +276,7 @@ Now let's say we want to write some logic that changes `left` and `top` when the
   // ...
 ```
 
-This is because when we update a state variable, we *replace* its value. This is different from `this.setState` in a class, which *merges* the updated fields into the object.
+This is because when we update a state variable, we *replace* its value, just as `this.setState` replaces the immutable state variable with a new variable that has all the same property values as the old state object except the properties that are changed by the object that is passed to `this.setState`. But 'this.setState` does this replacement under the hood, so you don't need to explicity add `...state` to the object passed to `this.setState`. 
 
 If you miss automatic merging, you can write a custom `useLegacyState` Hook that merges object state updates. However, instead **we recommend to split state into multiple state variables based on which values tend to change together.**
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -276,7 +276,7 @@ Now let's say we want to write some logic that changes `left` and `top` when the
   // ...
 ```
 
-This is because when we update a state variable, we *replace* its value, just as `this.setState` replaces the immutable state variable with a new variable that has all the same property values as the old state object except the properties that are changed by the object that is passed to `this.setState`. But 'this.setState` does this replacement under the hood, so you don't need to explicity add `...state` to the object passed to `this.setState`. 
+This is because when we update a state variable, we *replace* its value, just as `this.setState` replaces the immutable state variable with a new variable that has all the same property values as the old state object except the properties that are changed by the object that is passed to `this.setState`. But `this.setState` does this replacement under the hood, so you don't need to explicitly add `...state` to the object passed to `this.setState`. 
 
 If you miss automatic merging, you can write a custom `useLegacyState` Hook that merges object state updates. However, instead **we recommend to split state into multiple state variables based on which values tend to change together.**
 


### PR DESCRIPTION
The sentence that I'm replacing here says that `this.setState` merges new values into an existing state object rather than replace the object. This blatantly contradicts the explanations elsewhere in this documentation of how `setState` works. React treats the state object as **immutable**.  Accordingly, `setState` does _not_ change it. Instead, it creates a whole new object that duplicates the original state except that the properties of the object that are passed to `setState` are used to set the corresponding properties of the new state object. So, it _replaces_ the state object, the exact opposite of what the sentence that I want to fix is claiming.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
