### PR TITLE
Adding basic react typescript support

### DIFF
--- a/beta/src/components/MDX/Sandpack/index.tsx
+++ b/beta/src/components/MDX/Sandpack/index.tsx
@@ -16,6 +16,7 @@ type SandpackProps = {
   autorun?: boolean;
   setup?: SandpackSetup;
   showDevTools?: boolean;
+  template: 'react-ts' | undefined;
 };
 
 const sandboxStyle = `
@@ -65,7 +66,7 @@ ul {
 `.trim();
 
 function Sandpack(props: SandpackProps) {
-  let {children, setup, autorun = true, showDevTools = false} = props;
+  let {children, setup, autorun = true, showDevTools = false, template} = props;
   const [devToolsLoaded, setDevToolsLoaded] = React.useState(false);
   let codeSnippets = React.Children.toArray(children) as React.ReactElement[];
   let isSingleFile = true;
@@ -95,6 +96,8 @@ function Sandpack(props: SandpackProps) {
           filePath = '/App.js';
         } else if (props.className === 'language-css') {
           filePath = '/styles.css';
+        } else if (props.className === 'language-tsx') {
+          filePath = '/App.tsx';
         } else {
           throw new Error(
             `Code block is missing a filename: ${props.children}`
@@ -125,7 +128,7 @@ function Sandpack(props: SandpackProps) {
   return (
     <div className="sandpack-container my-8" translate="no">
       <SandpackProvider
-        template="react"
+        template={template || 'react'}
         customSetup={{...setup, files: files}}
         autorun={autorun}>
         <CustomPreset

--- a/beta/src/pages/learn/index.md
+++ b/beta/src/pages/learn/index.md
@@ -8,6 +8,31 @@ Welcome to the React documentation! This page will give you an introduction to t
 
 </Intro>
 
+
+<Sandpack template="react-ts">
+
+```tsx
+function MyButton({name}:{name:string}) {
+  return (
+    <button>
+      Click me {name}
+    </button>
+  );
+}
+
+export default function MyApp() {
+  return (
+    <div>
+      <h1>Welcome to my app</h1>
+      <MyButton name='harish'/>
+    </div>
+  );
+}
+```
+
+</Sandpack>
+
+
 <YouWillLearn>
 
 - How to create and nest components


### PR DESCRIPTION
This PR adds TypeScript support in Sandpack for writing examples in TypeScript. 

https://codesandbox.io/s/typescript-lsp-c3mqx?file=/src/App.tsx


We might have to add a worker as an extension like the codesandbox above to have the type validations working I guess.
(I'll probably try to add it as well)

cc: @danilowoz 