### PR TITLE
Callback ref clarifications 

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -471,7 +471,7 @@ One rudimentary way to measure the position or size of a DOM node is to use a [c
 function MeasureExample() {
   const [height, setHeight] = useState(0);
 
-  const measuredRef = useCallback(node => {
+  const measureH1 = useCallback(node => {
     if (node !== null) {
       setHeight(node.getBoundingClientRect().height);
     }
@@ -479,7 +479,7 @@ function MeasureExample() {
 
   return (
     <>
-      <h1 ref={measuredRef}>Hello, world</h1>
+      <h1 ref={measureH1}>Hello, world</h1>
       <h2>The above header is {Math.round(height)}px tall</h2>
     </>
   );
@@ -488,7 +488,9 @@ function MeasureExample() {
 
 We didn't choose `useRef` in this example because an object ref doesn't notify us about *changes* to the current ref value. Using a callback ref ensures that [even if a child component displays the measured node later](https://codesandbox.io/s/818zzk8m78) (e.g. in response to a click), we still get notified about it in the parent component and can update the measurements.
 
-Note that we pass `[]` as a dependency array to `useCallback`. This ensures that our ref callback doesn't change between the re-renders, and so React won't call it unnecessarily.
+Note that we pass `[]` as a dependency array to `useCallback`. We're defining a function to pass as our attribute rather than a ref object, and without `useCallback`'s memoization of that function, javascript would create a new object each time the function was declared (which happens each time our component renders), resulting in referential inequality. And so every time our component rendered, the function would be called to attach our "new" handler to the ref attribute. We don't want that, so we create a memoized version via `useCallback` to ensure that our ref callback doesn't change between the re-renders, so React won't call it unnecessarily.
+
+Now the callback ref will be called only when the component mounts and unmounts, since the rendered `<h1>` component stays present throughout any rerenders. If you want to be notified any time a component resizes, you may want to use [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) or a third-party Hook built on it.
 
 In this example, the callback ref will be called only when the component mounts and unmounts, since the rendered `<h1>` component stays present throughout any rerenders. If you want to be notified any time a component resizes, you may want to use [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) or a third-party Hook built on it.
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -277,6 +277,10 @@ class Parent extends React.Component {
 
 In the example above, `Parent` passes its ref callback as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same function as a special `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
+#### Callback refs and function components {#callback-refs-and-function-components}
+
+See [https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node](this example)
+
 ### Legacy API: String Refs {#legacy-api-string-refs}
 
 If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -279,7 +279,7 @@ In the example above, `Parent` passes its ref callback as an `inputRef` prop to 
 
 #### Callback refs and function components {#callback-refs-and-function-components}
 
-See [https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node](this example)
+See [this example](https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node)
 
 ### Legacy API: String Refs {#legacy-api-string-refs}
 


### PR DESCRIPTION
Recently a coworker asked me to review a PR containing a function component with a callback ref. Not having seen the pattern before, I was totally baffled trying to dissect what was going on in each part. Even after finding the pattern in the documentation, it took hours of searching and reading before I felt like I really understood what was happening in each part. 

I think this could have been more like 10 or 15 minutes if the documentation included a reference to an example of the pattern in a function component, which already exists in another corner of the docs, so I created a new subsection that links to the other example.

Then in the other example, I expanded on the explanation of one of the parts of the code that was most confusing to me, and changed the variable name in the example to clarify that our variable held a memoized function (the variable now reflects what the function *does*) rather than a ref, which was misleading/confusing to me when I first tried to digest the code. Hopefully this makes things more clear.