### PR TITLE
fix: match `Hello, world!`

### DIFF
--- a/src/content/learn/add-react-to-an-existing-project.md
+++ b/src/content/learn/add-react-to-an-existing-project.md
@@ -75,7 +75,7 @@ document.body.innerHTML = '<div id="app"></div>';
 
 // Render your React component instead
 const root = createRoot(document.getElementById('app'));
-root.render(<h1>Hello, world</h1>);
+root.render(<h1>Hello, world!</h1>);
 ```
 
 </Sandpack>
@@ -100,7 +100,7 @@ document.body.innerHTML = '<div id="app"></div>';
 
 // Render your React component instead
 const root = createRoot(document.getElementById('app'));
-root.render(<h1>Hello, world</h1>);
+root.render(<h1>Hello, world!</h1>);
 ```
 
 Of course, you don't actually want to clear the existing HTML content!


### PR DESCRIPTION
String `Hello, world!` is used everywhere else beside this page.
Even in the `If the entire content of your page was replaced by a "Hello, world!", everything worked! Keep reading.` few lines below.