### PR TITLE
Add warning about cache purging to useCallback reference

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -318,7 +318,7 @@ Returns a [memoized](https://en.wikipedia.org/wiki/Memoization) callback.
 
 Pass an inline callback and an array of dependencies. `useCallback` will return a memoized version of the callback that only changes if one of the dependencies has changed. This is useful when passing callbacks to optimized child components that rely on reference equality to prevent unnecessary renders (e.g. `shouldComponentUpdate`).
 
-`useCallback(fn, deps)` is equivalent to `useMemo(() => fn, deps)`.
+`useCallback(fn, deps)` is equivalent to `useMemo(() => fn, deps)`. This means that **you may rely on `useCallback` as a performance optimization, not as a semantic guarantee.** For more details, see the warning in the [`useMemo`](#usememo) section.
 
 > Note
 >


### PR DESCRIPTION
This PR fixes #2334 by adding a warning about cache purging to the `useCallback` reference documentation. 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
