### PR TITLE
Fix runtime error in image gallery example

### DIFF
--- a/src/content/learn/adding-interactivity.md
+++ b/src/content/learn/adding-interactivity.md
@@ -94,9 +94,14 @@ import { sculptureList } from './data.js';
 export default function Gallery() {
   const [index, setIndex] = useState(0);
   const [showMore, setShowMore] = useState(false);
+  const hasNext = index < sculptureList.length - 1;
 
   function handleNextClick() {
-    setIndex(index + 1);
+    if (hasNext) {
+      setIndex(index + 1);
+    } else {
+      setIndex(0);
+    }
   }
 
   function handleMoreClick() {


### PR DESCRIPTION
The `useState` image gallery example currently throws a runtime error when the user clicks "Next" on the 12th slide. The error can be found in the ["State: a component’s memory"](https://react.dev/learn/adding-interactivity#state-a-components-memory) section on the "Adding Interactivity" page.

For consistency across the codebase I have rectified this by using the same logic that's used [here](https://react.dev/learn/preserving-and-resetting-state#recap) on a similar image gallery component found in the 4th tab in the "Recap" section. 

PR resolves #5871.