### PR TITLE
Updated The React Podcast link and attribution

### DIFF
--- a/content/community/podcasts.md
+++ b/content/community/podcasts.md
@@ -10,7 +10,7 @@ Podcasts dedicated to React and individual podcast episodes with React discussio
 
 ## Podcasts {#podcasts}
 
-- [The React Podcast](https://reactpodcast.simplecast.fm/) - The podcast about everything React.js, hosted by [React Training](https://reacttraining.com)
+- [The React Podcast](https://reactpodcast.simplecast.com/) - The podcast about everything React.js, hosted by [Michael Chan](https://twitter.com/chantastic)
 
 - [JavaScript Air](https://javascriptair.com/) - All about JavaScript (currently not producing new episodes)
 


### PR DESCRIPTION
I noticed that the link and attribution for the React Podcast was out of date.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
