### PR TITLE
Flow typings for yaml files

### DIFF
--- a/flow-typed/yaml.js
+++ b/flow-typed/yaml.js
@@ -1,0 +1,47 @@
+declare module 'content/languages.yml' {
+  declare module.exports: {
+    name: string,
+    translated_name: string,
+    code: string,
+    status: 0 | 1 | 2,
+  }[];
+}
+
+declare module 'content/versions.yml' {
+  declare module.exports: {
+    title: string,
+    changelog: string,
+    path?: string,
+    url?: string,
+  }[];
+}
+
+declare module 'content/acknowledgements.yml' {
+  declare module.exports: string[];
+}
+
+interface NavItem {
+  id: string;
+  title: string;
+  href?: string;
+  forceInternal?: boolean;
+  subItems?: NavItem[];
+}
+
+interface NavSection {
+  title: string;
+  items: NavItem[];
+  isOrdered?: boolean;
+}
+
+declare module 'content/docs/nav.yml' {
+  declare module.exports: NavSection[];
+}
+
+declare module 'content/community/nav.yml' {
+  declare module.exports: NavSection[];
+}
+
+declare module 'content/tutorial/nav.yml' {
+  declare module.exports: NavSection[];
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+const path = require('path');
+
 module.exports = {
   siteMetadata: {
     title: 'React: A JavaScript library for building user interfaces',
@@ -24,6 +26,13 @@ module.exports = {
     'gatsby-plugin-netlify',
     'gatsby-plugin-glamor',
     'gatsby-plugin-twitter',
+    {
+      resolve: 'gatsby-plugin-root-import',
+      options: {
+        src: path.join(__dirname, 'src'),
+        content: path.join(__dirname, 'content'),
+      },
+    },
     {
       resolve: 'gatsby-plugin-nprogress',
       options: {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "devDependencies": {
     "@babel/preset-flow": "^7.0.0",
     "eslint-config-prettier": "^2.6.0",
+    "gatsby-plugin-root-import": "^2.0.5",
     "lz-string": "^1.4.4",
     "npm-run-all": "^4.1.5",
     "recursive-readdir": "^2.2.1",

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -8,8 +8,7 @@
 import Helmet from 'react-helmet';
 import React from 'react';
 import {urlRoot} from 'site-constants';
-// $FlowFixMe This is a valid path
-import languages from '../../../content/languages.yml';
+import languages from 'content/languages.yml';
 
 const defaultDescription = 'A JavaScript library for building user interfaces';
 

--- a/src/pages/acknowledgements.html.js
+++ b/src/pages/acknowledgements.html.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-present, Facebook, Inc.
  *
  * @emails react-core
+ * @flow
  */
 
 import Layout from 'components/Layout';
@@ -11,10 +12,9 @@ import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import React from 'react';
 import {urlRoot} from 'site-constants';
 import {sharedStyles} from 'theme';
+import names from 'content/acknowledgements.yml';
 
-import names from '../../content/acknowledgements.yml';
-
-const Acknowlegements = ({data, location}) => (
+const Acknowlegements = ({location}: {location: Location}) => (
   <Layout location={location}>
     <Container>
       <div css={sharedStyles.articleLayout.container}>

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -12,9 +12,7 @@ import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import React from 'react';
 import {urlRoot} from 'site-constants';
 import {media, sharedStyles} from 'theme';
-
-// $FlowFixMe This is a valid path
-import languages from '../../content/languages.yml';
+import languages from 'content/languages.yml';
 
 // Status enums indicate what percentage of "core" content has been translated:
 // 0: Incomplete (0–49%)

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -12,9 +12,7 @@ import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import React from 'react';
 import {urlRoot} from 'site-constants';
 import {sharedStyles} from 'theme';
-
-// $FlowFixMe This is a valid path
-import versions from '../../content/versions.yml';
+import versions from 'content/versions.yml';
 
 type Props = {
   location: Location,

--- a/src/utils/sectionList.js
+++ b/src/utils/sectionList.js
@@ -5,22 +5,19 @@
  * @flow
  */
 
-// $FlowExpectedError
-import navCommunity from '../../content/community/nav.yml';
-// $FlowExpectedError
-import navDocs from '../../content/docs/nav.yml';
-// $FlowExpectedError
-import navTutorial from '../../content/tutorial/nav.yml';
+import navCommunity from 'content/community/nav.yml';
+import navDocs from 'content/docs/nav.yml';
+import navTutorial from 'content/tutorial/nav.yml';
 
 const sectionListDocs = navDocs.map(
-  (item: Object): Object => ({
+  (item): Object => ({
     ...item,
     directory: 'docs',
   }),
 );
 
 const sectionListCommunity = navCommunity.map(
-  (item: Object): Object => ({
+  (item): Object => ({
     ...item,
     directory: 'community',
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5426,6 +5426,11 @@ gatsby-plugin-react-helmet@^3.0.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+gatsby-plugin-root-import@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-root-import/-/gatsby-plugin-root-import-2.0.5.tgz#04e520dc661d67f49aa7950f11b7c780fd2fdbd3"
+  integrity sha512-/yA6rFjfjiFb8D6nCjfFrrGqYQMkOt4J3u2o6s7VYEF/zpA5dw2C9ENJ5fDKkJSCbbwLiEIGVMMee3vMEip2zA==
+
 gatsby-plugin-sharp@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.0.6.tgz#6d0b7e7102fcedbe8d0018e53d366018ebc84fdf"


### PR DESCRIPTION
This means we no longer need to put a `$FlowFixMe` every time we import a yaml file.

This *does* require us to use [`gatsby-plugin-root-import`](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/), since yaml module declarations don't work on relative paths. If this isn't desirable then we don't have to do this.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
