### PR TITLE
Add prevState-only example

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -373,6 +373,15 @@ this.setState(function(state, props) {
 });
 ```
 
+If the props aren't needed for updating the state, you can also use `setState()` with a function that takes the previous state as only argument:
+
+```js
+// Correct
+this.setState(prevState => ({
+  counter: prevState.counter + 1
+}));
+```
+
 ### State Updates are Merged {#state-updates-are-merged}
 
 When you call `setState()`, React merges the object you provide into the current state.


### PR DESCRIPTION
Add an example where only the previous state is used to update the state; this prepares the reader for the toggle button example in the Handling Events chapter

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
