### PR TITLE
[Fixed]: Sidebar scrollbar disappearing on hover #5750

### DIFF
--- a/src/components/Layout/SidebarNav/SidebarNav.tsx
+++ b/src/components/Layout/SidebarNav/SidebarNav.tsx
@@ -35,7 +35,7 @@ export default function SidebarNav({
         'sticky top-0 lg:bottom-0 lg:h-[calc(100vh-4rem)] flex flex-col'
       )}>
       <div
-        className="overflow-y-scroll no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark"
+        className="overflow-y-scroll no-bg-scrollbar lg:w-[320px] grow bg-wash dark:bg-wash-dark"
         style={{
           overscrollBehavior: 'contain',
         }}>


### PR DESCRIPTION
Fixes: https://github.com/reactjs/react.dev/issues/5727

Resolved issue where scrollbar was getting disappeared when user tries to scroll by dragging scrollbar using cursor.

Solution: 

In sidebar component on aside tag before there was 342px size set for lg screen , so what i did is changed it to 320px. Thus the issue is resolved with minimal changes

Issue:
![image](https://user-images.githubusercontent.com/29714782/226108170-1251cdce-1cec-4bcc-bb2f-7c62225acac4.gif)



