### PR TITLE
page stay in same page after choosing language #3361

### DIFF
--- a/src/components/FeedbackForm/FeedbackForm.js
+++ b/src/components/FeedbackForm/FeedbackForm.js
@@ -15,7 +15,7 @@ const FeedbackForm = () => {
 
   if (feedbackGiven) {
     return 'Thanks for letting us know!';
-  } else {
+  }else {
     return (
       <span>
         Is this page useful?
@@ -53,6 +53,7 @@ const FeedbackForm = () => {
               label: window.location.pathname,
               value: 0,
             });
+            setFeedbackGiven(true);            
           }}>
           <svg
             css={{

--- a/src/components/FeedbackForm/FeedbackForm.js
+++ b/src/components/FeedbackForm/FeedbackForm.js
@@ -5,7 +5,7 @@
  * @flow
  */
 
-// $FlowExpectedError
+// $FlowExpectedError 
 import React, {useState} from 'react';
 import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
 import {sharedStyles} from 'theme';

--- a/src/components/FeedbackForm/FeedbackForm.js
+++ b/src/components/FeedbackForm/FeedbackForm.js
@@ -5,7 +5,7 @@
  * @flow
  */
 
-// $FlowExpectedError 
+// $FlowExpectedError
 import React, {useState} from 'react';
 import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
 import {sharedStyles} from 'theme';
@@ -15,7 +15,7 @@ const FeedbackForm = () => {
 
   if (feedbackGiven) {
     return 'Thanks for letting us know!';
-  }else {
+  } else {
     return (
       <span>
         Is this page useful?
@@ -53,7 +53,7 @@ const FeedbackForm = () => {
               label: window.location.pathname,
               value: 0,
             });
-            setFeedbackGiven(true);            
+            setFeedbackGiven(true);
           }}>
           <svg
             css={{

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -141,7 +141,7 @@ const Language = ({code, name, status, translatedName}) => {
         {status === 0 && translatedName}
         {status > 0 && (
           <a
-            href={`https://${prefix}reactjs.org/`}
+            href={`https://${prefix}reactjs.org/languages`}
             rel="nofollow"
             lang={code}
             hrefLang={code}>


### PR DESCRIPTION
Earlier after choosing the language page redirects to the home page now, it stays at /language after choosing the language of your choice.