### PR TITLE
fix: some wrong links in annotations of single-file-example.html

### DIFF
--- a/public/html/single-file-example.html
+++ b/public/html/single-file-example.html
@@ -6,7 +6,7 @@
     <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 
-    <!-- Don't use this in production—do this: https://reactjs.org/docs/add-react-to-a-website#add-jsx-to-a-project -->
+    <!-- Don't use this in production—do this: https://legacy.reactjs.org/docs/add-react-to-a-website.html#add-jsx-to-a-project -->
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>
   <body>
@@ -24,13 +24,13 @@
       It slowly compiles JSX with Babel in the browser and uses a large development build of React.
 
       Read this section for a production-ready setup with JSX:
-      https://reactjs.org/docs/docs/add-react-to-a-website#try-react-with-jsx
+      https://react.dev/learn/add-react-to-an-existing-project#add-jsx-to-a-project
 
       In a larger project, you can use an integrated toolchain that includes JSX instead:
-      https://reactjs.org/docs/start-a-new-react-project
+      https://react.dev/learn/start-a-new-react-project
 
       You can also use React without JSX, in which case you can remove Babel:
-      https://reactjs.org/docs/add-react-to-a-website#add-react-in-one-minute
+      https://legacy.reactjs.org/docs/react-without-jsx.html
     -->
   </body>
 </html>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

There are some wrong links in annotations of `single-file-example.html`.
