### PR TITLE
Fix: wording on Quick Start page to make more sense

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -4,7 +4,7 @@ title: Quick Start
 
 <Intro>
 
-Welcome to the React documentation! This page will give you an introduction to the 80% of React concepts that you will use on a daily basis.
+Welcome to the React documentation! This page will give you an introduction to 80% of the React concepts that you will use on a daily basis.
 
 </Intro>
 


### PR DESCRIPTION
- Changed wording on the "Quick Start" page from "Welcome to the React documentation! This page will give you an introduction to the 80% of React concepts that you will use on a daily basis." to "Welcome to the React documentation! This page will give you an introduction to 80% of the React concepts that you will use on a daily basis.". See screen shots below:

Before: 
![Screenshot from 2023-05-24 15-03-27](https://github.com/reactjs/react.dev/assets/60356596/407f61e1-d5d8-4b5f-a10a-e339c5f6acbe)

After:
![Screenshot from 2023-05-24 15-04-30](https://github.com/reactjs/react.dev/assets/60356596/c5b431bf-03fe-4b68-9be8-8fd0fb5aabde)

