### PR TITLE
fix: fix broken link in cloneElement.md

### DIFF
--- a/src/content/reference/react/cloneElement.md
+++ b/src/content/reference/react/cloneElement.md
@@ -70,7 +70,7 @@ Usually, you'll return the element from your component or make it a child of ano
 
 * You should only **pass children as multiple arguments to `cloneElement` if they are all statically known,** like `cloneElement(element, null, child1, child2, child3)`. If your children are dynamic, pass the entire array as the third argument: `cloneElement(element, null, listItems)`. This ensures that React will [warn you about missing `key`s](/learn/rendering-lists#keeping-list-items-in-order-with-key) for any dynamic lists. For static lists this is not necessary because they never reorder.
 
-* `cloneElement` makes it harder to trace the data flow, so **try the [alternatives](/#alternatives) instead.**
+* `cloneElement` makes it harder to trace the data flow, so **try the [alternatives](#alternatives) instead.**
 
 ---
 


### PR DESCRIPTION
* Simple fix for broken link in `cloneElement.md`. [Currently](https://react.dev/reference/react/cloneElement#caveats) it's linked to the root of the website.

Before the fix:
https://user-images.githubusercontent.com/9611545/226200800-edb1043f-38df-4177-80ba-56914d95dd44.mp4

After the fix:
https://user-images.githubusercontent.com/9611545/226200805-ea1d3fd0-4149-4323-8bac-5eca9331abfb.mp4


