### PR TITLE
Fix hover background color in StrictMode examples

### DIFF
--- a/src/content/reference/react/StrictMode.md
+++ b/src/content/reference/react/StrictMode.md
@@ -196,6 +196,7 @@ ul {
   margin: 0;
   list-style-type: none;
   height: 100%;
+  overflow: auto;
 }
 
 li {
@@ -283,6 +284,7 @@ ul {
   margin: 0;
   list-style-type: none;
   height: 100%;
+  overflow: auto;
 }
 
 li {
@@ -377,6 +379,7 @@ ul {
   margin: 0;
   list-style-type: none;
   height: 100%;
+  overflow: auto;
 }
 
 li {
@@ -467,6 +470,7 @@ ul {
   margin: 0;
   list-style-type: none;
   height: 100%;
+  overflow: auto;
 }
 
 li {


### PR DESCRIPTION
The StoryTray examples in StrictMode.md intend to change the background color on hover.

But it is not working. The reason is that `<li>` elements are styled with `float: left` CSS property, which makes the height of the parent `<ul>` element zero and thus makes the background color invisible.

This PR fixes the problem by adding `overflow: auto` CSS property to the `<ul>` element to clear floats, which is well supported by modern browsers.

| Before fix     | After fix      |
| -------------- | -------------- |
| <video src="https://github.com/reactjs/react.dev/assets/38355699/3a5e8785-ff2e-4de9-9728-bc3739619ce0"> | <video src="https://github.com/reactjs/react.dev/assets/38355699/153dacaf-86e2-4e63-9b5e-5f7a71329b14"> |

