### PR TITLE
Removed the multiple checks

### DIFF
--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -87,7 +87,7 @@ export function SidebarRouteTree({
         ) => {
           const selected = slug === path;
           let listItem = null;
-          if (!path || !path || heading) {
+          if (!path || heading) {
             // if current route item has no path and children treat it as an API sidebar heading
             listItem = (
               <SidebarRouteTree


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Removed the !path which was being checked twice.
Path\File : [src/components/Layout/Sidebar/SidebarRouteTree.tsx](https://github.com/reactjs/react.dev/blob/main/src/components/Layout/Sidebar/SidebarRouteTree.tsx)

* Fixes the issue - #5747 

From this:

<img width="447" alt="image" src="https://user-images.githubusercontent.com/113239388/226182260-edc1246d-20dc-41c4-a797-3757cea53e18.png">

To this:

<img width="539" alt="image" src="https://user-images.githubusercontent.com/113239388/226181460-54ed984e-f130-4b33-b610-467736cab17b.png">

