### PR TITLE
Add types for variantMap

### DIFF
--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -5,7 +5,16 @@
 import cn from 'classnames';
 import type {RouteTag} from './Layout/getRouteMeta';
 
-const variantMap = {
+type Variant = {
+  name: string;
+  classes: string;
+};
+
+type VariantMap = {
+  [key: string]: Variant;
+};
+
+const variantMap: VariantMap = {
   foundation: {
     name: 'Foundation',
     classes: 'bg-yellow-50 text-white',


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
In Tag.tsx component variantMap has no types, I added Variant and VariantMap types to enhance type safety for variantMap.