### PR TITLE
Fix type of routeTransitionTimer (any -> number)

### DIFF
--- a/src/hooks/usePendingRoute.ts
+++ b/src/hooks/usePendingRoute.ts
@@ -10,11 +10,11 @@ const usePendingRoute = () => {
   const [pendingRoute, setPendingRoute] = useState<string | null>(null);
   const currentRoute = useRef<string | null>(null);
   useEffect(() => {
-    let routeTransitionTimer: any = null;
+    let routeTransitionTimer: number;
 
     const handleRouteChangeStart = (url: string) => {
       clearTimeout(routeTransitionTimer);
-      routeTransitionTimer = setTimeout(() => {
+      routeTransitionTimer = window.setTimeout(() => {
         if (currentRoute.current !== url) {
           currentRoute.current = url;
           setPendingRoute(url);


### PR DESCRIPTION

`useEffect's callback function` of `usePendingRoute hook` will be executed in browser. So setTimeout will return timerId, type number. `clearTimeout` can rarely receive an undefined, but it ignores.