### PR TITLE
Use opening fragment instead of div

### DIFF
--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -1582,7 +1582,7 @@ export default function Board() {
   }
 
   return (
-    <div>
+    <>
       <div className="status">{status}</div>
       <div className="board-row">
         // ...


### PR DESCRIPTION
In Declaring a Winner section,  code example shows `<div>` as outermost tag as first line within the return statement. The `<div>` should be replaced by `<>` instead, so that it is consistent with full code listing show at other places in the document.
