### PR TITLE
Fix to pass unused handleClick to chart component

### DIFF
--- a/src/content/reference/react/useCallback.md
+++ b/src/content/reference/react/useCallback.md
@@ -924,7 +924,7 @@ const Report = memo(function Report({ item }) {
 
   return (
     <figure>
-      <Chart data={data} />
+      <Chart onClick={handleClick} />
     </figure>
   );
 });


### PR DESCRIPTION
`handleClick` is defined but not used. Fixed because it was inconsistent with the other example (`handleClick` is passed to the `Chart` component).

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
