### PR TITLE
Delete Pitfall about Next App Router in beta

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -92,12 +92,7 @@ These features are getting closer to being production-ready every day, and we've
 **[Next.js's App Router](https://beta.nextjs.org/docs/getting-started) is a redesign of the Next.js APIs aiming to fulfill the React team’s full-stack architecture vision.** It lets you fetch data in asynchronous components that run on the server or even during the build.
 
 Next.js is maintained by [Vercel](https://vercel.com/). You can [deploy a Next.js app](https://nextjs.org/docs/deployment) to any Node.js or serverless hosting, or to your own server. Next.js also supports [static export](https://beta.nextjs.org/docs/configuring/static-export) which doesn't require a server.
-<Pitfall>
-
-Next.js's App Router is **currently in beta and is not yet recommended for production** (as of Mar 2023). To experiment with it in an existing Next.js project, [follow this incremental migration guide](https://beta.nextjs.org/docs/upgrade-guide#migrating-from-pages-to-app).
-
-</Pitfall>
-
+ 
 <DeepDive>
 
 #### Which features make up the React team’s full-stack architecture vision? {/*which-features-make-up-the-react-teams-full-stack-architecture-vision*/}


### PR DESCRIPTION
This PR removes pitfall against the using of the App Router in production.
By Next.js 13.4 it is stable and ready to use.

This is the pitfall:
```markdown
<Pitfall>

Next.js's App Router is **currently in beta and is
not yet recommended for production** 
(as of Mar 2023). To experiment with it in an 
existing Next.js project, [follow this incremental 
migration guide]
(https://beta.nextjs.org/docs/upgrade-
guide#migrating-from-pages-to-app).

</Pitfall>
```