### PR TITLE
Fixed a wrong state name in explanation; renamed state name to follow naming convention

### DIFF
--- a/src/content/learn/updating-arrays-in-state.md
+++ b/src/content/learn/updating-arrays-in-state.md
@@ -549,7 +549,7 @@ artwork.seen = nextSeen; // Problem: mutates an existing item
 setMyList(myNextList);
 ```
 
-Although the `myNextList` array itself is new, the *items themselves* are the same as in the original `myList` array. So changing `artwork.seen` changes the *original* artwork item. That artwork item is also in `yourArtworks`, which causes the bug. Bugs like this can be difficult to think about, but thankfully they disappear if you avoid mutating state.
+Although the `myNextList` array itself is new, the *items themselves* are the same as in the original `myList` array. So changing `artwork.seen` changes the *original* artwork item. That artwork item is also in `yourList`, which causes the bug. Bugs like this can be difficult to think about, but thankfully they disappear if you avoid mutating state.
 
 **You can use `map` to substitute an old item with its updated version without mutation.**
 
@@ -681,7 +681,7 @@ export default function BucketList() {
   const [myList, updateMyList] = useImmer(
     initialList
   );
-  const [yourArtworks, updateYourList] = useImmer(
+  const [yourList, updateYourList] = useImmer(
     initialList
   );
 
@@ -712,7 +712,7 @@ export default function BucketList() {
         onToggle={handleToggleMyList} />
       <h2>Your list of art to see:</h2>
       <ItemList
-        artworks={yourArtworks}
+        artworks={yourList}
         onToggle={handleToggleYourList} />
     </>
   );


### PR DESCRIPTION
Updated `updating-arrays-in-state.md`.

At the [Updating objects inside arrays](https://react.dev/learn/updating-arrays-in-state#updating-objects-inside-arrays) part of the section, the _very first_ explanation is referring to a state `yourArtworks` which is a state that **doesn't** exist in the `Sandpack`  above. I renamed it into `yourList` which is the correct state name this explanation refers to.
Below is an image of the current explanation:
<img src="https://i.imgur.com/UuZxtUi.jpg" alt="Before fixing"/>
After fixing:
<img src="https://i.imgur.com/t8EnA8Z.jpg" alt="After fixing"/>

---
The second fix is inside the `Sandpack` of [Write concise update logic with Immer](https://react.dev/learn/updating-arrays-in-state#write-concise-update-logic-with-immer) part of the _sub-section_ on the same page, where a state named `yourArtworks` has a setter function named `updateYourList`, so, this state should instead be named `yourList` - which would additionally save readers from the confusion of why this state name has changed when its logic is a continuation of the two *Sandpack*'s above it (*in the same section*) which are using `yourList` name; alongside following naming conventions.

Below are images of the current code:
<img src="https://i.imgur.com/7cQmAWw.jpg" alt="Before fixing Part1">
<img src="https://i.imgur.com/YhIInZF.jpg" alt="Before fixing Part2">

After renaming:
<img src="https://i.imgur.com/jux9n5U.jpg" alt="After fixing Part1">
<img src="https://i.imgur.com/P9YYzLL.jpg" alt="After fixing Part2">

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
