### PR TITLE
Add a link to Bit under the Flexible Toolchains section

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -71,6 +71,8 @@ Learn Gatsby from [its official guide](https://www.gatsbyjs.org/docs/) and a [ga
 
 The following toolchains offer more flexibility and choice. We recommend them to more experienced users:
 
+- **[Bit](https://bit.dev)** is a scalable and collaborative way to build and reuse components, with built-in support for React, React Native, and more.
+
 - **[Neutrino](https://neutrinojs.org/)** combines the power of [webpack](https://webpack.js.org/) with the simplicity of presets, and includes a preset for [React apps](https://neutrinojs.org/packages/react/) and [React components](https://neutrinojs.org/packages/react-components/).
 
 - **[Nx](https://nx.dev/react)** is a toolkit for full-stack monorepo development, with built-in support for React, Next.js, [Express](https://expressjs.com/), and more.


### PR DESCRIPTION
Hi 👋,

Full disclaimer: I'm closely working with the Bit team, using the tool in practice and written several articles to their blog, Bits & Pieces

Bit is gaining some traction in the React community (already its a heavy choice to creating design systems with React and sharing independent components), and I think it would be a useful tool for React teams to build applications in more of a scalable way.

More info:
https://harmony-docs.bit.dev/getting-started/creating-components
https://bit.dev

PS. I added the link to Bit as the first item (I assume this section is sorted alphabetically).

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
