### PR TITLE
Clarify emptyHeading prop in Example 2

### DIFF
--- a/beta/src/components/Layout/HomeContent.js
+++ b/beta/src/components/Layout/HomeContent.js
@@ -974,7 +974,7 @@ function Example2() {
           isFromPackageImport={false}
           noShadow={true}
           noMargin={true}>
-          <div meta={meta}>{`function VideoList({ videos, emptyHeading }) {
+          <div meta={meta}>{`function VideoList({ videos, emptyHeading = 'No Videos Yet' }) {
   const count = videos.length;
   let heading = emptyHeading;
   if (count > 0) {


### PR DESCRIPTION
Add default value of 'No Videos Yet' to emptyHeading prop in Example 2 to make it clear that this is the heading displayed when videos is empty, not an "empty heading".

I believe this example can be confusing to read. I initially interpreted emptyHeading to mean an empty heading, as in an empty string, rather than a heading for when the videos array is empty.

I saw in the commit history this prop was added to replace the original heading value of 'No Videos Yet', and thought it was more clear with this context.

Therefore, I wanted to propose adding this as the default prop value to make it more obvious what emptyHeading means. Happy to hear thoughts.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
