### PR TITLE
fix useEffect example for passing non-empty dependency array

### DIFF
--- a/beta/src/content/reference/react/useEffect.md
+++ b/beta/src/content/reference/react/useEffect.md
@@ -1208,7 +1208,7 @@ export default function App() {
         </button>
       </label>
       {show && <hr />}
-      {show && <ChatRoom />}
+      {show && <ChatRoom roomId={roomId} />}
     </>
   );
 }


### PR DESCRIPTION
Hi, I could be wrong, but I think one of the `ChatRoom` examples for `useEffect` is missing an argument.

If you check out [this sandbox](https://codesandbox.io/s/b07ov3?file=/App.js&utm_medium=sandpack), it seems like the *setup* isn't getting called when changing the room, unless we add `roomId={roomId}`