### PR TITLE
Fix while navigating between languages, issue #3760

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -44,6 +44,17 @@ const Header = ({location}: {location: Location}) => (
       },
     }}>
     <ContainerWrapper>
+      {typeof window === 'undefined'
+        ? ''
+        : typeof localStorage === 'undefined'
+        ? ''
+        : window.location.pathname != '/languages'
+        ? localStorage.setItem(
+            'last_visited_path',
+            window.location.pathname + window.location.hash,
+          )
+        : ''}
+
       <Container>
         <div style={{position: 'relative'}}>
           <Banner />

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -141,7 +141,16 @@ const Language = ({code, name, status, translatedName}) => {
         {status === 0 && translatedName}
         {status > 0 && (
           <a
-            href={`https://${prefix}reactjs.org/`}
+            href={
+              'https://' +
+              prefix +
+              'reactjs.org' +
+              (typeof localStorage === undefined
+                ? ''
+                : typeof localStorage === 'undefined'
+                ? ''
+                : String(localStorage.getItem('last_visited_path')))
+            }
             rel="nofollow"
             lang={code}
             hrefLang={code}>


### PR DESCRIPTION
Users were having difficulties while navigating between different language. Issue in explained better here https://github.com/reactjs/reactjs.org/issues/3760

### About Solution
We would have to store last visited pathname right before the language page is visited in local storage and add the pathname when the language is changed.
For example -
A visted https://reactjs.org/docs/getting-started.html#try-react .
At this point the pathname would be "/docs/getting-started.html#try-react"
Now A has changed the language to Italian. This will add the pathname stored in the local storage to the main italian link which will become "https://it.reactjs.org/docs/getting-started.html#try-react". And A will be directed to same.]
Since different languages have different repository for each. The code has to be added in all the repositories with no change required. Currently i am adding the changes to the languages other than In Progress and Need Contributors sections. Which makes the remaining 17 languages.This is one of the repository.
I found this way efficient than others. I have made pull request in each of the repositories. Please let me know if any change is required. I would be happy to take any suggestion.

### Issue Details
Issue Title- When changing languages, user is sent to the home page instead of the current article
Issue number - 3760