### PR TITLE
Fix a wrong explanation in "Manipulating the DOM with Refs"

### DIFF
--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -31,7 +31,7 @@ Then, use it to declare a ref inside your component:
 const myRef = useRef(null);
 ```
 
-Finally, pass it to a JSX element as the `ref` attribute:
+Finally, pass your ref as the `ref` attribute to the JSX tag for which you want to get the DOM node:
 
 ```js
 <div ref={myRef}>

--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -31,7 +31,7 @@ Then, use it to declare a ref inside your component:
 const myRef = useRef(null);
 ```
 
-Finally, pass it to the DOM node as the `ref` attribute:
+Finally, pass it to a JSX element as the `ref` attribute:
 
 ```js
 <div ref={myRef}>


### PR DESCRIPTION
If I understand correctly, you never pass a ref to a real DOM node itself. It doesn't make sense to say "pass the ref **to the DOM node**" when you are explaining **how to get a DOM node** using a ref.