### PR TITLE
Add omitted optional parameters to signatures

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -102,7 +102,7 @@ Note that React may still need to render that specific component again before ba
 ### `useEffect` {#useeffect}
 
 ```js
-useEffect(didUpdate);
+useEffect(didUpdate, [deps]);
 ```
 
 Accepts a function that contains imperative, possibly effectful code.
@@ -469,7 +469,7 @@ Prefer the standard `useEffect` when possible to avoid blocking visual updates.
 ### `useDebugValue` {#usedebugvalue}
 
 ```js
-useDebugValue(value)
+useDebugValue(value, [format])
 ```
 
 `useDebugValue` can be used to display a label for custom hooks in React DevTools.


### PR DESCRIPTION
 Omitting optional parameters from signatures can be misleading since it's a reasonable expectation that reference materials would use complete signatures.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
