### PR TITLE
update browser to use with JAWS screenreader

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -498,7 +498,7 @@ Refer to the following guides on how to activate and use VoiceOver:
 - [Deque - VoiceOver for OS X Keyboard Shortcuts](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts)
 - [Deque - VoiceOver for iOS Shortcuts](https://dequeuniversity.com/screenreaders/voiceover-ios-shortcuts)
 
-#### JAWS in Internet Explorer {#jaws-in-internet-explorer}
+#### JAWS in Google Chrome {#jaws-in-chrome}
 
 [Job Access With Speech](https://www.freedomscientific.com/Products/software/JAWS/) or JAWS, is a prolifically used screen reader on Windows.
 


### PR DESCRIPTION
Chrome has been the most used browser with JAWS users for a couple of years now.
see: https://webaim.org/projects/screenreadersurvey9/#browsercombos
