### PR TITLE
Fix an incorrect person's name

### DIFF
--- a/src/content/learn/rendering-lists.md
+++ b/src/content/learn/rendering-lists.md
@@ -1086,7 +1086,7 @@ Here, `<Recipe {...recipe} key={recipe.id} />` is a syntax shortcut saying "pass
 
 #### List with a separator {/*list-with-a-separator*/}
 
-This example renders a famous haiku by Katsushika Hokusai, with each line wrapped in a `<p>` tag. Your job is to insert an `<hr />` separator between each paragraph. Your resulting structure should look like this:
+This example renders a famous haiku by Tachibana Hokushi, with each line wrapped in a `<p>` tag. Your job is to insert an `<hr />` separator between each paragraph. Your resulting structure should look like this:
 
 ```js
 <article>


### PR DESCRIPTION
- Changed the name of the people mentioned in the tutorial, because the haiku
> I write, erase, rewrite
> Erase again, and then
> A poppy blooms.

mentioned in tutorial is by Tachibana Hokushi, not Katsushika Hokusai.

Before:
<img width="830" alt="スクリーンショット 2023-05-25 12 54 38" src="https://github.com/reactjs/react.dev/assets/119467077/ec9c82a4-f464-4759-9b29-3e75f71057c7">

After:
<img width="839" alt="スクリーンショット 2023-05-25 12 54 51" src="https://github.com/reactjs/react.dev/assets/119467077/f754388f-6337-4df6-8118-96d7baf8ea78">

## Evidence
The haiku before being translated is
"書いて見たりけしたり果はけしの花".
You can find this haiku on [the Wikipedia page for Hakushi Tachibana (Japanese)](https://ja.wikipedia.org/wiki/%E7%AB%8B%E8%8A%B1%E5%8C%97%E6%9E%9D#%E9%80%B8%E8%A9%B1).
