### PR TITLE
Update reference-react.md

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -104,7 +104,7 @@ See the [React.Component API Reference](/docs/react-component.html) for a list o
 
 ### `React.PureComponent` {#reactpurecomponent}
 
-`React.PureComponent` is similar to [`React.Component`](#reactcomponent). The difference between them is that [`React.Component`](#reactcomponent) doesn't implement [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate), but `React.PureComponent` implements it with a shallow prop and state comparison.
+`React.PureComponent` is similar to [`React.Component`](#reactcomponent). The difference between them is that [`React.Component`](#reactcomponent) [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate) always returns true any time state or props are updated (but not necessarily changed), while `React.PureComponent` performs a shallow prop and state comparison within [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate).
 
 If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases.
 


### PR DESCRIPTION
The phrase "React.Component doesn't implement `shouldComponentUpdate`" is strictly incorrect:  React.Component *does* implement `shouldComponentUpdate`, it just always returns `true`.  Saying that it "doesn't implement" might suggest that the method is not available when we extend `React.Component`, which would be highly confusing and misleading.  Instead, we should emphasize that `shouldComponentUpdate` is "pre-implemented" for PureComponent, and we should also try to distinguish between a *change* in state, and an update in (i.e., setting a state slice's value to anything, even the same value)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
