### PR TITLE
fix: eslint warning on loading emoji

### DIFF
--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -110,7 +110,14 @@ export default function ArtistPage({ artist }) {
 }
 
 function Loading() {
-  return <h2>🌀 Loading...</h2>;
+  return (
+    <h2>
+      <span role="img" aria-label="loading-icon">
+        🌀
+      </span>
+      Loading...
+    </h2>
+  );
 }
 ```
 
@@ -345,7 +352,14 @@ export default function ArtistPage({ artist }) {
 }
 
 function Loading() {
-  return <h2>🌀 Loading...</h2>;
+  return (
+    <h2>
+      <span role="img" aria-label="loading-icon">
+        🌀
+      </span>
+      Loading...
+    </h2>
+  );
 }
 ```
 
@@ -672,7 +686,14 @@ export default function ArtistPage({ artist }) {
 }
 
 function BigSpinner() {
-  return <h2>🌀 Loading...</h2>;
+  return (
+    <h2>
+      <span role="img" aria-label="loading-icon">
+        🌀
+      </span>
+      Loading...
+    </h2>
+  );
 }
 
 function AlbumsGlimmer() {
@@ -1418,7 +1439,14 @@ function Router() {
 }
 
 function BigSpinner() {
-  return <h2>🌀 Loading...</h2>;
+  return (
+    <h2>
+      <span role="img" aria-label="loading-icon">
+        🌀
+      </span>
+      Loading...
+    </h2>
+  );
 }
 ```
 
@@ -1805,7 +1833,14 @@ function Router() {
 }
 
 function BigSpinner() {
-  return <h2>🌀 Loading...</h2>;
+  return (
+    <h2>
+      <span role="img" aria-label="loading-icon">
+        🌀
+      </span>
+      Loading...
+    </h2>
+  );
 }
 ```
 
@@ -2189,7 +2224,14 @@ function Router() {
 }
 
 function BigSpinner() {
-  return <h2>🌀 Loading...</h2>;
+  return (
+    <h2>
+      <span role="img" aria-label="loading-icon">
+        🌀
+      </span>
+      Loading...
+    </h2>
+  );
 }
 ```
 


### PR DESCRIPTION
## Issue Description
When I enter this page and read the example, I will see an eslint warning in the codeSandBox.
https://react.dev/reference/react/Suspense#displaying-a-fallback-while-content-is-loading

<img width="727" alt="螢幕擷取畫面 2023-05-02 103507" src="https://user-images.githubusercontent.com/31992650/235572434-a4f02125-eb70-4b15-8f78-9fbbc78b0bcd.png">

## Fix the issue
I adjust the example code to prevent the warning message showing.

<img width="817" alt="螢幕擷取畫面 2023-05-02 105114" src="https://user-images.githubusercontent.com/31992650/235572676-4aa4cb75-3897-464b-823d-6cf421198aad.png">
