### PR TITLE
Fix(github-actions): Update gh-actions dependencies to versions that utilize Node.js v16

### DIFF
--- a/.github/workflows/site_lint.yml
+++ b/.github/workflows/site_lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 20.x
 

--- a/.github/workflows/site_lint.yml
+++ b/.github/workflows/site_lint.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 20.x
 
       - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1.7.10
+        uses: bahmutov/npm-install@v1.8.32
 
       - name: Lint codebase
         run: yarn ci-check


### PR DESCRIPTION
This PR updates the GitHub Actions dependencies that currently use Node.js v12 to versions that utilize Node.js v16. The Node.js 12 actions are deprecated, as indicated by the following warning message:

```console
Node.js 12 actions are deprecated.
Please update the following actions to use Node.js 16: 
actions/checkout@v2, actions/setup-node@v1, 
bahmutov/npm-install@v1.7.10, actions/cache@v2. 
For more information see: 
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

The PR includes the following updates to the dependencies:

1. `actions/setup-node`: Updated from version `v1` to `v3`.
2. `bahmutov/npm-install`: Updated from version `v1.7.10` to `v1.8.32`.

These updates ensure that the GitHub Actions now utilize Node.js v16, aligning with the deprecation notice and maintaining compatibility with the latest supported version.