### PR TITLE
Update sharing-state-between-components.md

### DIFF
--- a/src/content/learn/sharing-state-between-components.md
+++ b/src/content/learn/sharing-state-between-components.md
@@ -153,7 +153,8 @@ function Panel({ title, children, isActive }) {
       {isActive ? (
         <p>{children}</p>
       ) : (
-        <button onClick={() => setIsActive(true)}>
+        <button>
+          // TODO: onClick method, see Step 3
           Show
         </button>
       )}


### PR DESCRIPTION
In the example of lifting state up: Step 1 deletes `isActive` and `setIsActive`. If a user e.g. changes the hardcoded code to e.g. `isActive={false}` for one of the panels, the `Show` button will be displayed, which causes an error in the old version, as `setIsActive` is not defined. So i removed the code and added a comment to step3

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
