### PR TITLE
optimize: use shorthand property names

### DIFF
--- a/src/pages/[[...markdownPath]].js
+++ b/src/pages/[[...markdownPath]].js
@@ -290,7 +290,7 @@ export async function getStaticPaths() {
   }));
 
   return {
-    paths: paths,
+    paths,
     fallback: false,
   };
 }


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
https://github.com/reactjs/react.dev/blob/main/src/pages/%5B%5B...markdownPath%5D%5D.js#L293
use shorthand property names
```js
return {
  paths
}
```
