### PR TITLE
Fix comments provided on the code example

### DIFF
--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -110,7 +110,7 @@ class Parent extends React.Component {
   }
 
   handleClick() {
-    // This will fire when the button in Child is clicked,
+    // This will fire when the button (practically anywhere) in Child is clicked,
     // updating Parent's state, even though button
     // is not direct descendant in the DOM.
     this.setState(state => ({


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fix the comments provided on the code example that's used to explain event bubbling within Portals

In the comments, it was saying that only click events that happen on the button would bubble. In fact, click events that happen anywhere in the child elements would bubble up to ancestors and be caught by event listeners in Parent