### PR TITLE
remove data-reactroot reference

### DIFF
--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -49,7 +49,7 @@ If you call [`ReactDOM.hydrate()`](/docs/react-dom.html#hydrate) on a node that 
 ReactDOMServer.renderToStaticMarkup(element)
 ```
 
-Similar to [`renderToString`](#rendertostring), except this doesn't create extra DOM attributes that React uses internally, such as `data-reactroot`. This is useful if you want to use React as a simple static page generator, as stripping away the extra attributes can save some bytes.
+Similar to [`renderToString`](#rendertostring), except this doesn't create extra DOM attributes that React uses internally. This is useful if you want to use React as a simple static page generator, as stripping away the extra attributes can save some bytes.
 
 If you plan to use React on the client to make the markup interactive, do not use this method. Instead, use [`renderToString`](#rendertostring) on the server and [`ReactDOM.hydrate()`](/docs/react-dom.html#hydrate) on the client.
 


### PR DESCRIPTION
It seems like it was removed in this PR https://github.com/facebook/react/pull/20996/files

Now I'm wondering if there are any internal attributes left, and if not, the whole sentence should be changed?