### PR TITLE
Condition 'typeof isExpanded' is always true because it evaluates to …

### DIFF
--- a/src/components/Layout/Sidebar/SidebarButton.tsx
+++ b/src/components/Layout/Sidebar/SidebarButton.tsx
@@ -46,7 +46,7 @@ export function SidebarButton({
         )}
         onClick={onClick}>
         {title}
-        {typeof isExpanded && !heading && (
+        {isExpanded && !heading && (
           <span className="pr-2 text-gray-30">
             <IconNavArrow displayDirection={isExpanded ? 'down' : 'right'} />
           </span>


### PR DESCRIPTION
Condition 'typeof isExpanded' is always true because it evaluates to a non-empty string.

`interface SidebarButtonProps {
  title: string;
  heading: boolean;
  level: number;
  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
  isExpanded?: boolean;
  isBreadcrumb?: boolean;
}

export function SidebarButton({
  title,
  heading,
  level,
  onClick,
  isExpanded,
  isBreadcrumb,
}: SidebarButtonProps) {

 {isExpanded && !heading && (
`

