### PR TITLE
Adding Conference  - Chain React 2023 -  Portland, USA

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -31,7 +31,7 @@ May 10 - 12, 2023. In-person in Kraków, Poland + remote
 [Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
 
 ### Chain React 2023 {/*chain-react-2023*/}
-May 17-19, 2023. Portland, OR, USA
+May 17 - 19, 2023. Portland, OR, USA
 
 [Website](https://chainreactconf.com/) - [Twitter](https://twitter.com/ChainReactConf) - [Facebook](https://www.facebook.com/ChainReactConf/) - [Youtube](https://www.youtube.com/channel/UCwpSzVt7QpLDbCnPXqR97-g/playlists)
 

--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -30,6 +30,11 @@ May 10 - 12, 2023. In-person in Kraków, Poland + remote
 
 [Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
 
+### Chain React 2023 {/*chain-react-2023*/}
+May 17-19, 2023. Portland, OR, USA
+
+[Website](https://chainreactconf.com/) - [Twitter](https://twitter.com/ChainReactConf) - [Facebook](https://www.facebook.com/ChainReactConf/) - [Youtube](https://www.youtube.com/channel/UCwpSzVt7QpLDbCnPXqR97-g/playlists)
+
 ### Render(ATL) 2023 🍑 {/*renderatl-2023-*/}
 May 31 - June 2, 2023. Atlanta, GA, USA
 


### PR DESCRIPTION
Hi @gaearon , @harish-sethuraman  & @hernanif1 , here is the addition of Chain React 2023 - Portland, USA, with a screenshot attached.
Please review and merge when you find time :D

<img width="1680" alt="Screenshot 2023-03-31 at 10 58 56 PM" src="https://user-images.githubusercontent.com/3509527/229229218-a52405d1-4542-45ed-8263-262c9a2fddba.png">

