### PR TITLE
Sidebar dropdown should close on second click #26601

### DIFF
--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -21,7 +21,8 @@ interface SidebarLinkProps {
   isBreadcrumb?: boolean;
   hideArrow?: boolean;
   isPending: boolean;
-  handleClick: (href: string) => void;
+  handleClick: (href: string | undefined) => void;
+  isRoutesInSlug?: boolean;
 }
 
 export function SidebarLink({
@@ -35,6 +36,7 @@ export function SidebarLink({
   hideArrow,
   isPending,
   handleClick,
+  isRoutesInSlug = false,
 }: SidebarLinkProps) {
   const ref = useRef<HTMLAnchorElement>(null);
 
@@ -48,6 +50,23 @@ export function SidebarLink({
     }
   }, [ref, selected]);
 
+  const handleArrowClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ): void => {
+    if (isExpanded && isRoutesInSlug) {
+      event.preventDefault();
+      handleClick(undefined);
+    } else {
+      handleClick(href);
+    }
+  };
+
+  const handleTitleClick = (): void => {
+    if (!isRoutesInSlug) {
+      handleClick(href);
+    }
+  };
+
   let target = '';
   if (href.startsWith('https://')) {
     target = '_blank';
@@ -59,7 +78,7 @@ export function SidebarLink({
         title={title}
         target={target}
         aria-current={selected ? 'page' : undefined}
-        onClick={() => handleClick(href)}
+        onClick={handleTitleClick}
         className={cn(
           'p-2 pr-2 w-full rounded-none lg:rounded-r-2xl text-left hover:bg-gray-5 dark:hover:bg-gray-80 relative flex items-center justify-between',
           {
@@ -87,7 +106,10 @@ export function SidebarLink({
             className={cn('pr-1', {
               'text-link dark:text-link-dark': isExpanded,
               'text-tertiary dark:text-tertiary-dark': !isExpanded,
-            })}>
+            })}
+            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
+              handleArrowClick(e)
+            }>
             <IconNavArrow displayDirection={isExpanded ? 'down' : 'right'} />
           </span>
         )}

--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -18,7 +18,6 @@ interface SidebarLinkProps {
   wip: boolean | undefined;
   icon?: React.ReactNode;
   isExpanded?: boolean;
-  isBreadcrumb?: boolean;
   hideArrow?: boolean;
   isPending: boolean;
   handleClick: (href: string | undefined) => void;
@@ -32,7 +31,6 @@ export function SidebarLink({
   wip,
   level,
   isExpanded,
-  isBreadcrumb,
   hideArrow,
   isPending,
   handleClick,
@@ -56,8 +54,6 @@ export function SidebarLink({
     if (isExpanded && isRoutesInSlug) {
       event.preventDefault();
       handleClick(undefined);
-    } else {
-      handleClick(href);
     }
   };
 

--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -21,6 +21,7 @@ interface SidebarLinkProps {
   isBreadcrumb?: boolean;
   hideArrow?: boolean;
   isPending: boolean;
+  handleClick: (href: string) => void;
 }
 
 export function SidebarLink({
@@ -33,6 +34,7 @@ export function SidebarLink({
   isBreadcrumb,
   hideArrow,
   isPending,
+  handleClick,
 }: SidebarLinkProps) {
   const ref = useRef<HTMLAnchorElement>(null);
 
@@ -57,6 +59,7 @@ export function SidebarLink({
         title={title}
         target={target}
         aria-current={selected ? 'page' : undefined}
+        onClick={() => handleClick(href)}
         className={cn(
           'p-2 pr-2 w-full rounded-none lg:rounded-r-2xl text-left hover:bg-gray-5 dark:hover:bg-gray-80 relative flex items-center justify-between',
           {

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -113,9 +113,9 @@ export function SidebarRouteTree({
             const isExpanded =
               (isForceExpanded || isBreadcrumb || selected) &&
               openSidebarPath === path;
-            const isRoutesInSlug = routes.some(
-              (route) => route.path === slug || route.path === path
-            );
+            const isRoutesInSlug =
+              routes.some((route) => route.path === slug) &&
+              openSidebarPath === path;
             listItem = (
               <li key={`${title}-${path}-${level}-heading`}>
                 <SidebarLink
@@ -127,7 +127,6 @@ export function SidebarRouteTree({
                   title={title}
                   wip={wip}
                   isExpanded={isExpanded}
-                  isBreadcrumb={isBreadcrumb}
                   hideArrow={isForceExpanded}
                   handleClick={handleClick}
                   isRoutesInSlug={isRoutesInSlug}

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -78,10 +78,12 @@ export function SidebarRouteTree({
   const slug = useRouter().asPath.split(/[\?\#]/)[0];
   const pendingRoute = usePendingRoute();
   const currentRoutes = routeTree.routes as RouteItem[];
-  const [openSidebarPath, setOpenSidebarPath] = useState<string>(slug);
+  const [openSidebarPath, setOpenSidebarPath] = useState<string | undefined>(
+    slug
+  );
 
-  const handleClick = (path: string): void => {
-    setOpenSidebarPath(path === openSidebarPath && openSidebarPath ? '' : path);
+  const handleClick = (path: string | undefined): void => {
+    setOpenSidebarPath(path === openSidebarPath ? undefined : path);
   };
 
   return (
@@ -111,6 +113,9 @@ export function SidebarRouteTree({
             const isExpanded =
               (isForceExpanded || isBreadcrumb || selected) &&
               openSidebarPath === path;
+            const isRoutesInSlug = routes.some(
+              (route) => route.path === slug || route.path === path
+            );
             listItem = (
               <li key={`${title}-${path}-${level}-heading`}>
                 <SidebarLink
@@ -125,6 +130,7 @@ export function SidebarRouteTree({
                   isBreadcrumb={isBreadcrumb}
                   hideArrow={isForceExpanded}
                   handleClick={handleClick}
+                  isRoutesInSlug={isRoutesInSlug}
                 />
                 <CollapseWrapper duration={250} isExpanded={isExpanded}>
                   <SidebarRouteTree

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {useRef, useLayoutEffect, Fragment} from 'react';
+import {useRef, useLayoutEffect, Fragment, useState} from 'react';
 
 import cn from 'classnames';
 import {useRouter} from 'next/router';
@@ -78,6 +78,12 @@ export function SidebarRouteTree({
   const slug = useRouter().asPath.split(/[\?\#]/)[0];
   const pendingRoute = usePendingRoute();
   const currentRoutes = routeTree.routes as RouteItem[];
+  const [openSidebarPath, setOpenSidebarPath] = useState<string>(slug);
+
+  const handleClick = (path: string): void => {
+    setOpenSidebarPath(path === openSidebarPath && openSidebarPath ? '' : path);
+  };
+
   return (
     <ul>
       {currentRoutes.map(
@@ -102,7 +108,9 @@ export function SidebarRouteTree({
             const isBreadcrumb =
               breadcrumbs.length > 1 &&
               breadcrumbs[breadcrumbs.length - 1].path === path;
-            const isExpanded = isForceExpanded || isBreadcrumb || selected;
+            const isExpanded =
+              (isForceExpanded || isBreadcrumb || selected) &&
+              openSidebarPath === path;
             listItem = (
               <li key={`${title}-${path}-${level}-heading`}>
                 <SidebarLink
@@ -116,6 +124,7 @@ export function SidebarRouteTree({
                   isExpanded={isExpanded}
                   isBreadcrumb={isBreadcrumb}
                   hideArrow={isForceExpanded}
+                  handleClick={handleClick}
                 />
                 <CollapseWrapper duration={250} isExpanded={isExpanded}>
                   <SidebarRouteTree
@@ -138,6 +147,7 @@ export function SidebarRouteTree({
                   level={level}
                   title={title}
                   wip={wip}
+                  handleClick={handleClick}
                 />
               </li>
             );


### PR DESCRIPTION
This PR related to this issue [26601](https://github.com/facebook/react/issues/26601). 

Currently you can not close sidebar dropdown if it's open, you should click to another main sidebar menu to close the current open one. 

The dropdown menu should close when we click on the dropdown icon again.

With my fix, all sidebar menus can be closed. Thanks!
![image](https://user-images.githubusercontent.com/57806596/231160387-7cde222c-5f3f-423f-9473-c41054459c09.png)

**After checking documentation website, I realized that dropdown title used as a link as well so I added control to not close dropdown if active url is not dropdown's title url and added control for closing with icon click option**