### PR TITLE
chore: "hello, world!" consistency

### DIFF
--- a/src/content/learn/add-react-to-an-existing-project.md
+++ b/src/content/learn/add-react-to-an-existing-project.md
@@ -75,7 +75,7 @@ document.body.innerHTML = '<div id="app"></div>';
 
 // Render your React component instead
 const root = createRoot(document.getElementById('app'));
-root.render(<h1>Hello, world</h1>);
+root.render(<h1>Hello, world!</h1>);
 ```
 
 </Sandpack>
@@ -100,7 +100,7 @@ document.body.innerHTML = '<div id="app"></div>';
 
 // Render your React component instead
 const root = createRoot(document.getElementById('app'));
-root.render(<h1>Hello, world</h1>);
+root.render(<h1>Hello, world!</h1>);
 ```
 
 Of course, you don't actually want to clear the existing HTML content!


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

This (very) minor change is due to the fact that on the following line we say that the user should see `"Hello, world!"`, when in fact - based on the code examples - they would see `"Hello, world"`.

https://github.com/reactjs/react.dev/blob/8ed23b1a06ed0d836151622c1455c74bf2d0ce25/src/content/learn/add-react-to-an-existing-project.md?plain=1#L83

I searched for other mentions of _Hello, world!_ and it appears the majority include the `!`, so I've chose to update the code blocks to match (as opposed to updating the "If the entire content..." string).

> I noticed this while doing the Spanish translations for this page https://github.com/reactjs/es.react.dev/pull/665
