### PR TITLE
Fix Typo in lifecycle-of-reactive-effects.md

### DIFF
--- a/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/src/content/learn/lifecycle-of-reactive-effects.md
@@ -744,7 +744,7 @@ function ChatRoom() {
 
 <Pitfall>
 
-The linter is your friend, but its powers are limited. The linter only knows when the dependencies are *wrong*. It doesn't know *the best* way to solve each case. If the linter suggests a dependency, but adding it causes a loop, it doesn't mean the linter should be ignored. You need to change the code inside (or outside) the Effect so that that value isn't reactive and doesn't *need* to be a dependency.
+The linter is your friend, but its powers are limited. The linter only knows when the dependencies are *wrong*. It doesn't know *the best* way to solve each case. If the linter suggests a dependency, but adding it causes a loop, it doesn't mean the linter should be ignored. You need to change the code inside (or outside) the Effect so that value isn't reactive and doesn't *need* to be a dependency.
 
 If you have an existing codebase, you might have some Effects that suppress the linter like this:
 


### PR DESCRIPTION

This PR addresses a small typo in the `lifecycle-of-reactive-effects.md` documentation file.

**Changes:**

Corrected repeated word typo in the document. The phrase `"that that"` has been changed to `"that"`.
This change aims to improve the readability and comprehension of the document for all readers. Looking forward to the review.