### PR TITLE
Add accessibility note to interactivity section in the new React docs

### DIFF
--- a/src/content/learn/adding-interactivity.md
+++ b/src/content/learn/adding-interactivity.md
@@ -26,12 +26,6 @@ React lets you add *event handlers* to your JSX. Event handlers are your own fun
 
 Built-in components like `<button>` only support built-in browser events like `onClick`. However, you can also create your own components, and give their event handler props any application-specific names that you like.
 
-<Note>
-
-When you create your own components, make sure to use the built in `<button>` html tag and html attributes for `onClick` handlers instead of `<div>`.  This makes it more accessible for assistive technology users to understand and use the elements in the intended way. Learn more why this matters [here](https://www.w3.org/WAI/ARIA/apg/about/aria-basics/#whatareaccessibilitysemantics?).
-
-</Note>
-
 <Sandpack>
 
 ```js

--- a/src/content/learn/adding-interactivity.md
+++ b/src/content/learn/adding-interactivity.md
@@ -26,6 +26,12 @@ React lets you add *event handlers* to your JSX. Event handlers are your own fun
 
 Built-in components like `<button>` only support built-in browser events like `onClick`. However, you can also create your own components, and give their event handler props any application-specific names that you like.
 
+<Note>
+
+When you create your own components, make sure to use the built in `<button>` html tag and html attributes for `onClick` handlers instead of `<div>`.  This makes it more accessible for assistive technology users to understand and use the elements in the intended way. Learn more why this matters [here](https://www.w3.org/WAI/ARIA/apg/about/aria-basics/#whatareaccessibilitysemantics?).
+
+</Note>
+
 <Sandpack>
 
 ```js

--- a/src/content/learn/responding-to-events.md
+++ b/src/content/learn/responding-to-events.md
@@ -233,6 +233,12 @@ If you use a [design system](https://uxdesign.cc/everything-you-need-to-know-abo
 
 Built-in components like `<button>` and `<div>` only support [browser event names](/reference/react-dom/components/common#common-props) like `onClick`. However, when you're building your own components, you can name their event handler props any way that you like.
 
+<Note>
+
+When you create your own components, make sure to use the built-in `<button>` html tag and html attributes for `onClick` handlers instead of `<div>`.  This makes it more accessible for assistive technology users to understand and use the elements in the intended way. Learn more why this matters [here](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML).
+
+</Note>
+
 By convention, event handler props should start with `on`, followed by a capital letter.
 
 For example, the `Button` component's `onClick` prop could have been called `onSmash`:

--- a/src/content/learn/responding-to-events.md
+++ b/src/content/learn/responding-to-events.md
@@ -233,12 +233,6 @@ If you use a [design system](https://uxdesign.cc/everything-you-need-to-know-abo
 
 Built-in components like `<button>` and `<div>` only support [browser event names](/reference/react-dom/components/common#common-props) like `onClick`. However, when you're building your own components, you can name their event handler props any way that you like.
 
-<Note>
-
-When you create your own components, make sure to use the built-in `<button>` html tag and html attributes for `onClick` handlers instead of `<div>`.  This makes it more accessible for assistive technology users to understand and use the elements in the intended way. Learn more why this matters [here](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML).
-
-</Note>
-
 By convention, event handler props should start with `on`, followed by a capital letter.
 
 For example, the `Button` component's `onClick` prop could have been called `onSmash`:
@@ -319,6 +313,12 @@ button { margin-right: 10px; }
 </Sandpack>
 
 Notice how the `App` component does not need to know *what* `Toolbar` will do with `onPlayMovie` or `onUploadImage`. That's an implementation detail of the `Toolbar`. Here, `Toolbar` passes them down as `onClick` handlers to its `Button`s, but it could later also trigger them on a keyboard shortcut. Naming props after app-specific interactions like `onPlayMovie` gives you the flexibility to change how they're used later.
+  
+<Note>
+
+Make sure that you use the appropriate HTML tags for your event handlers. For example, to handle clicks, use [`<button onClick={handleClick}>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) instead of `<div onClick={handleClick}>`. Using a real browser `<button>` enables built-in browser behaviors like keyboard navigation. If you don't like the default browser styling of a button and want to make it look more like a link or a different UI element, you can achieve it with CSS. [Learn more about writing accessible markup.](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML)
+  
+</Note>
 
 ## Event propagation {/*event-propagation*/}
 


### PR DESCRIPTION
We want to add accessibility into the new React Docs. This PR adds a note in the interactivity section letting users know to use the html tag `<button>` instead of `<div>` when using onClick handlers.

<img width="1410" alt="Screenshot 2023-05-12 at 1 17 42 PM" src="https://github.com/reactjs/react.dev/assets/20743223/27c91488-f591-4ef3-8071-4735a90ed16a">

