### PR TITLE
deleted pitfall component for NextJS app router beta warning

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -92,11 +92,7 @@ These features are getting closer to being production-ready every day, and we've
 **[Next.js's App Router](https://beta.nextjs.org/docs/getting-started) is a redesign of the Next.js APIs aiming to fulfill the React team’s full-stack architecture vision.** It lets you fetch data in asynchronous components that run on the server or even during the build.
 
 Next.js is maintained by [Vercel](https://vercel.com/). You can [deploy a Next.js app](https://nextjs.org/docs/deployment) to any Node.js or serverless hosting, or to your own server. Next.js also supports [static export](https://beta.nextjs.org/docs/configuring/static-export) which doesn't require a server.
-<Pitfall>
 
-Next.js's App Router is **currently in beta and is not yet recommended for production** (as of Mar 2023). To experiment with it in an existing Next.js project, [follow this incremental migration guide](https://beta.nextjs.org/docs/upgrade-guide#migrating-from-pages-to-app).
-
-</Pitfall>
 
 <DeepDive>
 


### PR DESCRIPTION
Issue #6006 

App router is now stable in NextJS 13.4 

So, The pitfall component for the NextJS app router still in beta from the file "start-a-new-react-project.md" is removed.

I think the pitfall component is only used there. But I didn't deleted the pitfall component and it's icon component files from the codebase. Let me know if these components can be deleted.