### PR TITLE
Fix: page jump while scrolling

### DIFF
--- a/src/styles/sandpack.css
+++ b/src/styles/sandpack.css
@@ -474,7 +474,7 @@ html.dark .sandpack--playground .sp-overlay {
 
 .sandpack .sp-layout > .sp-stack:nth-child(1) {
   /* Force vertical if there isn't enough space. */
-  min-width: 431px;
+  min-width: 389px;
   /* No min height on mobile because we know code in advance. */
   /* Max height is needed to avoid too long files. */
   max-height: 40vh;
@@ -482,7 +482,7 @@ html.dark .sandpack--playground .sp-overlay {
 
 .sandpack .sp-layout > .sp-stack:nth-child(2) {
   /* Force vertical if there isn't enough space. */
-  min-width: 431px;
+  min-width: 389px;
   /* Keep preview a fixed size on mobile to avoid jumps. */
   /* This is because we don't know its content in advance. */
   min-height: 40vh;


### PR DESCRIPTION
Closes #5995

**Why was the size changing?**
Due to the vertical alignment of the code editor and the output on the desktop at a certain screen width, the height of the sandpack is determined by the output iframe

**Solution**
By reducing the min-width values of both the editor and the iframe to accommodate desktop widths, they can now be arranged horizontally when viewed on a desktop screen.