### PR TITLE
fix(adding-interactivity): fixed Render and Commit link label

### DIFF
--- a/src/content/learn/adding-interactivity.md
+++ b/src/content/learn/adding-interactivity.md
@@ -12,7 +12,7 @@ Some things on the screen update in response to user input. For example, clickin
 
 * [How to handle user-initiated events](/learn/responding-to-events)
 * [How to make components "remember" information with state](/learn/state-a-components-memory)
-* [How React updates the UI in two phases](/learn/render-and-commit)
+* [How React updates the UI in three phases](/learn/render-and-commit)
 * [Why state doesn't update right after you change it](/learn/state-as-a-snapshot)
 * [How to queue multiple state updates](/learn/queueing-a-series-of-state-updates)
 * [How to update an object in state](/learn/updating-objects-in-state)


### PR DESCRIPTION
Fixes the label of the link that navigates to `Render and Commit`.

The label says that React updates the UI in **two** phases, however the page it links to affirms multiple times that the phases are **three** (Trigger, Render, Commit).