### PR TITLE
Added Gatsby Redirects for Versioned Documentations

### DIFF
--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -7,6 +7,8 @@
 'use strict';
 
 const {resolve} = require('path');
+const readFileSync = require('fs').readFileSync;
+const safeLoad = require('js-yaml').safeLoad;
 
 module.exports = async ({graphql, actions}) => {
   const {createPage, createRedirect} = actions;
@@ -18,6 +20,9 @@ module.exports = async ({graphql, actions}) => {
   const communityTemplate = resolve(__dirname, '../src/templates/community.js');
   const docsTemplate = resolve(__dirname, '../src/templates/docs.js');
   const tutorialTemplate = resolve(__dirname, '../src/templates/tutorial.js');
+  const versionsFile = resolve(__dirname, '../content/versions.yml');
+  const file = readFileSync(versionsFile, 'utf8');
+  const versions = safeLoad(file);
 
   // Redirect /index.html to root.
   createRedirect({
@@ -153,5 +158,18 @@ module.exports = async ({graphql, actions}) => {
       redirectInBrowser: true,
       toPath: newestBlogNode.fields.slug,
     });
+  });
+
+  // Each previous version page has been permanently moved
+  versions.forEach(version => {
+    if (version.path && version.url) {
+      createRedirect({
+        fromPath: version.path,
+        redirectInBrowser: true,
+        toPath: version.url,
+        isPermanent: true,
+        statusCode: 301,
+      });
+    }
   });
 };

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -58,14 +58,13 @@ const Versions = ({location}: Props) => (
                       Changelog
                     </a>
                   </li>
-                  {/**/}
-                  {/* {version.path && (
+                  {version.path && (
                     <li>
                       <a href={version.path} rel="nofollow">
                         Documentation
                       </a>
                     </li>
-                  )} */}
+                  )}
                 </ul>
               </div>
             ))}

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -58,13 +58,13 @@ const Versions = ({location}: Props) => (
                       Changelog
                     </a>
                   </li>
-                  {version.path && (
+                  {/* {version.path && (
                     <li>
                       <a href={version.path} rel="nofollow">
                         Documentation
                       </a>
                     </li>
-                  )}
+                  )} */}
                 </ul>
               </div>
             ))}

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -58,6 +58,7 @@ const Versions = ({location}: Props) => (
                       Changelog
                     </a>
                   </li>
+                  {/**/}
                   {/* {version.path && (
                     <li>
                       <a href={version.path} rel="nofollow">


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

I couldn't find anything related to docs on specific versions present in `/versions`, and the `/version/:version_number` was going to a broken link as mentioned in this [issue](https://github.com/reactjs/reactjs.org/issues/3268).
