### PR TITLE
Update conditional-rendering.md

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -147,7 +147,7 @@ It works because in JavaScript, `true && expression` always evaluates to `expres
 
 Therefore, if the condition is `true`, the element right after `&&` will appear in the output. If it is `false`, React will ignore and skip it.
 
-Note that returning a falsy expression will still cause the element after `&&` to be skipped but will return the falsy expression. In the example below, `<div>0</div>` will be returned by the render method.
+Note that returning a falsy expression will still cause the element after `&&` to be skipped, except in the case of `0`, `-0`, or `NaN`, which will be returned by the render method. In the example below, `<div>0</div>` will be returned by the render method.
 
 ```javascript{2,5}
 render() {


### PR DESCRIPTION
The statement about returning the falsy expression in the conditional rendering (`&&`) is not 100% correct. React only returns the falsy expression if it is `0`, `-0` or `NaN`. So, all other falsy expressions or values (e.g. `undefined`, `null`, `false`, `''`, etc) will not be returned by the render method.