### PR TITLE
Fix(docs): Enhance console warning to render `<ConsoleBlock>` component instead of plain text in `Tutorial Tic-tac-toe`

### DIFF
--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -2073,7 +2073,13 @@ export default function Game() {
 }
 ```
 
-You can see what your code should look like below. Note that you should see an error in the developer tools console that says: ``Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Game`.`` You'll fix this error in the next section.
+You can see what your code should look like below. Note that you should see an error in the developer tools console that says: 
+
+<ConsoleBlock level="warning">
+Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Game`.
+</ConsoleBlock>
+  
+You'll fix this error in the next section.
 
 <Sandpack>
 

--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -2076,7 +2076,7 @@ export default function Game() {
 You can see what your code should look like below. Note that you should see an error in the developer tools console that says: 
 
 <ConsoleBlock level="warning">
-Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Game`.
+Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of &#96;Game&#96;.
 </ConsoleBlock>
   
 You'll fix this error in the next section.


### PR DESCRIPTION
https://github.com/reactjs/react.dev/blob/9a1e1c61fcdaf7177e89494bd70bfdc7900e37ad/src/content/learn/tutorial-tic-tac-toe.md?plain=1#L2076

To be:

https://github.com/reactjs/react.dev/blob/c26308f69db305b3a8a4c9500fc2af88842ea674/src/content/learn/tutorial-tic-tac-toe.md?plain=1#L2075-L2081