### PR TITLE
Add <meta> tags for translations

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
   pageExtensions: ['jsx', 'js', 'ts', 'tsx', 'mdx', 'md'],
   reactStrictMode: true,
   experimental: {
+    plugins: true,
     scrollRestoration: true,
     legacyBrowsers: false,
     browsersListForSwc: true,

--- a/next.config.js
+++ b/next.config.js
@@ -16,8 +16,12 @@ const nextConfig = {
     browsersListForSwc: true,
   },
   redirects() {
+    const redirects = [];
     const languageCode = siteConfig.languageCode;
-    const subdomain = languageCode === 'en' ? '' : languageCode + '.';
+    const subdomain =
+      languageCode === 'en' || !siteConfig.hasLegacySite
+        ? ''
+        : languageCode + '.';
     return [
       {
         // Assume all *.html links are legacy site URLs.

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,8 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
+const siteConfig = require('./src/siteConfig').siteConfig;
+
 /**
  * @type {import('next').NextConfig}
  **/
@@ -9,10 +11,21 @@ const nextConfig = {
   pageExtensions: ['jsx', 'js', 'ts', 'tsx', 'mdx', 'md'],
   reactStrictMode: true,
   experimental: {
-    plugins: true,
     scrollRestoration: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
+  },
+  redirects() {
+    const languageCode = siteConfig.languageCode;
+    const subdomain = languageCode === 'en' ? '' : languageCode + '.';
+    return [
+      {
+        // Assume all *.html links are legacy site URLs.
+        source: '/:path*(\\.html)',
+        destination: `https://${subdomain}legacy.reactjs.org/:path*.html`,
+        permanent: false,
+      },
+    ];
   },
   env: {
     SANDPACK_BARE_COMPONENTS: process.env.SANDPACK_BARE_COMPONENTS,

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -22,7 +22,7 @@ const deployedTranslations = [
   // We'll add more languages when they have enough content.
 ];
 
-function getDomain(languageCode) {
+function getDomain(languageCode: string): string {
   const subdomain = languageCode === 'en' ? '' : languageCode + '.';
   return subdomain + 'react.dev';
 }

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -55,13 +55,13 @@ export const Seo = withRouter(
         <link
           rel="alternate"
           href={canonicalUrl.replace(siteDomain, getDomain('en'))}
-          hreflang="x-default"
+          hrefLang="x-default"
         />
         {deployedTranslations.map((languageCode) => (
           <link
             key={'alt-' + languageCode}
             rel="alternate"
-            hreflang={languageCode}
+            hrefLang={languageCode}
             href={canonicalUrl.replace(siteDomain, getDomain(languageCode))}
           />
         ))}

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -5,6 +5,7 @@
 import * as React from 'react';
 import Head from 'next/head';
 import {withRouter, Router} from 'next/router';
+import {siteConfig} from '../siteConfig';
 
 export interface SeoProps {
   title: string;
@@ -31,23 +32,19 @@ export const Seo = withRouter(
     const twitterTitle = pageTitle.replace(/[<>]/g, '');
     return (
       <Head>
-        {/* DEFAULT */}
-
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-
         {title != null && <title key="title">{pageTitle}</title>}
         {description != null && (
           <meta name="description" key="description" content={description} />
         )}
-        {/* <link rel="icon" type="image/x-icon" href={favicon} />
-      <link rel="apple-touch-icon" href={favicon} />  @todo favicon */}
         <meta property="fb:app_id" content="623268441017527" />
-        {/* OPEN GRAPH */}
         <meta property="og:type" key="og:type" content="website" />
         <meta
           property="og:url"
           key="og:url"
-          content={`https://react.dev${router.asPath.split(/[\?\#]/)[0]}`}
+          content={`https://${siteConfig.domain}${
+            router.asPath.split(/[\?\#]/)[0]
+          }`}
         />
         {title != null && (
           <meta property="og:title" content={pageTitle} key="og:title" />
@@ -59,14 +56,11 @@ export const Seo = withRouter(
             content={description}
           />
         )}
-
         <meta
           property="og:image"
           key="og:image"
-          content={`https://react.dev${image}`}
+          content={`https://${siteConfig.domain}${image}`}
         />
-
-        {/* TWITTER */}
         <meta
           name="twitter:card"
           key="twitter:card"
@@ -88,11 +82,10 @@ export const Seo = withRouter(
             content={description}
           />
         )}
-
         <meta
           name="twitter:image"
           key="twitter:image"
-          content={`https://react.dev${image}`}
+          content={`https://${siteConfig.domain}${image}`}
         />
         <meta
           name="google-site-verification"

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -17,6 +17,16 @@ export interface SeoProps {
   searchOrder?: number;
 }
 
+const deployedTranslations = [
+  'en',
+  // We'll add more languages when they have enough content.
+];
+
+function getDomain(languageCode) {
+  const subdomain = languageCode === 'en' ? '' : languageCode + '.';
+  return subdomain + 'react.dev';
+}
+
 export const Seo = withRouter(
   ({
     title,
@@ -27,6 +37,10 @@ export const Seo = withRouter(
     isHomePage,
     searchOrder,
   }: SeoProps & {router: Router}) => {
+    const siteDomain = getDomain(siteConfig.languageCode);
+    const canonicalUrl = `https://${siteDomain}${
+      router.asPath.split(/[\?\#]/)[0]
+    }`;
     const pageTitle = isHomePage ? 'React' : title + ' – React';
     // Twitter's meta parser is not very good.
     const twitterTitle = pageTitle.replace(/[<>]/g, '');
@@ -37,15 +51,23 @@ export const Seo = withRouter(
         {description != null && (
           <meta name="description" key="description" content={description} />
         )}
+        <link rel="canonical" href={canonicalUrl} />
+        <link
+          rel="alternate"
+          href={canonicalUrl.replace(siteDomain, getDomain('en'))}
+          hreflang="x-default"
+        />
+        {deployedTranslations.map((languageCode) => (
+          <link
+            key={'alt-' + languageCode}
+            rel="alternate"
+            hreflang={languageCode}
+            href={canonicalUrl.replace(siteDomain, getDomain(languageCode))}
+          />
+        ))}
         <meta property="fb:app_id" content="623268441017527" />
         <meta property="og:type" key="og:type" content="website" />
-        <meta
-          property="og:url"
-          key="og:url"
-          content={`https://${siteConfig.domain}${
-            router.asPath.split(/[\?\#]/)[0]
-          }`}
-        />
+        <meta property="og:url" key="og:url" content={canonicalUrl} />
         {title != null && (
           <meta property="og:title" content={pageTitle} key="og:title" />
         )}
@@ -59,7 +81,7 @@ export const Seo = withRouter(
         <meta
           property="og:image"
           key="og:image"
-          content={`https://${siteConfig.domain}${image}`}
+          content={`https://${siteDomain}${image}`}
         />
         <meta
           name="twitter:card"
@@ -85,7 +107,7 @@ export const Seo = withRouter(
         <meta
           name="twitter:image"
           key="twitter:image"
-          content={`https://${siteConfig.domain}${image}`}
+          content={`https://${siteDomain}${image}`}
         />
         <meta
           name="google-site-verification"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,11 +3,11 @@
  */
 
 import {Html, Head, Main, NextScript} from 'next/document';
+import {siteConfig} from '../siteConfig';
 
 const MyDocument = () => {
-  //  @todo specify language in HTML?
   return (
-    <Html lang="en">
+    <Html lang={siteConfig.languageCode}>
       <Head />
       <body className="font-text font-medium antialiased text-lg bg-wash dark:bg-wash-dark text-secondary dark:text-secondary-dark leading-base">
         <script

--- a/src/siteConfig.js
+++ b/src/siteConfig.js
@@ -4,8 +4,9 @@
 
 exports.siteConfig = {
   // --------------------------------------
-  // Translations should replace this line:
+  // Translations should replace these lines:
   languageCode: 'en',
+  hasLegacySite: true,
   // --------------------------------------
   copyright: `Copyright © ${new Date().getFullYear()} Facebook Inc. All Rights Reserved.`,
   repoUrl: 'https://github.com/facebook/react',

--- a/src/siteConfig.js
+++ b/src/siteConfig.js
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-export const siteConfig = {
+exports.siteConfig = {
   // --------------------------------------
   // Translations should replace this line:
   languageCode: 'en',

--- a/src/siteConfig.ts
+++ b/src/siteConfig.ts
@@ -3,10 +3,10 @@
  */
 
 export const siteConfig = {
-  // Translations should replace these lines:
-  domain: 'react.dev',
-  editUrl: 'https://github.com/reactjs/react.dev/tree/main/src/content',
-  // -----------------------------------------------------------------
+  // --------------------------------------
+  // Translations should replace this line:
+  languageCode: 'en',
+  // --------------------------------------
   copyright: `Copyright © ${new Date().getFullYear()} Facebook Inc. All Rights Reserved.`,
   repoUrl: 'https://github.com/facebook/react',
   twitterUrl: 'https://twitter.com/reactjs',

--- a/src/siteConfig.ts
+++ b/src/siteConfig.ts
@@ -3,7 +3,10 @@
  */
 
 export const siteConfig = {
-  editUrl: 'https://github.com/reactjs/react.dev/tree/main/src/pages',
+  // Translations should replace these lines:
+  domain: 'react.dev',
+  editUrl: 'https://github.com/reactjs/react.dev/tree/main/src/content',
+  // -----------------------------------------------------------------
   copyright: `Copyright © ${new Date().getFullYear()} Facebook Inc. All Rights Reserved.`,
   repoUrl: 'https://github.com/facebook/react',
   twitterUrl: 'https://twitter.com/reactjs',

--- a/vercel.json
+++ b/vercel.json
@@ -85,11 +85,6 @@
       "permanent": false
     },
     {
-      "source": "/:path*(\\.html)",
-      "destination": "https://legacy.reactjs.org/:path*.html",
-      "permanent": false
-    },
-    {
       "source": "/tips/controlled-input-null-value.html",
       "destination": "/reference/react-dom/components/input#im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled",
       "permanent": false


### PR DESCRIPTION
- Add language code to the site config for translations to override
- Set `<html lang>` based on that code
- Add `<link ref="canonical">` for the current page
- Add `<link rel="alternate" hrefLang="x-default">` pointing to the English version
- Add `<link rel="alternate" hrefLang="...">` for each language (currently, only English)
- Move `react.dev/docs/some-old.url.html -> legacy.reactjs.org/docs/some-old.url.html` redirect from Vercel config to Next.js config. This lets us send it to the current translation's legacy site instead of the English legacy site.