### PR TITLE
chore(SidebarLink): update effect deps

### DIFF
--- a/beta/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/beta/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -37,14 +37,14 @@ export function SidebarLink({
   const ref = useRef<HTMLAnchorElement>(null);
 
   useEffect(() => {
-    if (selected && ref && ref.current) {
+    if (selected && ref.current) {
       // @ts-ignore
       if (typeof ref.current.scrollIntoViewIfNeeded === 'function') {
         // @ts-ignore
         ref.current.scrollIntoViewIfNeeded();
       }
     }
-  }, [ref, selected]);
+  }, [selected]);
 
   let target = '';
   if (href.startsWith('https://')) {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Change for:

1. ref in deps array doesn't have any effect.
2. `Boolean(ref)` is always true.

Some other question:

As [doc](https://react.dev/learn/removing-effect-dependencies#to-change-the-dependencies-change-the-code:~:text=We%20recommend%20treating%20the%20dependency%20lint%20error%20as%20a%20compilation%20error.%20If%20you%20don%E2%80%99t%20suppress%20it%2C%20you%20will%20never%20see%20bugs%20like%20this.%20The%20rest%20of%20this%20page%20documents%20the%20alternatives%20for%20this%20and%20other%20cases.) says, u should not suppress deps linter. In user code, it's easy to change code to fit it. However, checking the reference stability of a library hook's return value, especially when it's a function, can be challenging as it requires inspecting the source code. In some case, I have to suppress deps linter because libray code return a function that is not wrapped by useCallback and changes its reference on every render. I also want to know, even if the return value is stable like ref, should I still add it to deps list? Will it affect the future Forget compiler work? In [usePendingRoutes](src/hooks/usePendingRoute.ts), it seems omit events return by useRouter.
