### PR TITLE
fix(docs): Updating docs for installation section with required changes

### DIFF
--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -12,7 +12,7 @@ Use as little or as much React as you need.
 
 React has been designed from the start for gradual adoption, and **you can use as little or as much React as you need**. Perhaps you only want to add some "sprinkles of interactivity" to an existing page. React components are a great way to do that.
 
-The majority of websites aren't, and don't need to be, single-page apps. With **a few lines of code and no build tooling**, try React in a small part of your website. You can then either gradually expand its presence, or keep it contained to a few dynamic widgets.
+The majority of websites aren't, and don't need to be single-page apps. With **a few lines of code and no build tooling**, try React in a small part of your website. You can then either gradually expand its presence, or keep it contained to a few dynamic widgets.
 
 ---
 
@@ -161,7 +161,7 @@ The quickest way to try JSX in your project is to add this `<script>` tag to you
 
 Now you can use JSX in any `<script>` tag by adding `type="text/babel"` attribute to it. Here is [an example HTML file with JSX](https://raw.githubusercontent.com/reactjs/reactjs.org/master/static/html/single-file-example.html) that you can download and play with.
 
-This approach is fine for learning and creating simple demos. However, it makes your website slow and **isn't suitable for production**. When you're ready to move forward, remove this new `<script>` tag and the `type="text/babel"` attributes you've added. Instead, in the next section you will set up a JSX preprocessor to convert all your `<script>` tags automatically.
+This approach is fine for learning and creating simple demos. However, it makes your website slow and **isn't suitable for production**. When you're ready to move forward, remove this new `<script>` tag and the `type="text/babel"` attributes you've added. Instead, in the next section, you will set up a JSX preprocessor to convert all your `<script>` tags automatically.
 
 ### Add JSX to a Project {#add-jsx-to-a-project}
 

--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -24,13 +24,13 @@ To load a specific version of `react` and `react-dom`, replace `16` with the ver
 
 ### Why the `crossorigin` Attribute? {#why-the-crossorigin-attribute}
 
-If you serve React from a CDN, we recommend to keep the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute set:
+If you serve React from a CDN, we recommend keeping the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute set:
 
 ```html
 <script crossorigin src="..."></script>
 ```
 
-We also recommend to verify that the CDN you are using sets the `Access-Control-Allow-Origin: *` HTTP header:
+We also recommend verifying that the CDN you are using sets the `Access-Control-Allow-Origin: *` HTTP header:
 
 ![Access-Control-Allow-Origin: *](../images/docs/cdn-cors-header.png)
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -75,7 +75,7 @@ The following toolchains offer more flexibility and choice. We recommend them to
 
 - **[Nx](https://nx.dev/react)** is a toolkit for full-stack monorepo development, with built-in support for React, Next.js, [Express](https://expressjs.com/), and more.
 
-- **[Parcel](https://parceljs.org/)** is a fast, zero configuration web application bundler that [works with React](https://parceljs.org/recipes.html#react).
+- **[Parcel](https://parceljs.org/)** is a fast, zero-configuration web application bundler that [works with React](https://parceljs.org/recipes.html#react).
 
 - **[Razzle](https://github.com/jaredpalmer/razzle)** is a server-rendering framework that doesn't require any configuration, but offers more flexibility than Next.js.
 
@@ -87,7 +87,7 @@ A JavaScript build toolchain typically consists of:
 
 * A **bundler**, such as [webpack](https://webpack.js.org/) or [Parcel](https://parceljs.org/). It lets you write modular code and bundle it together into small packages to optimize load time.
 
-* A **compiler** such as [Babel](https://babeljs.io/). It lets you write modern JavaScript code that still works in older browsers.
+* A **compiler** such as [Babel](https://babeljs.io/). It lets you write a modern JavaScript code that still works in older browsers.
 
 If you prefer to set up your own JavaScript toolchain from scratch, [check out this guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) that re-creates some of the Create React App functionality.
 

--- a/content/docs/release-channels.md
+++ b/content/docs/release-channels.md
@@ -46,9 +46,9 @@ Releases in Next are published with the `next` tag on npm. Versions are generate
 
 The Next channel is designed to support integration testing between React and other projects.
 
-All changes to React go through extensive internal testing before they are released to the public. However, there are a myriad of environments and configurations used throughout the React ecosystem, and it's not possible for us to test against every single one.
+All changes to React go through extensive internal testing before they are released to the public. However, there are myriad of environments and configurations used throughout the React ecosystem, and it's not possible for us to test against every single one.
 
-If you're the author of a third party React framework, library, developer tool, or similar infrastructure-type project, you can help us keep React stable for your users and the entire React community by periodically running your test suite against the most recent changes. If you're interested, follow these steps:
+If you're the author of a third-party React framework, library, developer tool, or similar infrastructure-type project, you can help us keep React stable for your users and the entire React community by periodically running your test suite against the most recent changes. If you're interested, follow these steps:
 
 - Set up a cron job using your preferred continuous integration platform. Cron jobs are supported by both [CircleCI](https://circleci.com/docs/2.0/triggers/#scheduled-builds) and [Travis CI](https://docs.travis-ci.com/user/cron-jobs/).
 - In the cron job, update your React packages to the most recent React release in the Next channel, using `next` tag on npm. Using the npm cli:
@@ -72,7 +72,7 @@ A project that uses this workflow is Next.js. (No pun intended! Seriously!) You 
 
 Like Next, the Experimental channel is a prerelease channel that tracks the master branch of the React repository. Unlike Next, Experimental releases include additional features and APIs that are not ready for wider release.
 
-Usually, an update to Next is accompanied by a corresponding update to Experimental. They are based on the same source revision, but are built using a different set of feature flags.
+Usually, an update to Next is accompanied by a corresponding update to Experimental. They are based on the same source revision but are built using a different set of feature flags.
 
 Experimental releases may be significantly different than releases to Next and Latest. **Do not use Experimental releases in user-facing applications.** You should expect frequent breaking changes between releases in the Experimental channel.
 


### PR DESCRIPTION
### Changes
- [x] replacing `to keep` to `keeping` & `to verify` to `verifying` for making it sounds like a readable sentence
- [x] adding and removing `comma (,)`, where required
- [x] combining words with `-` like `third party` to `third-party` & `zero configuration` to `zero-configuration` 
- [x] removing unwanted `articles (a/an/the)`
 