### PR TITLE
Adds live examples of the reference apps in Hooks docs

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -33,6 +33,8 @@ function Example() {
 }
 ```
 
+**[Try it on CodeSandbox](https://codesandbox.io/s/github/reactjs/reactjs.org/tree/master/examples/effect-hook-react-hooks-examples)**
+
 This snippet is based on the [counter example from the previous page](/docs/hooks-state.html), but we added a new feature to it: we set the document title to a custom message including the number of clicks.
 
 Data fetching, setting up a subscription, and manually changing the DOM in React components are all examples of side effects. Whether or not you're used to calling these operations "side effects" (or just "effects"), you've likely performed them in your components before.

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -25,6 +25,8 @@ function Example() {
 }
 ```
 
+**[Try it on CodeSandbox](https://codesandbox.io/s/github/reactjs/reactjs.org/tree/master/examples/state-hook-react-hooks-examples)**
+
 This new function `useState` is the first "Hook" we'll learn about, but this example is just a teaser. Don't worry if it doesn't make sense yet!
 
 **You can start learning Hooks [on the next page](/docs/hooks-overview.html).** On this page, we'll continue by explaining why we're adding Hooks to React and how they can help you write great applications.

--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -38,6 +38,8 @@ function Example() {
 }
 ```
 
+**[Try it on CodeSandbox](https://codesandbox.io/s/github/reactjs/reactjs.org/tree/master/examples/state-hook-react-hooks-examples)**
+
 Here, `useState` is a *Hook* (we'll talk about what this means in a moment). We call it inside a function component to add some local state to it. React will preserve this state between re-renders. `useState` returns a pair: the *current* state value and a function that lets you update it. You can call this function from an event handler or somewhere else. It's similar to `this.setState` in a class, except it doesn't merge the old and new state together. (We'll show an example comparing `useState` to `this.state` in [Using the State Hook](/docs/hooks-state.html).)
 
 The only argument to `useState` is the initial state. In the example above, it is `0` because our counter starts from zero. Note that unlike `this.state`, the state here doesn't have to be an object -- although it can be if you want. The initial state argument is only used during the first render.
@@ -98,6 +100,8 @@ function Example() {
   );
 }
 ```
+
+**[Try it on CodeSandbox](https://codesandbox.io/s/github/reactjs/reactjs.org/tree/master/examples/effect-hook-react-hooks-examples)**
 
 When you call `useEffect`, you're telling React to run your "effect" function after flushing changes to the DOM. Effects are declared inside the component so they have access to its props and state. By default, React runs the effects after every render -- *including* the first render. (We'll talk more about how this compares to class lifecycles in [Using the Effect Hook](/docs/hooks-effect.html).)
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -28,6 +28,8 @@ function Example() {
 }
 ```
 
+**[Try it on CodeSandbox](https://codesandbox.io/s/github/reactjs/reactjs.org/tree/master/examples/state-hook-react-hooks-examples)**
+
 We'll start learning about Hooks by comparing this code to an equivalent class example.
 
 ## Equivalent Class Example {#equivalent-class-example}

--- a/examples/effect-hook-react-hooks-examples/package.json
+++ b/examples/effect-hook-react-hooks-examples/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "effect-hook-react-hooks-examples",
+  "version": "1.0.0",
+  "description": "This component sets the document title after React updates the DOM",
+  "keywords": [
+    "hooks",
+    "react"
+  ],
+  "main": "src/index.js",
+  "dependencies": {
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
+  },
+  "devDependencies": {
+    "typescript": "^3.3.3"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/effect-hook-react-hooks-examples/public/index.html
+++ b/examples/effect-hook-react-hooks-examples/public/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Effect Hook - React Hooks Examples</title>
+  </head>
+
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/examples/effect-hook-react-hooks-examples/src/index.js
+++ b/examples/effect-hook-react-hooks-examples/src/index.js
@@ -1,0 +1,21 @@
+import React, { useState, useEffect } from "react";
+import ReactDOM from "react-dom";
+
+function Example() {
+  const [count, setCount] = useState(0);
+
+  // Similar to componentDidMount and componentDidUpdate:
+  useEffect(() => {
+    // Update the document title using the browser API
+    document.title = `You clicked ${count} times`;
+  });
+
+  return (
+    <div>
+      <p>You clicked {count} times</p>
+      <button onClick={() => setCount(count + 1)}>Click me</button>
+    </div>
+  );
+}
+
+ReactDOM.render(<Example />, document.getElementById("root"));

--- a/examples/state-hook-react-hooks-examples/package.json
+++ b/examples/state-hook-react-hooks-examples/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "state-hook-react-hooks-examples",
+  "version": "1.0.0",
+  "description": "This example renders a counter. When you click the button, it increments the value.",
+  "keywords": [
+    "react",
+    "hooks"
+  ],
+  "main": "src/index.js",
+  "dependencies": {
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
+  },
+  "devDependencies": {
+    "typescript": "^3.3.3"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/state-hook-react-hooks-examples/public/index.html
+++ b/examples/state-hook-react-hooks-examples/public/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>State Hook - React Hooks Examples</title>
+  </head>
+
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/examples/state-hook-react-hooks-examples/src/index.js
+++ b/examples/state-hook-react-hooks-examples/src/index.js
@@ -1,0 +1,16 @@
+import React, { useState } from "react";
+import ReactDOM from "react-dom";
+
+function Example() {
+  // Declare a new state variable, which we'll call "count"
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <p>You clicked {count} times</p>
+      <button onClick={() => setCount(count + 1)}>Click me</button>
+    </div>
+  );
+}
+
+ReactDOM.render(<Example />, document.getElementById("root"));


### PR DESCRIPTION
I found the live examples included in the Concurrent Mode docs (and elsewhere) useful but noticed there's no such examples in the Hooks documentation. This PR adds live versions of the State and Effect hooks examples to the examples folder, loading them with CodeSandbox so folks can see them online without setup.
