### PR TITLE
Update hooks-reference.md

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -288,6 +288,10 @@ function Counter() {
 >
 >React guarantees that `dispatch` function identity is stable and won't change on re-renders. This is why it's safe to omit from the `useEffect` or `useCallback` dependency list.
 
+>Note
+>
+>The reducer function must be `pure`. In strict mode the `dispatch` function is called twice to highlight poptential side effects. See  [<React.StrictMode> detecting unexpected side effects](/docs/strict-mode.md#detecting-unexpected-side-effects)
+
 #### Specifying the initial state {#specifying-the-initial-state}
 
 There are two different ways to initialize `useReducer` state. You may choose either one depending on the use case. The simplest way is to pass the initial state as a second argument:


### PR DESCRIPTION
Making it explicit that reducer functions must be pure and highlighting that in Strict mode the dispatch function fires it twice

I hope this helps others to avoid the same pit I just fell in. Please be gentle with me - I am a complete newb, so I probably broke all the rules :-)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
