### PR TITLE
Remove `import React` for consistency

### DIFF
--- a/src/content/learn/rendering-lists.md
+++ b/src/content/learn/rendering-lists.md
@@ -1213,7 +1213,7 @@ Alternatively, you could render a collection of fragments which contain `<hr />`
 <Sandpack>
 
 ```js
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 
 const poem = {
   lines: [


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
- Remove `import React` for consistency  in `src/content/learn/rendering-lists.md`
