### PR TITLE
fix : Using React.ReactNode instead of any

### DIFF
--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
+import * as React from 'react';
 import {useRef, useLayoutEffect, Fragment} from 'react';
 
 import cn from 'classnames';
@@ -25,7 +26,7 @@ function CollapseWrapper({
 }: {
   isExpanded: boolean;
   duration: number;
-  children: any;
+  children: React.ReactNode;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const timeoutRef = useRef<number | null>(null);


### PR DESCRIPTION
This will ensure that the children prop only accepts values that are valid ReactNode types, providing better type safety and avoiding potential errors in code

`function CollapseWrapper({
  isExpanded,
  duration,
  children,
}: {
  isExpanded: boolean;
  duration: number;
  children: any;
}) {`

` <CollapseWrapper duration={250} isExpanded={isExpanded}>
                  <SidebarRouteTree
                    isForceExpanded={isForceExpanded}
                    routeTree={{title, routes}}
                    breadcrumbs={breadcrumbs}
                    level={level + 1}
                  />
  </CollapseWrapper>`
