### PR TITLE
Update "top level" language to be less ambiguous with "levelContext"

### DIFF
--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -336,7 +336,7 @@ export default function Heading({ children }) {
 }
 ```
 
-`useContext` is a Hook. Just like `useState` and `useReducer`, you can only call a Hook at the top level of a React component. **`useContext` tells React that the `Heading` component wants to read the `LevelContext`.**
+`useContext` is a Hook. Just like `useState` and `useReducer`, you can only call a Hook immediately inside a React component (not inside loops or conditions). **`useContext` tells React that the `Heading` component wants to read the `LevelContext`.**
 
 Now that the `Heading` component doesn't have a `level` prop, you don't need to pass the level prop to `Heading` in your JSX like this anymore:
 


### PR DESCRIPTION
We use "top level" all over the docs, but this specific topic uses a different meaning of "level". If you're learning about passing context across multiple "levels" of components, this is actually pretty confusing and makes you think you can only useContext at, for example, the top level of your app.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
