### PR TITLE
Add external resources link

### DIFF
--- a/beta/src/components/Layout/Footer.tsx
+++ b/beta/src/components/Layout/Footer.tsx
@@ -132,6 +132,9 @@ export function Footer() {
                 Docs Contributors
               </FooterLink>
               <FooterLink href="/learn/meet-the-team">Meet the Team</FooterLink>
+              <FooterLink href="https://reactjs.org/community/external-resources.html">
+                External Resources
+              </FooterLink>
               <FooterLink href="https://reactjs.org/blog">Blog</FooterLink>
               {/* <FooterLink href="/">Community Resources</FooterLink> */}
             </div>

--- a/beta/src/sidebarLearn.json
+++ b/beta/src/sidebarLearn.json
@@ -202,6 +202,9 @@
           }, {
             "title": "Meet the Team",
             "path": "/learn/meet-the-team"
+          }, {
+            "title": "External Resources",
+            "path": "https://reactjs.org/community/external-resources.html"
           }]
         },
         {


### PR DESCRIPTION
Added the link to external resources from the old page, similar to the current link to the blog. I believe that external resources like communities help new developers learn. In addition, motivating people who are passionate about react to produce new content to disseminate knowledge.

In the future, a page with the new layout could be created, as I believe will happen with the blog.