### PR TITLE
fix: language link jump direction

### DIFF
--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -142,6 +142,13 @@ const Language = ({code, name, status, translatedName}) => {
         {status > 0 && (
           <a
             href={`https://${prefix}reactjs.org/`}
+            onClick={(e) => {
+              e.preventDefault();
+              history.back();
+              setTimeout(() => {
+                location.host = `${prefix}reactjs.org`;
+              }, 100);
+            }}
             rel="nofollow"
             lang={code}
             hrefLang={code}>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
From this issue:  https://github.com/reactjs/reactjs.org/issues/4900 .
The user clicks the button and it should jump to the page he just viewed. Even if the users directly visits the `language page`, they can jump to the `language page of the target language`, because `history.back()` will be blocked.