### PR TITLE
Make note about React.PropTypes explicitly address its users (fixes #3632)

### DIFF
--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -6,9 +6,9 @@ redirect_from:
   - "docs/react-api.html#typechecking-with-proptypes"
 ---
 
-> Note:
+> Note for `React.PropTypes` users:
 >
-> `React.PropTypes` has moved into a different package since React v15.5. Please use [the `prop-types` library instead](https://www.npmjs.com/package/prop-types).
+> In React v15.5 it moved into a different package, [`prop-types`](https://www.npmjs.com/package/prop-types). Please use that instead.
 >
 >We provide [a codemod script](/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes) to automate the conversion.
 


### PR DESCRIPTION
Minor tweak of wording so new users know the note isn't for them.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
