### PR TITLE
Add :target styles to avoid headlines underneath the header

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -14,6 +14,7 @@ require('normalize.css');
 require('./src/css/reset.css');
 require('./src/prism-styles');
 require('./src/css/algolia.css');
+require('./src/css/target.css');
 
 // Expose React and ReactDOM as globals for console playground
 window.React = React;

--- a/src/css/target.css
+++ b/src/css/target.css
@@ -1,0 +1,4 @@
+:target {
+  margin-top: -3rem;
+  padding-top: 3rem;
+}


### PR DESCRIPTION
When opening a link like https://reactjs.org/docs/getting-started.html#try-react, the headline "Try React" is underneath the header and thus not visible:
<img width="1280" alt="grafik" src="https://user-images.githubusercontent.com/509669/91712062-4d681300-eb87-11ea-9ceb-fed71d78371f.png">

This PR adds styles that only apply to the :target selector to avoid this issue. By using a negative top margin and a positive top padding of the same amount, this causes no visible layout changes.

With these styles, the page looks as follows depending on the break point:
<img width="1920" alt="grafik" src="https://user-images.githubusercontent.com/509669/91712274-b485c780-eb87-11ea-934e-3e50cd5d4d77.png">

<img width="1299" alt="grafik" src="https://user-images.githubusercontent.com/509669/91712312-c9faf180-eb87-11ea-916b-9b09cb5cb999.png">

<img width="1012" alt="grafik" src="https://user-images.githubusercontent.com/509669/91712342-daab6780-eb87-11ea-8436-9c9abb60a14d.png">

<img width="817" alt="grafik" src="https://user-images.githubusercontent.com/509669/91712382-eac34700-eb87-11ea-95b9-b2ce835a13be.png">

<img width="827" alt="grafik" src="https://user-images.githubusercontent.com/509669/91712585-53122880-eb88-11ea-8ac0-c7436331f561.png">

<img width="661" alt="grafik" src="https://user-images.githubusercontent.com/509669/91712413-f7479f80-eb87-11ea-88dc-e8435c16b91e.png">
