### PR TITLE
Update getting-started.md: add `<>` in `script` tags

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -46,7 +46,7 @@ You can [add React to an HTML page in one minute](/docs/add-react-to-a-website.h
 
 ### Create a New React App {#create-a-new-react-app}
 
-When starting a React project, a [simple HTML page with script tags](/docs/add-react-to-a-website.html) might still be the best option. It only takes a minute to set up!
+When starting a React project, a [simple HTML page with `<script>` tags](/docs/add-react-to-a-website.html) might still be the best option. It only takes a minute to set up!
 
 As your application grows, you might want to consider a more integrated setup. There are several JavaScript toolchains we recommend for larger applications. Each of them can work with little to no configuration and lets you take full advantage of the rich React ecosystem. [Learn how.](/docs/create-a-new-react-app.html)
 


### PR DESCRIPTION
I noticed that most of the descriptions for "tags" in the documentation had backticks and angle brackets to indicate that it was a piece of code, and this "script" didn't, so I fixed it.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
