### PR TITLE
docs: list Vite as viable option for new projects

### DIFF
--- a/src/content/learn/add-react-to-an-existing-project.md
+++ b/src/content/learn/add-react-to-an-existing-project.md
@@ -24,7 +24,7 @@ Here's how we recommend to set it up:
 2. **Specify `/some-app` as the *base path*** in your framework's configuration (here's how: [Next.js](https://nextjs.org/docs/api-reference/next.config.js/basepath), [Gatsby](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)).
 3. **Configure your server or a proxy** so that all requests under `/some-app/` are handled by your React app.
 
-This ensures the React part of your app can [benefit from the best practices](/learn/start-a-new-react-project#can-i-use-react-without-a-framework) baked into those frameworks.
+This ensures the React part of your app can [benefit from the best practices](/learn/start-a-new-react-project#should-i-use-react-with-a-framework) baked into those frameworks.
 
 Many React-based frameworks are full-stack and let your React app take advantage of the server. However, you can use the same approach even if you can't or don't want to run JavaScript on the server. In that case, serve the HTML/CSS/JS export ([`next export` output](https://nextjs.org/docs/advanced-features/static-html-export) for Next.js, default for Gatsby) at `/some-app/` instead.
 

--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -4,7 +4,7 @@ title: Start a New React Project
 
 <Intro>
 
-If you want to build a new app or a new website fully with React, we recommend picking one of the React-powered frameworks popular in the community. Frameworks provide features that most apps and sites eventually need, including routing, data fetching, and generating HTML.
+For beginners, quickstart using Vite. If you're comfortable with basics and want to build a new app or a new website fully with React, we recommend picking one of the React-powered frameworks popular in the community. Frameworks provide features that most apps and sites eventually need, including routing, data fetching, and generating HTML.
 
 </Intro>
 
@@ -13,6 +13,16 @@ If you want to build a new app or a new website fully with React, we recommend p
 **You need to install [Node.js](https://nodejs.org/en/) for local development.** You can *also* choose to use Node.js in production, but you don't have to. Many React frameworks support export to a static HTML/CSS/JS folder.
 
 </Note>
+
+## Quickstart React Development with Vite {/*quickstart-react-development-with-vite*/}
+
+**[Vite](https://vitejs.dev/) is a modern build tool that simplifies learning React development.** While other frameworks offer many powerful features, Vite's simplicity makes it a great choice for React beginners. Vite is fast, supports [TypeScript](https://vitejs.dev/guide/features.html#typescript) out of the box, and includes the [Hot Module Replacement (HMR)](https://vitejs.dev/guide/features.html#hot-module-replacement) feature to quickly test code modifications. To create a new Vite project, run in your terminal:
+
+<TerminalBlock>
+npx create-vite
+</TerminalBlock>
+
+Vite is best for small to medium-sized [single page applications (SPA)](https://developer.mozilla.org/en-US/docs/Glossary/SPA). For larger projects, consider using a framework.
 
 ## Production-grade React frameworks {/*production-grade-react-frameworks*/}
 

--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -76,7 +76,7 @@ Expo is maintained by [Expo (the company)](https://expo.dev/about). Building app
 
 <DeepDive>
 
-#### Can I use React without a framework? {/*can-i-use-react-without-a-framework*/}
+#### Should I use React with a framework? {/*should-i-use-react-with-a-framework*/}
 
 You can definitely use React without a framework--that's how you'd [use React for a part of your page.](/learn/add-react-to-an-existing-project#using-react-for-a-part-of-your-existing-page) **However, if you're building a new app or a site fully with React, we recommend using a framework.**
 


### PR DESCRIPTION
## Summary

![image](https://github.com/reactjs/react.dev/assets/54838975/0e9abd6f-3017-4cf0-8f3b-c6ce43ab58ae)

- resolves #5797

## Changes

### Added Vite in `Intro`

### Added `Quickstart React Development with Vite` section at the top of page

### Renamed `Can I use React without a framework?` to `Should I use React with a framework?`

- reflected as Vite is now listed as a viable and default option for starting react project.
- changed link `add-react-to-an-existing-project.md` to account for the change in link.
