### PR TITLE
docs: add missing import statement

### DIFF
--- a/beta/src/content/learn/tutorial-tic-tac-toe.md
+++ b/beta/src/content/learn/tutorial-tic-tac-toe.md
@@ -330,7 +330,7 @@ Click on the file labeled `styles.css` in the _Files_ section of CodeSandbox. Th
 Click on the file labeled `index.js` in the _Files_ section of CodeSandbox. You won't be editing this file during the tutorial but it is the bridge between the component you created in the `App.js` file and the web browser.
 
 ```jsx
-import {StrictMode} from 'react';
+import React, {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import './styles.css';
 


### PR DESCRIPTION
The current Beta documentation shows a code snippet a little different from the one available in the Sandbox.

It seems that the `React` import is missing from the documentation.

Steps to reproduce:

- Fork the first code sandbox that appears on the tutorial on the "Tutorial Setup" section (https://beta.reactjs.org/learn/tutorial-tic-tac-toe#setup-for-the-tutorial)

![Screenshot 2023-03-10 at 18 47 17](https://user-images.githubusercontent.com/36083448/224404122-e5936009-b5ca-42a1-8a31-d81f6e854976.png)

![Screenshot 2023-03-10 at 20 05 06](https://user-images.githubusercontent.com/36083448/224404191-a25c327b-ae1e-4967-b72a-8ce9a587d23e.png)

This PR fixes the documentation to be in sync with the sandbox example.