### PR TITLE
Rename confusing variable in useImperativeHandle example

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -473,7 +473,7 @@ function FancyInput(props, ref) {
 FancyInput = forwardRef(FancyInput);
 ```
 
-In this example, a parent component that renders `<FancyInput ref={inputRef} />` would be able to call `inputRef.current.focus()`.
+In this example, a parent component that renders `<FancyInput ref={fancyRef} />` would be able to call `fancyRef.current.focus()`.
 
 ### `useLayoutEffect` {#uselayouteffect}
 


### PR DESCRIPTION
Unless I've missed something, the example uses an internal ref called `inputRef` to bind the ref passed to the `FancyInput` component to the input dom node. The fact that the ref passed to the `<FancyInput />` component instance has the same name as the ref used internally in the component declaration is confusing.