### PR TITLE
fix Illustration and IllustrationBlock alt color on dark mode

### DIFF
--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -239,7 +239,7 @@ function Illustration({
           src={src}
           alt={alt}
           style={{maxHeight: 300}}
-          className="bg-white rounded-lg"
+          className="rounded-lg"
         />
         {caption ? (
           <figcaption className="text-center leading-tight mt-4">
@@ -271,7 +271,12 @@ function IllustrationBlock({
   const images = imageInfos.map((info, index) => (
     <figure key={index}>
       <div className="bg-white rounded-lg p-4 flex-1 flex xl:p-6 justify-center items-center my-4">
-        <img src={info.src} alt={info.alt} height={info.height} />
+        <img
+          className="text-primary"
+          src={info.src}
+          alt={info.alt}
+          height={info.height}
+        />
       </div>
       {info.caption ? (
         <figcaption className="text-secondary dark:text-secondary-dark text-center leading-tight mt-4">


### PR DESCRIPTION
### Motivation

When dark mode is turned on, the alt text rendered by the Illustration and IllustrationBlock components is not visible.
On dark mode, the text color inherited is `text-primary-dark`, which is not visible on the white background.

### Change

Applying a fixed `text-primary` ensures that the text is always visible regardless of the current theme.

### Demonstration

Source of the images have been removed for the sake of testing.

**Current behaviour:**

<img width="928" alt="Screenshot 2023-04-30 at 17 29 58" src="https://user-images.githubusercontent.com/6226131/235361905-1681b0ce-bcab-4e3a-b8ff-c42f86e7f2df.png">
<img width="928" alt="Screenshot 2023-04-30 at 17 32 03" src="https://user-images.githubusercontent.com/6226131/235361932-462c7ed1-cbc5-4566-9dde-0babd930b12f.png">

**Fixed behaviour:**

<img width="928" alt="Screenshot 2023-04-30 at 17 30 02" src="https://user-images.githubusercontent.com/6226131/235361908-0406f4fc-90ac-4919-8fd6-8e68160eb4be.png">
<img width="928" alt="Screenshot 2023-04-30 at 17 32 06" src="https://user-images.githubusercontent.com/6226131/235361945-62241f8c-21c6-4807-a0c2-7fbac84b285e.png">
