### PR TITLE
Cancel double path check and remove unused props

### DIFF
--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -18,7 +18,6 @@ interface SidebarLinkProps {
   wip: boolean | undefined;
   icon?: React.ReactNode;
   isExpanded?: boolean;
-  isBreadcrumb?: boolean;
   hideArrow?: boolean;
   isPending: boolean;
 }
@@ -30,7 +29,6 @@ export function SidebarLink({
   wip,
   level,
   isExpanded,
-  isBreadcrumb,
   hideArrow,
   isPending,
 }: SidebarLinkProps) {

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -87,7 +87,7 @@ export function SidebarRouteTree({
         ) => {
           const selected = slug === path;
           let listItem = null;
-          if (!path || !path || heading) {
+          if (!path || heading) {
             // if current route item has no path and children treat it as an API sidebar heading
             listItem = (
               <SidebarRouteTree
@@ -114,7 +114,6 @@ export function SidebarRouteTree({
                   title={title}
                   wip={wip}
                   isExpanded={isExpanded}
-                  isBreadcrumb={isBreadcrumb}
                   hideArrow={isForceExpanded}
                 />
                 <CollapseWrapper duration={250} isExpanded={isExpanded}>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
In this PR I cancelled double path  check on SidebarRouteTree.tsx and remove unused props from SidebarLink.tsx
