### PR TITLE
root object is not creating in each callback

### DIFF
--- a/content/docs/rendering-elements.md
+++ b/content/docs/rendering-elements.md
@@ -54,7 +54,7 @@ Consider this ticking clock example:
 
 **[Try it on CodePen](https://codepen.io/gaearon/pen/gwoJZk?editors=1010)**
 
-It calls [`root.render()`](/docs/react-dom.html#render) every second from a [`setInterval()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setInterval) callback.
+It calls [`root.render()`](/docs/react-dom.html#render) every second from a [`setInterval()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setInterval) callback. Here we are creating a new function trick() on each callback, not the root object. ReactDOM.createRoot is created once in this program and by using its object root we are updating the output on root.render(element) successfully.
 
 >**Note:**
 >


### PR DESCRIPTION
I just want to clear we are creating a tick function on each callback not creating the ReactDOM object. It is explanation of the trick(), ReactDOM.creatRoot, and its object 'root'. It will be much more helpful for beginners to avoid any confusion.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
