### PR TITLE
add dependency array to examples

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -342,7 +342,7 @@ function Counter() {
   const prevCountRef = useRef();
   useEffect(() => {
     prevCountRef.current = count;
-  });
+  }, [count]);
   const prevCount = prevCountRef.current;
 
   return <h1>Now: {count}, before: {prevCount}</h1>;
@@ -362,7 +362,7 @@ function usePrevious(value) {
   const ref = useRef();
   useEffect(() => {
     ref.current = value;
-  });
+  }, [value]);
   return ref.current;
 }
 ```


### PR DESCRIPTION
The `usePrevious` example is missing a dependency on `value`.