### PR TITLE
Add more fonts

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -129,7 +129,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
         <Suspense fallback={null}>
           <main className="min-w-0 isolate">
             <article
-              className="break-words text-primary dark:text-primary-dark"
+              className="break-words font-normal text-primary dark:text-primary-dark"
               key={asPath}>
               {content}
             </article>

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -128,7 +128,9 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
         {/* No fallback UI so need to be careful not to suspend directly inside. */}
         <Suspense fallback={null}>
           <main className="min-w-0 isolate">
-            <article className="break-words" key={asPath}>
+            <article
+              className="break-words text-primary dark:text-primary-dark"
+              key={asPath}>
               {content}
             </article>
             <div

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -138,6 +138,20 @@ export const Seo = withRouter(
           type="font/woff2"
           crossOrigin="anonymous"
         />
+        <link
+          rel="preload"
+          href="https://react.dev/fonts/Optimistic_Text_W_Rg.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href="https://react.dev/fonts/Optimistic_Text_W_It.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
         {children}
       </Head>
     );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -9,7 +9,7 @@ const MyDocument = () => {
   return (
     <Html lang="en">
       <Head />
-      <body className="font-text antialiased text-lg bg-wash dark:bg-wash-dark text-secondary dark:text-secondary-dark leading-base">
+      <body className="font-text font-medium antialiased text-lg bg-wash dark:bg-wash-dark text-secondary dark:text-secondary-dark leading-base">
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -46,7 +46,7 @@
     font-family: 'Optimistic Text';
     src: url('https://react.dev/fonts/Optimistic_Text_W_Rg.woff2')
       format('woff2');
-    font-weight: 300;
+    font-weight: 400;
     font-style: normal;
     font-display: swap;
   }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -15,6 +15,8 @@
     src: url('/fonts/Source-Code-Pro-Regular.woff2') format('woff2');
   }
 
+  /* Latin */
+
   @font-face {
     font-family: 'Optimistic Display';
     src: url('https://react.dev/fonts/Optimistic_Display_W_Md.woff2')
@@ -121,6 +123,260 @@
     font-weight: 700;
     font-style: italic;
     font-display: swap;
+  }
+
+  /* Arabic */
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Arbc_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0600-06FF;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Arbc_W_SBd.woff2')
+      format('woff2');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0600-06FF;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Arbc_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0600-06FF;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Arbc_W_Rg.woff2')
+      format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0600-06FF;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Arbc_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0600-06FF;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Arbc_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0600-06FF;
+  }
+
+  /* Cyrillic */
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Cyrl_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0400-045F, U+2116;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Cyrl_W_SBd.woff2')
+      format('woff2');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0400-045F, U+2116;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Cyrl_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0400-045F, U+2116;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Cyrl_W_Rg.woff2')
+      format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0400-045F, U+2116;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Cyrl_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0400-045F, U+2116;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Cyrl_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0400-045F, U+2116;
+  }
+
+  /* Devanagari */
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Deva_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
+      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Deva_W_SBd.woff2')
+      format('woff2');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
+      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Deva_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
+      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Deva_W_Rg.woff2')
+      format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
+      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Deva_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
+      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Deva_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8,
+      U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
+  }
+
+  /* Vietnamese */
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Viet_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Viet_W_SBd.woff2')
+      format('woff2');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_Viet_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Viet_W_Rg.woff2')
+      format('woff2');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Viet_W_Md.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_Viet_W_Bd.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
   }
 
   /* Write your own custom base styles here */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -26,6 +26,15 @@
 
   @font-face {
     font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_W_MdIt.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: italic;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
     src: url('https://react.dev/fonts/Optimistic_Display_W_SBd.woff2')
       format('woff2');
     font-weight: 600;
@@ -35,10 +44,28 @@
 
   @font-face {
     font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_W_SBdIt.woff2')
+      format('woff2');
+    font-weight: 600;
+    font-style: italic;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
     src: url('https://react.dev/fonts/Optimistic_Display_W_Bd.woff2')
       format('woff2');
     font-weight: 700;
     font-style: normal;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Display';
+    src: url('https://react.dev/fonts/Optimistic_Display_W_BdIt.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: italic;
     font-display: swap;
   }
 
@@ -53,6 +80,15 @@
 
   @font-face {
     font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_W_It.woff2')
+      format('woff2');
+    font-weight: 400;
+    font-style: italic;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
     src: url('https://react.dev/fonts/Optimistic_Text_W_Md.woff2')
       format('woff2');
     font-weight: 500;
@@ -62,10 +98,28 @@
 
   @font-face {
     font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_W_MdIt.woff2')
+      format('woff2');
+    font-weight: 500;
+    font-style: italic;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
     src: url('https://react.dev/fonts/Optimistic_Text_W_Bd.woff2')
       format('woff2');
     font-weight: 700;
     font-style: normal;
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: 'Optimistic Text';
+    src: url('https://react.dev/fonts/Optimistic_Text_W_BdIt.woff2')
+      format('woff2');
+    font-weight: 700;
+    font-style: italic;
     font-display: swap;
   }
 


### PR DESCRIPTION
- Fix CSS so that 400 corresponds to the "regular" font. Previously, "regular" font was marked as 300, so the browser ended up choosing 500 instead (for regular style).
- Make the body text inside the main content area darker (primary). Previously it was secondary. But secondary feels like it doesn't have enough contrast to me now that it's thinner.
- Only use the "regular" font for main content area. Keep nav and other stuff "medium" (500).
- Add proper italics.
- Hook up localized fonts to their unicode ranges. (I did a best guess — not sure these ranges are right.)
- Edit font preloads.