### PR TITLE
Fix: invalid highlighting in ON THIS PAGE nav

### DIFF
--- a/src/components/Layout/useTocHighlight.tsx
+++ b/src/components/Layout/useTocHighlight.tsx
@@ -4,7 +4,7 @@
 
 import {useState, useRef, useEffect} from 'react';
 
-const TOP_OFFSET = 75;
+const TOP_OFFSET = 85;
 
 export function getHeaderAnchors(): HTMLAnchorElement[] {
   return Array.prototype.filter.call(
@@ -32,7 +32,7 @@ export function useTocHighlight() {
       const scrollPosition = window.scrollY + window.innerHeight;
       const headersAnchors = getHeaderAnchors();
 
-      if (scrollPosition >= 0 && pageHeight - scrollPosition <= TOP_OFFSET) {
+      if (scrollPosition >= 0 && pageHeight - scrollPosition <= 0) {
         // Scrolled to bottom of page.
         setCurrentIndex(headersAnchors.length - 1);
         return;


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->


https://user-images.githubusercontent.com/89984740/226314188-a97e6d85-6fee-4c1f-a1db-ad2e5d3fcf7a.mp4


---

 Fixes: #5761 
- set `TOP_OFFSET` 75 to 85
- If the document is short when selecting the second heading from the end, the last heading is selected. So changed the conditions.

