### PR TITLE
Remove border from h2 with two borders

### DIFF
--- a/content/docs/addons-animation.md
+++ b/content/docs/addons-animation.md
@@ -223,8 +223,6 @@ You can disable animating `enter` or `leave` animations if you want. For example
 >
 > When using `ReactCSSTransitionGroup`, there's no way for your components to be notified when a transition has ended or to perform any more complex logic around animation. If you want more fine-grained control, you can use the lower-level `ReactTransitionGroup` API which provides the hooks you need to do custom transitions.
 
-* * *
-
 ## Low-level API: ReactTransitionGroup {#low-level-api-reacttransitiongroup}
 
 **Importing**
@@ -285,8 +283,6 @@ Now you can specify `FirstChild` as the `component` prop in `<ReactTransitionGro
 ```
 
 This only works when you are animating a single child in and out, such as a collapsible panel. This approach wouldn't work when animating multiple children or replacing the single child with another child, such as an image carousel. For an image carousel, while the current image is animating out, another image will animate in, so `<ReactTransitionGroup>` needs to give them a common DOM parent. You can't avoid the wrapper for multiple children, but you can customize the wrapper with the `component` prop as described above.
-
-* * *
 
 ## Reference {#reference}
 

--- a/content/docs/addons-perf.md
+++ b/content/docs/addons-perf.md
@@ -56,8 +56,6 @@ The following methods use the measurements returned by [`Perf.getLastMeasurement
  - [`printOperations()`](#printoperations)
  - [`printDOM()`](#printdom)
 
-* * *
-
 ## Reference {#reference}
 
 ### `start()` {#start}

--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -309,8 +309,6 @@ ReactDOM.render(element, domContainer);
 >
 > You will need to have `window`, `window.document` and `window.document.createElement` globally available **before** you import `React`. Otherwise React will think it can't access the DOM and methods like `setState` won't work.
 
-* * *
-
 ## Other Utilities {#other-utilities}
 
 ### `Simulate` {#simulate}

--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -64,8 +64,6 @@ The event handlers below are triggered by an event in the bubbling phase. To reg
 - [Transition Events](#transition-events)
 - [Other Events](#other-events)
 
-* * *
-
 ## Reference {#reference}
 
 ### Clipboard Events {#clipboard-events}

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -103,8 +103,6 @@ Each component also provides some other APIs:
   - [`props`](#props)
   - [`state`](#state)
 
-* * *
-
 ## Reference {#reference}
 
 ### Commonly Used Lifecycle Methods {#commonly-used-lifecycle-methods}
@@ -496,8 +494,6 @@ Typically, this method can be replaced by `componentDidUpdate()`. If you were re
 >
 > `UNSAFE_componentWillUpdate()` will not be invoked if [`shouldComponentUpdate()`](#shouldcomponentupdate) returns false.
 
-* * *
-
 ## Other APIs {#other-apis-1}
 
 Unlike the lifecycle methods above (which React calls for you), the methods below are the methods *you* can call from your components.
@@ -587,8 +583,6 @@ Calling `forceUpdate()` will cause `render()` to be called on the component, ski
 
 Normally you should try to avoid all uses of `forceUpdate()` and only read from `this.props` and `this.state` in `render()`.
 
-* * *
-
 ## Class Properties {#class-properties-1}
 
 ### `defaultProps` {#defaultprops}
@@ -626,8 +620,6 @@ If `props.color` is set to `null`, it will remain `null`:
 ### `displayName` {#displayname}
 
 The `displayName` string is used in debugging messages. Usually, you don't need to set it explicitly because it's inferred from the name of the function or class that defines the component. You might want to set it explicitly if you want to display a different name for debugging purposes or when you create a higher-order component, see [Wrap the Display Name for Easy Debugging](/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging) for details.
-
-* * *
 
 ## Instance Properties {#instance-properties-1}
 

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -27,8 +27,6 @@ These additional methods depend on a package (`stream`) that is **only available
 - [`renderToNodeStream()`](#rendertonodestream)
 - [`renderToStaticNodeStream()`](#rendertostaticnodestream)
 
-* * *
-
 ## Reference {#reference}
 
 ### `renderToString()` {#rendertostring}

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -26,8 +26,6 @@ React supports all popular browsers, including Internet Explorer 9 and above, al
 >
 > We don't support older browsers that don't support ES5 methods, but you may find that your apps do work in older browsers if polyfills such as [es5-shim and es5-sham](https://github.com/es-shims/es5-shim) are included in the page. You're on your own if you choose to take this path.
 
-* * *
-
 ## Reference {#reference}
 
 ### `render()` {#render}

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -82,8 +82,6 @@ Suspense lets components "wait" for something before rendering. Today, Suspense 
   - [`useLayoutEffect`](/docs/hooks-reference.html#uselayouteffect)
   - [`useDebugValue`](/docs/hooks-reference.html#usedebugvalue)
 
-* * *
-
 ## Reference {#reference}
 
 ### `React.Component` {#reactcomponent}


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Some h2 have two borders, so removed one.

- animation.html
  - [#low-level-api-reacttransitiongroup](https://reactjs.org/docs/animation.html#low-level-api-reacttransitiongroup)
  - [#reference](https://reactjs.org/docs/animation.html#reference)
- perf.html
  - [#reference](https://reactjs.org/docs/perf.html#reference)
- test-utils.html
  - [#other-utilities](https://reactjs.org/docs/test-utils.html#other-utilities)
- events.html
  - [#reference](https://reactjs.org/docs/events.html#reference)
- react-component.html
  - [#reference](https://reactjs.org/docs/react-component.html#reference)
  - [#other-apis-1](https://reactjs.org/docs/react-component.html#other-apis-1)
  - [#class-properties-1](https://reactjs.org/docs/react-component.html#class-properties-1)
  - [#instance-properties-1](https://reactjs.org/docs/react-component.html#instance-properties-1)
- react-dom-server.html
  - [#reference](https://reactjs.org/docs/react-dom-server.html#reference)
- react-dom.html
  - [#reference](https://reactjs.org/docs/react-dom.html#reference)
- react-api.html
  - [#reference](https://reactjs.org/docs/react-api.html#reference)
