### PR TITLE
Update hooks-faq.md

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -91,7 +91,7 @@ Hooks do have a learning curve of their own. If there's something missing in thi
 
 When you're ready, we'd encourage you to start trying Hooks in new components you write. Make sure everyone on your team is on board with using them and familiar with this documentation. We don't recommend rewriting your existing classes to Hooks unless you planned to rewrite them anyway (e.g. to fix bugs).
 
-You can't use Hooks *inside* of a class component, but you can definitely mix classes and function components with Hooks in a single tree. Whether a component is a class or a function that uses Hooks is an implementation detail of that component. In the longer term, we expect Hooks to be the primary way people write React components.
+You can't use Hooks *inside* of a class component, but you can definitely mix classes and function components with Hooks in a single tree. Hooks used by a component(class or function) is an implementation detail of that component. In the longer term, we expect Hooks to be the primary way people write React components.
 
 ### Do Hooks cover all use cases for classes? {#do-hooks-cover-all-use-cases-for-classes}
 


### PR DESCRIPTION
"Whether a component is a class or a function that uses Hooks is an implementation detail of that component." wasn't framed correctly and had an ambiguous implication. 
Updated it to -  Hooks used by a component (class or function) is an implementation detail of that component.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
