### PR TITLE
Added reference to create-react-app in components docs ([#5985](https://github.com/reactjs/react.dev/issues/5985))

### DIFF
--- a/src/content/learn/importing-and-exporting-components.md
+++ b/src/content/learn/importing-and-exporting-components.md
@@ -8,6 +8,12 @@ The magic of components lies in their reusability: you can create components tha
 
 </Intro>
 
+<Note>
+
+**Before getting started with components, be sure to follow [Start a New React Project](./start-a-new-react-project.md) to create your first React app.**
+
+</Note>
+
 <YouWillLearn>
 
 * What a root component file is

--- a/src/content/learn/your-first-component.md
+++ b/src/content/learn/your-first-component.md
@@ -8,6 +8,12 @@ title: Your First Component
 
 </Intro>
 
+<Note>
+
+**Before getting started with components, be sure to follow [Start a New React Project](./start-a-new-react-project.md) to create your first React app.**
+
+</Note>
+
 <YouWillLearn>
 
 * What a component is


### PR DESCRIPTION
Added note in [Your First Component](https://react.dev/learn/your-first-component) and [Importing and Exporting Components](https://react.dev/learn/importing-and-exporting-components) that links to [Start a New React Project](https://react.dev/learn/start-a-new-react-project) to help new users navigate the documentation. The note allows them to see how to create a new react app before starting with components, avoiding confusion.

Adds: [#5985](https://github.com/reactjs/react.dev/issues/5985)
