### PR TITLE
fix(docs): remove unnecessary import

### DIFF
--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -281,7 +281,6 @@ import { render, unmountComponentAtNode } from "react-dom";
 import { act } from "react-dom/test-utils";
 
 import Contact from "./contact";
-import MockedMap from "./map";
 
 jest.mock("./map", () => {
   return function DummyMap(props) {


### PR DESCRIPTION
Code snippet for Module Mocking guide under testing recipes has unnecessary import as Mocked module import is not required in test files.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
