### PR TITLE
Small inconsistency in updating-arrays-in-state.md fixed

### DIFF
--- a/src/content/learn/updating-arrays-in-state.md
+++ b/src/content/learn/updating-arrays-in-state.md
@@ -766,7 +766,7 @@ function ItemList({ artworks, onToggle }) {
 Note how with Immer, **mutation like `artwork.seen = nextSeen` is now okay:**
 
 ```js
-updateMyTodos(draft => {
+updateYourList(draft => {
   const artwork = draft.find(a => a.id === artworkId);
   artwork.seen = nextSeen;
 });


### PR DESCRIPTION
This in-text code snippet in the text mentions a function named "updateMyTodos". However, this function name does not actually exist in the interactive code example to which the code snippet seems to refer. 

Instead, the function name in this code snippet should probably be changed to "updateMyList" which refers to a function that does exist in the example, to improve the consistency.

This is likely a tiny error.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
