### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/analyze_comment.yml
+++ b/.github/workflows/analyze_comment.yml
@@ -44,8 +44,8 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo ::set-output name=body::$body
-          echo ::set-output name=pr-number::$pr_number
+          echo "body=$body" >> $GITHUB_OUTPUT
+          echo "pr-number=$pr_number" >> $GITHUB_OUTPUT
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1


### PR DESCRIPTION
## Description

Resolve #5775

Update `.github/workflows/analyze_comment.yml` to use environment file instead of deprecated `set-output` command. 

For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo ::set-output name=body::$body
echo ::set-output name=pr-number::$pr_number
```

**TO-BE**

```yml
echo "body=$body" >> $GITHUB_OUTPUT
echo "pr-number=$pr_number" >> $GITHUB_OUTPUT
```
