### PR TITLE
Update reference-profiler.md

### DIFF
--- a/content/docs/reference-profiler.md
+++ b/content/docs/reference-profiler.md
@@ -26,9 +26,9 @@ For example, to profile a `Navigation` component and its descendants:
 ```js{3}
 render(
   <App>
-    <Profiler id="Navigation" onRender={callback}>
+    <React.Profiler id="Navigation" onRender={callback}>
       <Navigation {...props} />
-    </Profiler>
+    </React.Profiler>
     <Main {...props} />
   </App>
 );
@@ -38,12 +38,12 @@ Multiple `Profiler` components can be used to measure different parts of an appl
 ```js{3,6}
 render(
   <App>
-    <Profiler id="Navigation" onRender={callback}>
+    <React.Profiler id="Navigation" onRender={callback}>
       <Navigation {...props} />
-    </Profiler>
-    <Profiler id="Main" onRender={callback}>
+    </React.Profiler>
+    <React.Profiler id="Main" onRender={callback}>
       <Main {...props} />
-    </Profiler>
+    </React.Profiler>
   </App>
 );
 ```
@@ -52,16 +52,16 @@ render(
 ```js{2,6,8}
 render(
   <App>
-    <Profiler id="Panel" onRender={callback}>
+    <React.Profiler id="Panel" onRender={callback}>
       <Panel {...props}>
-        <Profiler id="Content" onRender={callback}>
+        <React.Profiler id="Content" onRender={callback}>
           <Content {...props} />
-        </Profiler>
-        <Profiler id="PreviewPane" onRender={callback}>
+        </React.Profiler>
+        <React.Profiler id="PreviewPane" onRender={callback}>
           <PreviewPane {...props} />
-        </Profiler>
+        </React.Profiler>
       </Panel>
-    </Profiler>
+    </React.Profiler>
   </App>
 );
 ```


### PR DESCRIPTION
I noticed that the documentation don't specify from where the component Profiler comes from. So in the context maybe setting React.Profiler instead of Profiler gives a better idea to new users how to import it. Or, if they want, using React.Profiler won't crash the application by "Uncaught ReferenceError"



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
