### PR TITLE
CI: Add `typos` gh-action - Spell Check 🔡

### DIFF
--- a/.github/workflows/typos_spellcheck.yml
+++ b/.github/workflows/typos_spellcheck.yml
@@ -1,0 +1,33 @@
+# Reference: https://github.com/crate-ci/typos/blob/master/docs/github-action.md
+
+name: 🔡 Spell Check
+
+on:
+  push:
+    branches:
+      - main
+      # TODO: (decide) Update this to run on all branches
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  run:
+    name: 🔍 Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v3
+
+      - name: Use typos config file
+        uses: crate-ci/typos@master
+        continue-on-error: false # TODO: decide how and when to comment under the PR
+        with:
+          # scan all files in the repository
+          config: ${{ github.workspace }}/.github/workflows_resources/typos.toml
+          files: ${{ github.workspace }}/
+          write_changes: false # don't write changes locally at least for now
+          # TODO: set write_changes to true
+          # and save the output as a Comment body
+
+      # TODO: Create Comment with the changes (from the Comment body) under the PR
+      # TODO: Update the Comment when the PR is updated

--- a/.github/workflows_resources/typos.toml
+++ b/.github/workflows_resources/typos.toml
@@ -1,0 +1,32 @@
+# Reference: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default]
+locale = "en-us" # English dialect to correct to
+binary = false # Don't check binary files
+
+[default.extend-words] # Extend the default dictionary with these words
+seeked = "seeked" # key = value - correction pairs
+onSeeked = "onSeeked"
+prev = "prev" # (e.g. prevState)
+Prev = "Prev" # (e.g. setPrevCount)
+goes = "goes" # ¯\_(ツ)_/¯
+BARE = "BARE"
+prepend = "prepend"
+learnt = "learnt" # This and below all valid British spellings TODO: Decide locale with team 
+Learnt = "Learnt"
+Centre = "Centre"
+savoury = "savoury"
+queueing = "queueing"
+Queueing = "Queueing"
+fuelled = "fuelled"
+traveller = "traveller"
+ba = "ba"
+hel = "hel"
+Tae = "Tae" # surname
+
+# [default.extend-identifiers] # Extend the default dictionary with these identifiers
+
+
+[files]
+extend-exclude = ["*.patch"] # Exclude .patch files from spell check
+ignore-dot = true # Respect .ignore files (e.g. skip files specified in .gitignore)


### PR DESCRIPTION
Summary:
I'm proposing to add the `typos` gh-action in CI in order to perform **Spell Check** on push and PRs
As discussed [here](https://github.com/reactjs/react.dev/pull/5767#issuecomment-1475378990)

Changes:
- add typos gh-action `typos_spellcheck.yml`,
- plus, typos _config_ `typos.toml`.
- create and add dictionary of `React.dev` specific words to skip (e.g. `seeked`, `onSeeked`, etc)

Test Plan:
- Manually tested workflow runs.