### PR TITLE
Fix typo: missing `reactNode` in `hydrateRoot.md`

### DIFF
--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -18,7 +18,7 @@ const root = hydrateRoot(domNode, reactNode, options?)
 
 ## Reference {/*reference*/}
 
-### `hydrateRoot(domNode, options?)` {/*hydrateroot*/}
+### `hydrateRoot(domNode, reactNode, options?)` {/*hydrateroot*/}
 
 Call `hydrateRoot` to “attach” React to existing HTML that was already rendered by React in a server environment.
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

- missing `reactNode` in `src/content/reference/react-dom/client/hydrateRoot.md`
