### PR TITLE
Fix a wrong explanation in "hydrateRoot"

### DIFF
--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -107,7 +107,7 @@ Calling `root.unmount` will unmount all the components in the root and "detach" 
 
 #### Returns {/*root-unmount-returns*/}
 
-`render` returns `null`.
+`root.unmount` returns `undefined`.
 
 #### Caveats {/*root-unmount-caveats*/}
 


### PR DESCRIPTION
In the section for the returns of `root.unmount`, it is written that `render` returns `null`. 

It should be `root.unmount` returns `undefined`.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
