### PR TITLE
fix scrollbar hiding on hover/click

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -121,7 +121,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
         )}
         {/* No fallback UI so need to be careful not to suspend directly inside. */}
         <Suspense fallback={null}>
-          <main className="min-w-0 isolate">
+          <main className="min-w-0 isolate lg:ml-5">
             <article className="break-words" key={asPath}>
               {content}
             </article>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fixes: https://github.com/reactjs/react.dev/issues/5727

the main layout is overlapping the SideBarNav which is preventing scroll using drag.

before:

https://user-images.githubusercontent.com/75031127/226160054-84dbcedc-b889-4723-af0b-6bbb22e7f4e6.mov

after:

<img width="1227" alt="Screenshot 2023-03-19 at 12 18 28 AM" src="https://user-images.githubusercontent.com/75031127/226160141-7bb87a2e-72f0-4bb0-b817-0af09d9d2da1.png">

