### PR TITLE
fix: sandbox preview height

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -290,7 +290,7 @@ html.dark .sp-devtools > div {
   min-width: 431px;
   /* Keep preview a fixed size on mobile to avoid jumps. */
   /* This is because we don't know its content in advance. */
-  min-height: 40vh;
+  min-height: fit-content;
   max-height: 40vh;
 }
 .sp-layout.sp-layout-expanded > .sp-stack:nth-child(1) {


### PR DESCRIPTION
### Before 
<img style="max-height:200px;" src='https://user-images.githubusercontent.com/43666833/178134079-a333846c-2501-440f-9c9e-346f9a5ba6cc.jpg' alt='before'>

### After
<img style="max-height:200px;" src='https://user-images.githubusercontent.com/43666833/178134127-ffbc6289-4c75-4aef-9480-d607e34ae9bc.jpg' alt='after'>


