### PR TITLE
"Must Only Be Unique" -> "Only Need To Be Unique"

### DIFF
--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -205,7 +205,7 @@ ReactDOM.render(
 
 A good rule of thumb is that elements inside the `map()` call need keys.
 
-### Keys Must Only Be Unique Among Siblings {#keys-must-only-be-unique-among-siblings}
+### Keys Only Need To Be Unique Among Siblings {#keys-only-need-to-be-unique-among-siblings}
 
 Keys used within arrays should be unique among their siblings. However they don't need to be globally unique. We can use the same keys when we produce two different arrays:
 


### PR DESCRIPTION
In the former, "must only" implies that they can't be unique if not among siblings, which is not the case. Could be "Only Must Be", but that's an awkward construction, so I used "need to be" in parallel with the opening paragraph.

Should I change the anchor text as well? Does that need to be updated elsewhere?



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
