### PR TITLE
Fix grammatical error: change 'are' to 'is'

### DIFF
--- a/src/content/learn/updating-arrays-in-state.md
+++ b/src/content/learn/updating-arrays-in-state.md
@@ -567,7 +567,7 @@ setMyList(myList.map(artwork => {
 
 Here, `...` is the object spread syntax used to [create a copy of an object.](/learn/updating-objects-in-state#copying-objects-with-the-spread-syntax)
 
-With this approach, none of the existing state items are being mutated, and the bug is fixed:
+With this approach, none of the existing state items is being mutated, and the bug is fixed:
 
 <Sandpack>
 


### PR DESCRIPTION
The sentence reads:

With this approach, none of the existing state items are being mutated, and the bug is fixed:

It should read:

With this approach, none of the existing state items is being mutated, and the bug is fixed:

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
