### PR TITLE
State: A Component's Memory - runtime error

### DIFF
--- a/src/content/learn/state-a-components-memory.md
+++ b/src/content/learn/state-a-components-memory.md
@@ -208,9 +208,14 @@ import { sculptureList } from './data.js';
 
 export default function Gallery() {
   const [index, setIndex] = useState(0);
-
+  const hasNext = index < sculptureList.length - 1;
+  
   function handleClick() {
-    setIndex(index + 1);
+    if (hasNext) {
+      setIndex(index + 1);
+    } else {
+      setIndex(0);
+    }
   }
 
   let sculpture = sculptureList[index];
@@ -392,9 +397,14 @@ import { sculptureList } from './data.js';
 export default function Gallery() {
   const [index, setIndex] = useState(0);
   const [showMore, setShowMore] = useState(false);
+  const hasNext = index < sculptureList.length - 1;
 
   function handleNextClick() {
-    setIndex(index + 1);
+    if (hasNext) {
+      setIndex(index + 1);
+    } else {
+      setIndex(0);
+    }
   }
 
   function handleMoreClick() {
@@ -573,9 +583,14 @@ function Gallery() {
   // Each useState() call will get the next pair.
   const [index, setIndex] = useState(0);
   const [showMore, setShowMore] = useState(false);
+  const hasNext = index < sculptureList.length - 1;
 
   function handleNextClick() {
-    setIndex(index + 1);
+    if (hasNext) {
+      setIndex(index + 1);
+    } else {
+      setIndex(0);
+    }
   }
 
   function handleMoreClick() {
@@ -757,9 +772,14 @@ import { sculptureList } from './data.js';
 export default function Gallery() {
   const [index, setIndex] = useState(0);
   const [showMore, setShowMore] = useState(false);
+  const hasNext = index < sculptureList.length - 1;
 
   function handleNextClick() {
-    setIndex(index + 1);
+    if (hasNext) {
+      setIndex(index + 1);
+    } else {
+      setIndex(0);
+    }
   }
 
   function handleMoreClick() {


### PR DESCRIPTION
getting an `Runtime Error` on ["State: A Component's Memory"](https://react.dev/learn/state-a-components-memory#adding-a-state-variable) page

same changes as [here](https://github.com/reactjs/react.dev/pull/5877)

**PR solves:** https://github.com/reactjs/react.dev/issues/5871.

before:
![image](https://user-images.githubusercontent.com/10272176/230692731-d83151d7-0e35-4f25-85c4-95d17e24512c.png)
after (on local):
![image](https://user-images.githubusercontent.com/10272176/230692814-df7ab2af-1554-4364-b3ce-031317d28c31.png)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
