### PR TITLE
Bug: Function return different output as compared to the output that is shown in React Docs Beta

### DIFF
--- a/beta/src/content/learn/keeping-components-pure.md
+++ b/beta/src/content/learn/keeping-components-pure.md
@@ -98,7 +98,7 @@ let guest = 0;
 
 function Cup() {
   // Bad: changing a preexisting variable!
-  guest = guest + 1;
+  guest = guest + 2;
   return <h2>Tea cup for guest #{guest}</h2>;
 }
 


### PR DESCRIPTION
 React doc beta--> keeping components pure--> side effects:(un)intended consequences : Previously the value that was added with guest was 1(guest=guest+1)  and which results different output as compare to the output image thats  shows in react beta doc  , changing the guest value to 2 , (guest=guest+2) will return the desired output as shown in the output image in react beta doc

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
#5606 