### PR TITLE
Update `a-component-using-external-plugins.md`: add a link of `remarkable` library

### DIFF
--- a/content/home/examples/a-component-using-external-plugins.md
+++ b/content/home/examples/a-component-using-external-plugins.md
@@ -4,4 +4,4 @@ order: 3
 domid: markdown-example
 ---
 
-React allows you to interface with other libraries and frameworks. This example uses **remarkable**, an external Markdown library, to convert the `<textarea>`'s value in real time.
+React allows you to interface with other libraries and frameworks. This example uses [**remarkable**](https://github.com/jonschlinkert/remarkable), an external Markdown library, to convert the `<textarea>`'s value in real time.


### PR DESCRIPTION
When we see an unfamiliar library, we must first find its official documentation and understand its usage, so I added a GitHub link (or npm / yarn library link is also OK) in, hoping to reduce readers' manual search for this library time.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
