### PR TITLE
Fix breadcrumbs accesibility

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -2,25 +2,27 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {Fragment} from 'react';
-import Link from 'next/link';
 import type {RouteItem} from 'components/Layout/getRouteMeta';
+import Link from 'next/link';
+import {Fragment} from 'react';
 
 function Breadcrumbs({breadcrumbs}: {breadcrumbs: RouteItem[]}) {
   return (
-    <div className="flex flex-wrap">
+    <ol className="flex flex-wrap">
       {breadcrumbs.map(
         (crumb, i) =>
           crumb.path &&
           !crumb.skipBreadcrumb && (
-            <div className="flex mb-3 mt-0.5 items-center" key={i}>
+            <li className="flex mb-3 mt-0.5 items-center" key={i}>
               <Fragment key={crumb.path}>
                 <Link href={crumb.path}>
                   <a className="text-link dark:text-link-dark text-sm tracking-wide font-bold uppercase mr-1 hover:underline">
                     {crumb.title}
                   </a>
                 </Link>
-                <span className="inline-block mr-1 text-link dark:text-link-dark text-lg">
+                <span
+                  className="inline-block mr-1 text-link dark:text-link-dark text-lg"
+                  aria-hidden>
                   <svg
                     width="20"
                     height="20"
@@ -34,10 +36,10 @@ function Breadcrumbs({breadcrumbs}: {breadcrumbs: RouteItem[]}) {
                   </svg>
                 </span>
               </Fragment>
-            </div>
+            </li>
           )
       )}
-    </div>
+    </ol>
   );
 }
 

--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -25,7 +25,11 @@ function PageHeading({
   return (
     <div className="px-5 sm:px-12 pt-3.5">
       <div className="max-w-4xl ml-0 2xl:mx-auto">
-        {breadcrumbs ? <Breadcrumbs breadcrumbs={breadcrumbs} /> : null}
+        {breadcrumbs ? (
+          <nav aria-label="Breadcrumb">
+            <Breadcrumbs breadcrumbs={breadcrumbs} />
+          </nav>
+        ) : null}
         <H1 className="mt-0 text-primary dark:text-primary-dark -mx-.5 break-words">
           {title}
           {status ? <em>—{status}</em> : ''}


### PR DESCRIPTION
The current markup doesn't follow W3C Standards.  I've updated the Breadcrumbs with the correct semantic tags,
and aria attributes to ensure proper accesibility. This follows closely [W3C APG](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/) recommendations, however,
Since the rendered breadcrumbs do not contain the current active page I've omitted the `aria-current="page"` attribute.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
