### PR TITLE
Edit Next.js example file to use the new app router

### DIFF
--- a/src/content/learn/your-first-component.md
+++ b/src/content/learn/your-first-component.md
@@ -211,7 +211,7 @@ When a child component needs some data from a parent, [pass it by props](/learn/
 
 #### Components all the way down {/*components-all-the-way-down*/}
 
-Your React application begins at a "root" component. Usually, it is created automatically when you start a new project. For example, if you use [CodeSandbox](https://codesandbox.io/) or [Create React App](https://create-react-app.dev/), the root component is defined in `src/App.js`. If you use the framework [Next.js](https://nextjs.org/), the root component is defined in `pages/index.js`. In these examples, you've been exporting root components.
+Your React application begins at a "root" component. Usually, it is created automatically when you start a new project. For example, if you use [CodeSandbox](https://codesandbox.io/) or [Create React App](https://create-react-app.dev/), the root component is defined in `src/App.js`. If you use the framework [Next.js](https://nextjs.org/), the root component is defined in `app/page.ts`. In these examples, you've been exporting root components.
 
 Most React apps use components all the way down. This means that you won't only use components for reusable pieces like buttons, but also for larger pieces like sidebars, lists, and ultimately, complete pages! Components are a handy way to organize UI code and markup, even if some of them are only used once.
 


### PR DESCRIPTION
See this qoute:
```markdown 
if you use [CodeSandbox](https://codesandbox.io/) 
or [Create React App](https://create-react-app.dev/), 
the root component is defined in `src/App.js`. 
If you use the framework [Next.js](https://nextjs.org/), 
the root component is defined in `pages/index.js`.
```

This PR edits `pages/index.js` to be `app/page.ts`