### PR TITLE
fix toc to highlight the correct header on click

### DIFF
--- a/src/components/Layout/useTocHighlight.tsx
+++ b/src/components/Layout/useTocHighlight.tsx
@@ -32,7 +32,7 @@ export function useTocHighlight() {
       const scrollPosition = window.scrollY + window.innerHeight;
       const headersAnchors = getHeaderAnchors();
 
-      if (scrollPosition >= 0 && pageHeight - scrollPosition <= TOP_OFFSET) {
+      if (scrollPosition >= 0 && pageHeight - scrollPosition <= 0) {
         // Scrolled to bottom of page.
         setCurrentIndex(headersAnchors.length - 1);
         return;

--- a/src/components/Layout/useTocHighlight.tsx
+++ b/src/components/Layout/useTocHighlight.tsx
@@ -4,7 +4,7 @@
 
 import {useState, useRef, useEffect} from 'react';
 
-const TOP_OFFSET = 75;
+const TOP_OFFSET = 85;
 
 export function getHeaderAnchors(): HTMLAnchorElement[] {
   return Array.prototype.filter.call(


### PR DESCRIPTION
Hi, 

If the user clicks one of the topics from the "On this Page" list, it will always highlight the one topic before. By increasing the TOP_OFFSET, this will solve the issue.

Thanks!