### PR TITLE
Fix: Modal doesn't disappear when using search bar shortcut on initially rendered page

### DIFF
--- a/src/components/Layout/TopNav/TopNav.tsx
+++ b/src/components/Layout/TopNav/TopNav.tsx
@@ -247,9 +247,6 @@ export default function TopNav({
               </div>
               <div className="flex w-full md:hidden"></div>
               <div className="flex items-center -space-x-2.5 xs:space-x-0 ">
-                <div className="flex md:hidden">
-                  <Search />
-                </div>
                 <div className="flex dark:hidden">
                   <button
                     type="button"

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -74,7 +74,8 @@ function useDocSearchKeyboardEvents({
         }
       }
       if (
-        (event.keyCode === 27 && isOpen) ||
+        (event.key === 'Enter' && isOpen) ||
+        (event.key === 'Escape' && isOpen) ||
         (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
         (!isEditingContent(event) && event.key === '/' && !isOpen)
       ) {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -74,7 +74,6 @@ function useDocSearchKeyboardEvents({
         }
       }
       if (
-        (event.key === 'Enter' && isOpen) ||
         (event.key === 'Escape' && isOpen) ||
         (event.key === 'k' && (event.metaKey || event.ctrlKey)) ||
         (!isEditingContent(event) && event.key === '/' && !isOpen)


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fixes: #5783 

- Add condition `(event.key === 'Enter' && isOpen)`
- `(event.keyCode === 27 && isOpen)` to `(event.key === 'Escape' && isOpen)` [KeyboardEvent.keyCode is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)

> press Enter without entering a search because of the conditions i added, the search modal disappears.