### PR TITLE
Add missing `you` in installation.md section text 

### DIFF
--- a/src/content/learn/installation.md
+++ b/src/content/learn/installation.md
@@ -49,7 +49,7 @@ If you want to build an app or a website fully with React, [start a new React pr
 
 ## Add React to an existing project {/*add-react-to-an-existing-project*/}
 
-If want to try using React in your existing app or a website, [add React to an existing project.](/learn/add-react-to-an-existing-project)
+If you want to try using React in your existing app or a website, [add React to an existing project.](/learn/add-react-to-an-existing-project)
 
 ## Next steps {/*next-steps*/}
 


### PR DESCRIPTION
Added missing "you" word in this section: https://react.dev/learn/installation#add-react-to-an-existing-project
![screenshot](https://github.com/reactjs/react.dev/assets/136004637/1a1fe6cf-d7c1-49e0-aca0-121783e8fdf1)
