### PR TITLE
[Beta] fix effects docs error

### DIFF
--- a/beta/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/beta/src/content/learn/lifecycle-of-reactive-effects.md
@@ -1185,7 +1185,7 @@ The problem with the original code was suppressing the dependency linter. If you
 
 The author of the original code has "lied" to React by saying that the Effect does not depend (`[]`) on any reactive values. This is why React did not re-synchronize the Effect after `canMove` has changed (and `handleMove` with it). Because React did not re-synchronize the Effect, the `handleMove` attached as a listener is the `handleMove` function created during the initial render. During the initial render, `canMove` was `true`, which is why `handleMove` from the initial render will forever see that value.
 
-**If you never suppress the linter, you will never see problems with stale values.** There are a few different ways to solve this bug, but you should always start by removing the linter suppression. Then change the code to fix the lint error.
+**If you suppress the linter, you will never see problems with stale values.** There are a few different ways to solve this bug, but you should always start by removing the linter suppression. Then change the code to fix the lint error.
 
 You can change the Effect dependencies to `[handleMove]`, but since it's going to be a newly defined function for every render, you might as well remove dependencies array altogether. Then the Effect *will* re-synchronize after every re-render:
 

--- a/beta/src/content/learn/separating-events-from-effects.md
+++ b/beta/src/content/learn/separating-events-from-effects.md
@@ -790,7 +790,7 @@ The problem with the this code is in suppressing the dependency linter. If you r
 
 The author of the original code has "lied" to React by saying that the Effect does not depend (`[]`) on any reactive values. This is why React did not re-synchronize the Effect after `canMove` has changed (and `handleMove` with it). Because React did not re-synchronize the Effect, the `handleMove` attached as a listener is the `handleMove` function created during the initial render. During the initial render, `canMove` was `true`, which is why `handleMove` from the initial render will forever see that value.
 
-**If you never suppress the linter, you will never see problems with stale values.**
+**If you suppress the linter, you will never see problems with stale values.**
 
 With `useEvent`, there is no need to "lie" to the linter, and the code works as you would expect:
 


### PR DESCRIPTION
## Adjustment on the docs

### Reason

from the beta page: https://beta.reactjs.org/learn/separating-events-from-effects

>If you never suppress the linter, you will never see problems with stale values.

^^ that's probably wrong because I guess we do not recommend suppressing the linter there.

### Diff

Made a small adjustment by removing the first `never`, the sentence becomes

>If you suppress the linter, you will never see problems with stale values.
