### PR TITLE
Update tutorial.md

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1134,10 +1134,10 @@ Next, we'll define the `jumpTo` method in Game to update that `stepNumber`. We a
     // this method has not changed
   }
 
-  jumpTo(step) {
+  jumpTo(move) {
     this.setState({
-      stepNumber: step,
-      xIsNext: (step % 2) === 0,
+      stepNumber: move,
+      xIsNext: (move % 2) === 0,
     });
   }
 


### PR DESCRIPTION
In `history.map((step, move))` call is being made to `jumpTo(move)` but in definition of `jumpTo` variable name used is `step` which may confuse people. Surely did confuse me cuz i forgot that `jumpTo` was actually being passed variable `move`. (Looking at the definition I kept wondering why was `step` being passed to it)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
