### PR TITLE
[Beta] Fix Layout on Blog page

### DIFF
--- a/beta/src/components/Layout/Footer.tsx
+++ b/beta/src/components/Layout/Footer.tsx
@@ -9,14 +9,11 @@ import {ExternalLink} from 'components/ExternalLink';
 import {IconFacebookCircle} from 'components/Icon/IconFacebookCircle';
 import {IconTwitter} from 'components/Icon/IconTwitter';
 
-export function Footer({fullWidth = true}) {
+export function Footer() {
   const socialLinkClasses = 'hover:text-primary dark:text-primary-dark';
   return (
     <>
-      <div
-        className={cn('self-stretch w-full', {
-          'sm:pl-0 lg:pl-80 sm:pr-0 2xl:pr-80 pl-0 pr-0': fullWidth,
-        })}>
+      <div className="w-full">
         <div className="mx-auto w-full px-5 sm:px-12 md:px-12 pt-10 md:pt-12 lg:pt-10">
           <hr className="max-w-7xl mx-auto border-border dark:border-border-dark" />
         </div>

--- a/beta/src/components/Layout/Footer.tsx
+++ b/beta/src/components/Layout/Footer.tsx
@@ -9,11 +9,14 @@ import {ExternalLink} from 'components/ExternalLink';
 import {IconFacebookCircle} from 'components/Icon/IconFacebookCircle';
 import {IconTwitter} from 'components/Icon/IconTwitter';
 
-export function Footer() {
+export function Footer({fullWidth = true}) {
   const socialLinkClasses = 'hover:text-primary dark:text-primary-dark';
   return (
     <>
-      <div className="self-stretch w-full sm:pl-0 lg:pl-80 sm:pr-0 2xl:pr-80 pl-0 pr-0">
+      <div
+        className={cn('self-stretch w-full', {
+          'sm:pl-0 lg:pl-80 sm:pr-0 2xl:pr-80 pl-0 pr-0': fullWidth,
+        })}>
         <div className="mx-auto w-full px-5 sm:px-12 md:px-12 pt-10 md:pt-12 lg:pt-10">
           <hr className="max-w-7xl mx-auto border-border dark:border-border-dark" />
         </div>

--- a/beta/src/components/Layout/LayoutBlog.tsx
+++ b/beta/src/components/Layout/LayoutBlog.tsx
@@ -1,0 +1,23 @@
+import {MenuProvider} from 'components/useMenu';
+import {Footer} from './Footer';
+import {Nav} from './Nav';
+import {Sidebar} from './Sidebar';
+
+interface LayoutBlogProps {
+  children: React.ReactNode;
+}
+
+export function LayoutBlog({children}: LayoutBlogProps) {
+  return (
+    <MenuProvider>
+      <div className="flex flex-1 w-full h-full self-stretch">
+        <div className="w-full min-w-0">
+          <main className="flex flex-1 self-stretch flex-col items-end justify-around">
+            {children}
+            <Footer />
+          </main>
+        </div>
+      </div>
+    </MenuProvider>
+  );
+}

--- a/beta/src/components/Layout/LayoutPost.tsx
+++ b/beta/src/components/Layout/LayoutPost.tsx
@@ -107,13 +107,7 @@ function LayoutPost({meta, children}: LayoutPostProps) {
 }
 
 function AppShell(props: {children: React.ReactNode}) {
-  return (
-    <Page
-      displaySidebar={false}
-      routeTree={recentPostsRouteTree as RouteItem}
-      {...props}
-    />
-  );
+  return <Page routeTree={recentPostsRouteTree as RouteItem} {...props} />;
 }
 
 export default function withLayoutPost(meta: any) {

--- a/beta/src/components/Layout/LayoutPost.tsx
+++ b/beta/src/components/Layout/LayoutPost.tsx
@@ -4,7 +4,6 @@
 
 // @ts-ignore
 import {MDXContext} from '@mdx-js/react';
-import recentPostsRouteTree from 'blogIndexRecent.json';
 import {DocsPageFooter} from 'components/DocsFooter';
 import {ExternalLink} from 'components/ExternalLink';
 import {MDXComponents} from 'components/MDX/MDXComponents';
@@ -15,9 +14,9 @@ import {useRouter} from 'next/router';
 import * as React from 'react';
 import {getAuthor} from 'utils/getAuthor';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
-import {Page} from './Page';
 import {RouteItem, useRouteMeta} from './useRouteMeta';
 import {useTwitter} from './useTwitter';
+import {LayoutBlog} from './LayoutBlog';
 
 interface PageFrontmatter {
   id?: string;
@@ -107,7 +106,7 @@ function LayoutPost({meta, children}: LayoutPostProps) {
 }
 
 function AppShell(props: {children: React.ReactNode}) {
-  return <Page routeTree={recentPostsRouteTree as RouteItem} {...props} />;
+  return <LayoutBlog {...props} />;
 }
 
 export default function withLayoutPost(meta: any) {

--- a/beta/src/components/Layout/LayoutPost.tsx
+++ b/beta/src/components/Layout/LayoutPost.tsx
@@ -67,23 +67,24 @@ function LayoutPost({meta, children}: LayoutPostProps) {
   useTwitter();
   return (
     <>
-      <div className="w-full px-12">
+      <div className="w-full lg:pt-8 px-5 sm:px-12">
         <div className="h-full mx-auto max-w-4xl relative pt-16 w-full overflow-x-hidden">
           <Seo title={meta.title} />
-          <h1 className="mb-6 pt-8 text-4xl md:text-5xl font-bold leading-snug tracking-tight text-primary dark:text-primary-dark">
+          <h1 className="mb-6 pt-8 text-4xl md:text-5xl font-bold leading-snug tracking-tight dark:text-primary-dark">
             {meta.title}
           </h1>
           <p className="mb-6 text-lgtext-secondary dark:text-secondary-dark">
             By{' '}
             {toCommaSeparatedList(meta.author, (author) => (
               <ExternalLink
+                key={author}
                 href={getAuthor(author).url}
                 className="text-link dark:text-link-dark underline font-bold">
                 {getAuthor(author).name}
               </ExternalLink>
             ))}
             <span className="mx-2">·</span>
-            <span className="lead inline-flex text-gray-50">
+            <span className="lead inline-flex text-gray-50 dark:text-gray-20">
               <time dateTime={dateTime}>{date}</time>
             </span>
           </p>
@@ -106,7 +107,13 @@ function LayoutPost({meta, children}: LayoutPostProps) {
 }
 
 function AppShell(props: {children: React.ReactNode}) {
-  return <Page routeTree={recentPostsRouteTree as RouteItem} {...props} />;
+  return (
+    <Page
+      displaySidebar={false}
+      routeTree={recentPostsRouteTree as RouteItem}
+      {...props}
+    />
+  );
 }
 
 export default function withLayoutPost(meta: any) {

--- a/beta/src/components/Layout/MarkdownPage.tsx
+++ b/beta/src/components/Layout/MarkdownPage.tsx
@@ -117,7 +117,7 @@ export function MarkdownPage<
 
   return (
     <article className="h-full mx-auto relative w-full min-w-0">
-      <div className="lg:pt-0 pt-20 pl-0 lg:pl-80 2xl:px-80 ">
+      <div>
         <Seo title={title} />
         {!isHomePage && (
           <PageHeading

--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -11,26 +11,23 @@ import {Footer} from './Footer';
 interface PageProps {
   children: React.ReactNode;
   routeTree: RouteItem;
-  displaySidebar?: boolean;
 }
 
-export function Page({routeTree, children, displaySidebar = true}: PageProps) {
+export function Page({routeTree, children}: PageProps) {
   return (
     <MenuProvider>
       <SidebarContext.Provider value={routeTree}>
         <div className="h-auto lg:h-screen flex flex-row">
-          {displaySidebar && (
-            <div className="no-bg-scrollbar h-auto lg:h-full lg:overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
-              <Nav />
-              <Sidebar />
-            </div>
-          )}
+          <div className="no-bg-scrollbar h-auto lg:h-full lg:overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
+            <Nav />
+            <Sidebar />
+          </div>
 
           <div className="flex flex-1 w-full h-full self-stretch">
             <div className="w-full min-w-0">
-              <main className="flex flex-1 self-stretch flex-col items-end justify-around">
+              <main className="flex flex-1 self-stretch flex-col items-end justify-around sm:pl-0 lg:pl-80 sm:pr-0 2xl:pr-80 pl-0 pr-0">
                 {children}
-                <Footer fullWidth={displaySidebar} />
+                <Footer />
               </main>
             </div>
           </div>

--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -11,23 +11,26 @@ import {Footer} from './Footer';
 interface PageProps {
   children: React.ReactNode;
   routeTree: RouteItem;
+  displaySidebar?: boolean;
 }
 
-export function Page({routeTree, children}: PageProps) {
+export function Page({routeTree, children, displaySidebar = true}: PageProps) {
   return (
     <MenuProvider>
       <SidebarContext.Provider value={routeTree}>
         <div className="h-auto lg:h-screen flex flex-row">
-          <div className="no-bg-scrollbar h-auto lg:h-full lg:overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
-            <Nav />
-            <Sidebar />
-          </div>
+          {displaySidebar && (
+            <div className="no-bg-scrollbar h-auto lg:h-full lg:overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
+              <Nav />
+              <Sidebar />
+            </div>
+          )}
 
           <div className="flex flex-1 w-full h-full self-stretch">
             <div className="w-full min-w-0">
               <main className="flex flex-1 self-stretch flex-col items-end justify-around">
                 {children}
-                <Footer />
+                <Footer fullWidth={displaySidebar} />
               </main>
             </div>
           </div>

--- a/beta/src/components/MDX/MDXComponents.module.css
+++ b/beta/src/components/MDX/MDXComponents.module.css
@@ -4,7 +4,7 @@
 
 /* Stop purging. */
 .markdown p {
-  @apply mb-4 leading-7 whitespace-pre-wrap text-gray-70;
+  @apply mb-4 leading-7 whitespace-pre-wrap;
 }
 
 .markdown ol {

--- a/beta/src/components/PageHeading.tsx
+++ b/beta/src/components/PageHeading.tsx
@@ -30,7 +30,7 @@ function PageHeading({
           {status ? <em>—{status}</em> : ''}
         </H1>
         {description && (
-          <p className="mt-4 mb-6 text-primary dark:text-primary-dark text-xl text-gray-90 leading-large">
+          <p className="mt-4 mb-6 text-primary dark:text-primary-dark text-xl leading-large">
             {description}
           </p>
         )}

--- a/beta/src/pages/blog/all.tsx
+++ b/beta/src/pages/blog/all.tsx
@@ -19,12 +19,12 @@ export default function Archive() {
           <h1 className="text-5xl font-bold">Blog Archive</h1>
           <a
             href="/feed.xml"
-            className="p-2 betterhover:hover:bg-gray-20 transition duration-150 ease-in-out rounded-lg inline-flex items-center">
+            className="p-2 bg-card betterhover:hover:bg-secondary-button dark:bg-secondary-button-dark betterhover:hover:dark:bg-card-dark transition duration-150 ease-in-out rounded-lg inline-flex items-center">
             <IconRss className="w-5 h-5 mr-2" />
             RSS
           </a>
         </div>
-        <p className="text-gray-70 text-2xl">
+        <p className="text-gray-70 dark:text-gray-20 text-2xl">
           Historical archive of React news, announcements, and release notes.
         </p>
       </header>
@@ -38,17 +38,18 @@ export default function Archive() {
             </h3>
             <div className="flex items-center">
               <div>
-                <p className="text-sm leading-5 text-gray-80">
+                <p className="text-sm leading-5 text-gray-80 dark:text-gray-10">
                   By{' '}
                   {toCommaSeparatedList(post.author, (author) => (
                     <ExternalLink
+                      key={author}
                       href={getAuthor(author).url}
                       className="font-bold betterhover:hover:underline">
                       <span>{getAuthor(author).name}</span>
                     </ExternalLink>
                   ))}
                 </p>
-                <div className="flex text-sm leading-5 text-gray-50">
+                <div className="flex text-sm leading-5 text-gray-50 dark:text-gray-30">
                   <time dateTime={post.date}>
                     {format(parseISO(post.date), 'MMMM dd, yyyy')}
                   </time>
@@ -67,5 +68,11 @@ export default function Archive() {
 Archive.displayName = 'Index';
 
 Archive.appShell = function AppShell(props: {children: React.ReactNode}) {
-  return <Page routeTree={blogIndexRecentRouteTree} {...props} />;
+  return (
+    <Page
+      displaySidebar={false}
+      routeTree={blogIndexRecentRouteTree}
+      {...props}
+    />
+  );
 };

--- a/beta/src/pages/blog/all.tsx
+++ b/beta/src/pages/blog/all.tsx
@@ -1,8 +1,7 @@
 import blogIndex from 'blogIndex.json';
-import blogIndexRecentRouteTree from 'blogIndexRecent.json';
 import {ExternalLink} from 'components/ExternalLink';
 import {IconRss} from 'components/Icon/IconRss';
-import {Page} from 'components/Layout/Page';
+import {LayoutBlog} from 'components/Layout/LayoutBlog';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 import Link from 'next/link';
@@ -68,11 +67,5 @@ export default function Archive() {
 Archive.displayName = 'Index';
 
 Archive.appShell = function AppShell(props: {children: React.ReactNode}) {
-  return (
-    <Page
-      displaySidebar={false}
-      routeTree={blogIndexRecentRouteTree}
-      {...props}
-    />
-  );
+  return <LayoutBlog {...props} />;
 };

--- a/beta/src/pages/blog/index.tsx
+++ b/beta/src/pages/blog/index.tsx
@@ -15,7 +15,7 @@ import toCommaSeparatedList from 'utils/toCommaSeparatedList';
 export default function RecentPosts() {
   return (
     <>
-      <div className="w-full px-12">
+      <div className="w-full lg:pt-8 px-5 sm:px-12">
         <div className="max-w-4xl mx-auto w-full container pt-10">
           <header className="pt-14 pb-8">
             <div className="flex items-center justify-between">
@@ -23,45 +23,49 @@ export default function RecentPosts() {
                 title="Blog"
                 description="Offical React.js news, announcements, and release notes."
               />
-              <h1 className="text-5xl font-bold text-primary dark:text-primary-dark mb-8">
+              <h1 className="text-5xl font-bold  dark:text-primary-dark mb-8">
                 Blog
               </h1>
               <a
                 href="/feed.xml"
-                className="p-2 betterhover:hover:bg-gray-20 transition duration-150 ease-in-out rounded-lg inline-flex items-center">
+                className="p-2 bg-card betterhover:hover:bg-secondary-button dark:bg-secondary-button-dark betterhover:hover:dark:bg-card-dark transition duration-150 ease-in-out rounded-lg inline-flex items-center">
                 <IconRss className="w-5 h-5 mr-2" />
                 RSS
               </a>
             </div>
-            <p className="text-primary dark:text-primary-dark text-xl text-primary dark:text-primary-dark leading-large">
+            <p className=" dark:text-primary-dark text-xl leading-large">
               Offical React.js news, announcements, and release notes.
             </p>
           </header>
           <div className="space-y-12 pb-40">
             {blogIndexRecentRouteTree.routes.map((post) => (
               <div key={post.path}>
-                <h3 className="font-bold leading-8 text-primary dark:text-primary-dark text-2xl mb-2 hover:underline">
+                <h3 className="font-bold leading-8 dark:text-primary-dark text-2xl mb-2 hover:underline">
                   <Link href={removeFromLast(post.path, '.')}>
                     <a>{post.title}</a>
                   </Link>
                 </h3>
                 <div
-                  className={styles.markdown + ' mb-0'}
+                  className={
+                    styles.markdown +
+                    ' text-gray-70 dark:text-primary-dark mb-0'
+                  }
                   dangerouslySetInnerHTML={{__html: post.excerpt.trim()}}
                 />
                 <div className="flex items-center">
                   <div>
-                    <p className="text-sm leading-5 text-gray-80">
+                    <p className="text-sm leading-5 text-gray-80 dark:text-gray-10">
                       By{' '}
                       {toCommaSeparatedList(post.author, (author) => (
                         <ExternalLink
+                          key={author}
                           href={getAuthor(author).url}
                           className="font-bold betterhover:hover:underline">
                           <span>{getAuthor(author).name}</span>
                         </ExternalLink>
                       ))}
                     </p>
-                    <div className="flex text-sm leading-5 text-gray-50">
+                    <div className="flex text-sm leading-5 text-gray-50 dark:text-gray-20">
                       <time dateTime={post.date}>
                         {format(parseISO(post.date), 'MMMM dd, yyyy')}
                       </time>
@@ -74,7 +78,7 @@ export default function RecentPosts() {
             ))}
             <div className="text-center">
               <Link href="/blog/all">
-                <a className="p-2 text-center bg-card dark:bg-card-dark font-bold betterhover:hover:bg-secondary-button dark:bg-secondary-button-dark transition duration-150 ease-in-out rounded-lg inline-flex items-center">
+                <a className="p-2 text-center bg-card font-bold betterhover:hover:bg-secondary-button dark:bg-secondary-button-dark betterhover:hover:dark:bg-card-dark transition duration-150 ease-in-out rounded-lg inline-flex items-center">
                   View all articles
                 </a>
               </Link>
@@ -91,5 +95,11 @@ export default function RecentPosts() {
 RecentPosts.displayName = 'Index';
 
 RecentPosts.appShell = function AppShell(props: {children: React.ReactNode}) {
-  return <Page routeTree={blogIndexRecentRouteTree} {...props} />;
+  return (
+    <Page
+      displaySidebar={false}
+      routeTree={blogIndexRecentRouteTree}
+      {...props}
+    />
+  );
 };

--- a/beta/src/pages/blog/index.tsx
+++ b/beta/src/pages/blog/index.tsx
@@ -1,7 +1,7 @@
 import blogIndexRecentRouteTree from 'blogIndexRecent.json';
 import {ExternalLink} from 'components/ExternalLink';
 import {IconRss} from 'components/Icon/IconRss';
-import {Page} from 'components/Layout/Page';
+import {LayoutBlog} from 'components/Layout/LayoutBlog';
 import styles from 'components/MDX/MDXComponents.module.css';
 import {Seo} from 'components/Seo';
 import format from 'date-fns/format';
@@ -95,11 +95,5 @@ export default function RecentPosts() {
 RecentPosts.displayName = 'Index';
 
 RecentPosts.appShell = function AppShell(props: {children: React.ReactNode}) {
-  return (
-    <Page
-      displaySidebar={false}
-      routeTree={blogIndexRecentRouteTree}
-      {...props}
-    />
-  );
+  return <LayoutBlog {...props} />;
 };


### PR DESCRIPTION
Hello 
This PR adresses a fix for the bug mentionned on #4370 
I've made a small change on the `Page` Layout to pass a prop about whether to display or not the sidebar since it's the base layout used in all pages. Also I prefered to not add the Navbar component for now since it isn't adaptable for desktop viewport and I don't have an idea about how it would look like in the design. 
What still need to be fixed :
- Link to `feed.xml` is broken.
- Reference links for other blogs in the docs are broken since the links on the old website end with `.html`  
- There's an error message on the console when accessing a not found page about the routes on the sidebar.

Looking forward for your review.

Screenshots : 
![image](https://user-images.githubusercontent.com/44533239/155183980-e7ec58a4-aca3-4074-9daf-d8ce26bee190.png)
![image](https://user-images.githubusercontent.com/44533239/155184677-e96fbbdd-9949-4dbe-94d6-7b45ed6de5ec.png)


