### PR TITLE
tic-tac-toe-edit-declare-a-winner

### DIFF
--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -1522,7 +1522,7 @@ body {
 
 ### Declaring a winner {/*declaring-a-winner*/}
 
-Now that you show which player's turn is next, you should also show when the game is won and there are no more turns to make. To do this you'll add a helper function called `calculateWinner` that takes an array of 9 squares, checks for a winner and returns `'X'`, `'O'`, or `null` as appropriate. Don't worry too much about the `calculateWinner` function; it's not specific to React:
+Now you should display which player’s turn is next or when the game is won, and there are no more turns. To do this you'll add a helper function called `calculateWinner` that takes an array of 9 squares, checks for a winner and returns `'X'`, `'O'`, or `null` as appropriate. Don't worry too much about the `calculateWinner` function; it's not specific to React:
 
 ```js App.js
 export default function Board() {


### PR DESCRIPTION
fix #5854

Hi @gaearon , please take a look; I think this little change in text is fixing the issue without the need to complicate it and make any edits in the text above :D



Before:
<img width="891" alt="Screenshot 2023-04-01 at 11 12 19 AM" src="https://user-images.githubusercontent.com/3509527/229277252-18501dce-abbe-487e-96d0-d259eda514d4.png">


After:
<img width="920" alt="Screenshot 2023-04-01 at 11 11 52 AM" src="https://user-images.githubusercontent.com/3509527/229277283-a8809ff3-62ef-4afa-b2c2-166a4cd8a8fd.png">
