### PR TITLE
docs: Disable lint in Code Example Preview unblock user from seeing initial UI  

### DIFF
--- a/src/content/learn/removing-effect-dependencies.md
+++ b/src/content/learn/removing-effect-dependencies.md
@@ -802,7 +802,8 @@ const serverUrl = 'https://localhost:1234';
 
 function ChatRoom({ roomId }) {
   const [message, setMessage] = useState('');
-    
+
+  // Temporarily disable the linter to demonstrate the problem
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const options = {
     serverUrl: serverUrl,

--- a/src/content/learn/removing-effect-dependencies.md
+++ b/src/content/learn/removing-effect-dependencies.md
@@ -802,7 +802,8 @@ const serverUrl = 'https://localhost:1234';
 
 function ChatRoom({ roomId }) {
   const [message, setMessage] = useState('');
-
+    
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const options = {
     serverUrl: serverUrl,
     roomId: roomId


### PR DESCRIPTION
## Problems: 
- There was lint errors that block the preview for user to try test behavior when typing

Link to error: https://react.dev/learn/removing-effect-dependencies#:~:text=with%20the%20new-,options,-.%20However%2C%20there%20is

## Screenshots
Before Fixing

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/38217535/226183475-d52490f4-c4f5-402c-a80c-496bae3f01be.png">

After Fixing

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/38217535/226183500-ae0cc056-5df0-4f62-9e43-8fe9e0fffc87.png">
<table>

 