### PR TITLE
make simple FancyButton style consistent w/ others

### DIFF
--- a/examples/forwarding-refs/fancy-button-simple.js
+++ b/examples/forwarding-refs/fancy-button-simple.js
@@ -1,7 +1,5 @@
-function FancyButton(props) {
-  return (
-    <button className="FancyButton">
-      {props.children}
-    </button>
-  );
-}
+const FancyButton = (props, ref) => (
+  <button className="FancyButton">
+    {props.children}
+  </button>
+);


### PR DESCRIPTION
The example after this one (that I edited) is:
```
const FancyButton = React.forwardRef((props, ref) => (
  <button ref={ref} className="FancyButton">
    {props.children}
  </button>
));
```
The whole style of writing functions changes in the second example, which makes it harder to read+see the difference. All we are really trying to show is that you add React.forwardRef wrapper, and `ref={ref}`

These are rendered on this page: https://reactjs.org/docs/forwarding-refs.html