### PR TITLE
Remove extra "on"

### DIFF
--- a/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/src/content/learn/lifecycle-of-reactive-effects.md
@@ -387,7 +387,7 @@ function ChatRoom({ roomId }) { // Props change over time
     return () => {
       connection.disconnect();
     };
-  }, [roomId, serverUrl]); // So you tell React that this Effect "depends on" on props and state
+  }, [roomId, serverUrl]); // So you tell React that this Effect "depends on" props and state
   // ...
 }
 ```


### PR DESCRIPTION
A comment reads: 

So you tell React that this Effect "depends on" on props and state

It should read: 

So you tell React that this Effect "depends on" props and state

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
