### PR TITLE
Upgrade react-collapsed to @collapsed/react

### DIFF
--- a/beta/.npmrc
+++ b/beta/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com

--- a/beta/package.json
+++ b/beta/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@codesandbox/sandpack-react": "1.15.5",
+    "@collapsed/react": "^4.0.1",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.7.0",
@@ -36,7 +37,6 @@
     "next-remote-watch": "^1.0.0",
     "parse-numeric-range": "^1.2.0",
     "react": "0.0.0-experimental-cb5084d1c-20220924",
-    "react-collapsed": "npm:@gaearon/react-collapsed@3.1.0-forked.1",
     "react-dom": "0.0.0-experimental-cb5084d1c-20220924",
     "remark-frontmatter": "^4.0.1",
     "remark-gfm": "^3.0.1"

--- a/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -10,7 +10,7 @@ import {useRouter} from 'next/router';
 import {removeFromLast} from 'utils/removeFromLast';
 import {useRouteMeta} from '../useRouteMeta';
 import {SidebarLink} from './SidebarLink';
-import useCollapse from 'react-collapsed';
+import {useCollapse} from '@collapsed/react';
 import usePendingRoute from 'hooks/usePendingRoute';
 
 interface SidebarRouteTreeProps {

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -746,6 +746,21 @@
     react-devtools-inline "4.4.0"
     react-is "^17.0.2"
 
+"@collapsed/core@4.0.1":
+  version "4.0.1"
+  resolved "https://artifactorybase.service.csnzoo.com/artifactory/api/npm/npm/@collapsed/core/-/core-4.0.1.tgz#859714110abfb68eac48f6ce5ed480bf97bcfd72"
+  integrity sha512-RdejmttES4HzIrtIoX0hIi6cUtrakmgaS7CJEiz7lANgbPU/WRSZBLghcM4ZeNY0dyH6kHYL46KsiuyNijWqXg==
+  dependencies:
+    tiny-warning "^1.0.3"
+
+"@collapsed/react@^4.0.1":
+  version "4.0.1"
+  resolved "https://artifactorybase.service.csnzoo.com/artifactory/api/npm/npm/@collapsed/react/-/react-4.0.1.tgz#87f4fc2b3974812e4aa31653c7a9462c9d055726"
+  integrity sha512-tHm5bgxl/ddsfh6paK+0XTxdE3t9UfISOWODUbikyhhVGPh06mg4C2z7Y0AkXaj+LJIFBnn6Qbp73AH2KULdrw==
+  dependencies:
+    "@collapsed/core" "4.0.1"
+    tiny-warning "^1.0.3"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -4864,11 +4879,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-
 periscopic@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/periscopic/-/periscopic-3.0.4.tgz#b3fbed0d1bc844976b977173ca2cd4a0ef4fa8d1"
@@ -5320,13 +5330,6 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-raf@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -5341,14 +5344,6 @@ raw-body@2.5.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-"react-collapsed@npm:@gaearon/react-collapsed@3.1.0-forked.1":
-  version "3.1.0-forked.1"
-  resolved "https://registry.yarnpkg.com/@gaearon/react-collapsed/-/react-collapsed-3.1.0-forked.1.tgz#b287b81fc2af2971d7d7b523dc40b6cf116822ac"
-  integrity sha512-QkW55Upl4eeOtnDMOxasafDtDwaF+DpYKvHq8KZoNz9P477iUH8Ik1YFYuqtI7UA8mHm1/z66LD678dZCXwEEg==
-  dependencies:
-    raf "^3.4.1"
-    tiny-warning "^1.0.3"
 
 react-devtools-inline@4.4.0:
   version "4.4.0"

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -748,14 +748,14 @@
 
 "@collapsed/core@4.0.1":
   version "4.0.1"
-  resolved "https://artifactorybase.service.csnzoo.com/artifactory/api/npm/npm/@collapsed/core/-/core-4.0.1.tgz#859714110abfb68eac48f6ce5ed480bf97bcfd72"
+  resolved "https://registry.yarnpkg.com/@collapsed/core/-/core-4.0.1.tgz#859714110abfb68eac48f6ce5ed480bf97bcfd72"
   integrity sha512-RdejmttES4HzIrtIoX0hIi6cUtrakmgaS7CJEiz7lANgbPU/WRSZBLghcM4ZeNY0dyH6kHYL46KsiuyNijWqXg==
   dependencies:
     tiny-warning "^1.0.3"
 
 "@collapsed/react@^4.0.1":
   version "4.0.1"
-  resolved "https://artifactorybase.service.csnzoo.com/artifactory/api/npm/npm/@collapsed/react/-/react-4.0.1.tgz#87f4fc2b3974812e4aa31653c7a9462c9d055726"
+  resolved "https://registry.yarnpkg.com/@collapsed/react/-/react-4.0.1.tgz#87f4fc2b3974812e4aa31653c7a9462c9d055726"
   integrity sha512-tHm5bgxl/ddsfh6paK+0XTxdE3t9UfISOWODUbikyhhVGPh06mg4C2z7Y0AkXaj+LJIFBnn6Qbp73AH2KULdrw==
   dependencies:
     "@collapsed/core" "4.0.1"


### PR DESCRIPTION
This fork was created while react-collapsed didn't support React 18's `useId`. I've since updated that library to `@collapsed/react` and it now uses `useId`!