### PR TITLE
fix(docs): correct example to avoid eslint warning

### DIFF
--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -433,21 +433,21 @@ Your code might use timer-based functions like `setTimeout` to schedule more wor
 
 import React, { useEffect } from "react";
 
-export default function Card(props) {
+export default function Card({onSelect}) {
   useEffect(() => {
     const timeoutID = setTimeout(() => {
-      props.onSelect(null);
+      onSelect(null);
     }, 5000);
     return () => {
       clearTimeout(timeoutID);
     };
-  }, [props.onSelect]);
+  }, [onSelect]);
 
   return [1, 2, 3, 4].map(choice => (
     <button
       key={choice}
       data-testid={choice}
-      onClick={() => props.onSelect(choice)}
+      onClick={() => onSelect(choice)}
     >
       {choice}
     </button>


### PR DESCRIPTION
Timers related example has used props in such a way that eslint complains about the usage with useEffect => react-hooks/exhaustive-deps


![example](https://i.ibb.co/Vq1gK33/Screenshot-3.png "warning")
