### PR TITLE
fix(docs): remove useless markdown format in comments

### DIFF
--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -31,8 +31,8 @@ However, sometimes it's useful to insert a child into a different location in th
 
 ```js{6}
 render() {
-  // React does *not* create a new div. It renders the children into `domNode`.
-  // `domNode` is any valid DOM node, regardless of its location in the DOM.
+  // React does not create a new div. It renders the children into domNode.
+  // domNode is any valid DOM node, regardless of its location in the DOM.
   return ReactDOM.createPortal(
     this.props.children,
     domNode


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
