### PR TITLE
refactor(context docs): better to use functional component

### DIFF
--- a/examples/context/reference-caveats-problem.js
+++ b/examples/context/reference-caveats-problem.js
@@ -1,10 +1,8 @@
-class App extends React.Component {
-  render() {
-    // highlight-range{2}
-    return (
-      <MyContext.Provider value={{something: 'something'}}>
-        <Toolbar />
-      </MyContext.Provider>
-    );
-  }
-}
+const App = () => {
+  // highlight-range{2}
+  return (
+    <MyContext.Provider value={{something: 'something'}}>
+      <Toolbar />
+    </MyContext.Provider>
+  );
+};


### PR DESCRIPTION
Hi, when reading 'context' docs, I noticed that it uses class components in majority cases...    
So, thought it may be good ti change to more contemporary syntax, to use function components instead
