### PR TITLE
Fix wrong explanation in preserving-and-resetting-state

### DIFF
--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -688,7 +688,7 @@ label {
 
 </Sandpack>
 
-The counter state gets reset when you click the checkbox. Although you render a `Counter`, the first child of the `div` changes from a `div` to a `section`. When the child `div` was removed from the DOM, the whole tree below it (including the `Counter` and its state) was destroyed as well.
+The counter state gets reset when you click the checkbox. Although you render a `Counter`, the first child of the `div` changes from a `section` to a `div`. When the child `section` was removed from the DOM, the whole tree below it (including the `Counter` and its state) was destroyed as well.
 
 <DiagramGroup>
 


### PR DESCRIPTION
In "Preserving and Resetting State", I found that a part of the description did not correctly reflect the corresponding example code and diagrams. The correct behavior (as seen in the code and the diagrams) is as follows:

| phase | `isFancy` state | container |
| - | :-: | :-: |
| initial state | `false` | `section` |
| after checking the checkbox | `true` | `div` |