### PR TITLE
Mention that the setter returned by useState has no return value

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -37,7 +37,7 @@ Returns a stateful value, and a function to update it.
 
 During the initial render, the returned state (`state`) is the same as the value passed as the first argument (`initialState`).
 
-The `setState` function is used to update the state. It accepts a new state value and enqueues a re-render of the component.
+The `setState` function is used to update the state. It accepts a new state value and enqueues a re-render of the component. It has no return value.
 
 ```js
 setState(newState);


### PR DESCRIPTION
This PR fixes #2232 by mentioning that the setter returned by `useState(...)` function does not return any value (return type is declared as void in the React source).