### PR TITLE
docs: Remove `serverUrl` in code example

### DIFF
--- a/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/src/content/learn/lifecycle-of-reactive-effects.md
@@ -672,7 +672,7 @@ This may look like a React error, but really React is pointing out a bug in your
 To fix the bug, follow the linter's suggestion to specify `roomId` and `serverUrl` as dependencies of your Effect:
 
 ```js {9}
-function ChatRoom({ roomId, serverUrl }) {
+function ChatRoom({ roomId }) {
   const [serverUrl, setServerUrl] = useState('https://localhost:1234'); // serverUrl is reactive
   useEffect(() => {
     const connection = createConnection(serverUrl, roomId);


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->


Hi team!
I really like the new site.

I found `Duplicate identifier` error in code example. ([docs link](https://react.dev/learn/lifecycle-of-reactive-effects#react-verifies-that-you-specified-every-reactive-value-as-a-dependency))
In my small opinion, I'd like to suggest that get rid of it.