### PR TITLE
Fix GA for first page view

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import '../styles/sandpack.css';
 if (typeof window !== 'undefined') {
   if (process.env.NODE_ENV === 'production') {
     ga('create', process.env.NEXT_PUBLIC_GA_TRACKING_ID, 'auto');
+    ga('send', 'pageview');
   }
   const terminationEvent = 'onpagehide' in window ? 'pagehide' : 'unload';
   window.addEventListener(terminationEvent, function () {


### PR DESCRIPTION
It looks like we weren't sending the GA event for the initial page view. Not sure how that happened cause I thought I tested this in the past.

See also: https://github.com/jehna/ga-lite#migrating-from-v1

>Notice that ga-lite does not send any events or page views anymore on your behalf. You must explicitly call galite('send', 'pageview') to send the initial page view event.

