### PR TITLE
Shortened hyperlink text

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -142,7 +142,7 @@ As a last resort, you can pass an item's index in the array as a key. This can w
 
 Reorders can also cause issues with component state when indexes are used as keys. Component instances are updated and reused based on their key. If the key is an index, moving an item changes it. As a result, component state for things like uncontrolled inputs can get mixed up and updated in unexpected ways.
 
-Here is [an example of the issues that can be caused by using indexes as keys](codepen://reconciliation/index-used-as-key) on CodePen, and here is [an updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues](codepen://reconciliation/no-index-used-as-key).
+Here is [an example of the issues that can be caused by using indexes as keys](codepen://reconciliation/index-used-as-key) on CodePen, and here is [an updated version of the same example](codepen://reconciliation/no-index-used-as-key) showing how not using indexes as keys will fix these reordering, sorting, and prepending issues.
 
 ## Tradeoffs {#tradeoffs}
 


### PR DESCRIPTION
Shortened the really long Hyperlink text to just the required one.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
