### PR TITLE
Adds a TypeScript overview page

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -290,6 +290,7 @@ export function Footer() {
           </FooterLink>
           <FooterLink href="/learn/">Quick Start</FooterLink>
           <FooterLink href="/learn/installation">Installation</FooterLink>
+          <FooterLink href="/learn/typescript">Using TypeScript</FooterLink>
           <FooterLink href="/learn/describing-the-ui">
             Describing the UI
           </FooterLink>

--- a/src/components/MDX/Sandpack/NavigationBar.tsx
+++ b/src/components/MDX/Sandpack/NavigationBar.tsx
@@ -21,6 +21,7 @@ import {ResetButton} from './ResetButton';
 import {DownloadButton} from './DownloadButton';
 import {IconChevron} from '../../Icon/IconChevron';
 import {Listbox} from '@headlessui/react';
+import {OpenInTypeScriptPlaygroundButton} from './OpenInTypeScriptPlayground';
 
 export function useEvent(fn: any): any {
   const ref = useRef(null);
@@ -182,6 +183,11 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
         <DownloadButton providedFiles={providedFiles} />
         <ResetButton onReset={handleReset} />
         <OpenInCodeSandboxButton />
+        {activeFile.endsWith('.tsx') && (
+          <OpenInTypeScriptPlaygroundButton
+            content={sandpack.files[activeFile]?.code || ''}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/MDX/Sandpack/OpenInTypeScriptPlayground.tsx
+++ b/src/components/MDX/Sandpack/OpenInTypeScriptPlayground.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ */
+
+import {IconNewPage} from '../../Icon/IconNewPage';
+
+export const OpenInTypeScriptPlaygroundButton = (props: {content: string}) => {
+  const contentWithReactImport = `import * as React from 'react';\n\n${props.content}`;
+  return (
+    <a
+      className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1 ml-2 md:ml-1"
+      href={`https://www.typescriptlang.org/play#src=${encodeURIComponent(
+        contentWithReactImport
+      )}`}
+      title="Open in TypeScript Playground"
+      target="_blank"
+      rel="noreferrer">
+      <IconNewPage
+        className="inline ml-1 mr-1 relative top-[1px]"
+        width="1em"
+        height="1em"
+      />
+      <span className="hidden md:block">TypeScript Playground</span>
+    </a>
+  );
+};

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -13,8 +13,7 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. Out
 
 * [TypeScript with React Components](/learn/typescript#typescript-with-react-components)
 * [Typing common hooks](/learn/typescript#typing-hooks)
-* [How to set up your editor](/learn/editor-setup)
-* [How to install React Developer Tools](/learn/react-developer-tools)
+* [Typing Events](/learn/typescript/#typing-dom-events)
 
 </YouWillLearn>
 
@@ -141,7 +140,7 @@ The [`useReducer` hook](/reference/react/useReducer) is a more complex hook that
 <Sandpack>
 
 ```tsx App.tsx active
-import {useReducer, useCallback} from 'react';
+import {useReducer} from 'react';
 
 interface State {
    count: number 
@@ -167,8 +166,8 @@ function stateReducer(state: State, action: CounterAction): State {
 export default function App() {
   const [state, dispatch] = useReducer(stateReducer, initialState);
 
-  const addFive = useCallback(() => dispatch({ type: "setCount", value: state.count + 5 }), [state.count]);
-  const reset = useCallback(() => dispatch({ type: "reset" }), []);
+  const addFive = () => dispatch({ type: "setCount", value: state.count + 5 });
+  const reset = () => dispatch({ type: "reset" });
 
   return (
     <div>
@@ -333,4 +332,46 @@ export default App = AppTSX;
 </Sandpack>
 
 
-### `useMemo` / `useCallback` {/*typing-other-hooks*/}
+### `useMemo` / `useCallback` {/*typing-memo-callback*/}
+
+The [`useMemo`](/reference/react/useMemo) and [`useCallback`](/reference/react/useCallback) hooks follow the same pattern with determining their type from the parameter passed to them. If needed you can pass a type argument to them to explicitly set the type.
+
+`useCallback` requires adding your 
+
+### `useEffect` {/*typing-useeffect*/}
+
+The [`useEffect` hook](/reference/react/useEffect) is used to perform side effects in a component. It is called after every render by default, but can be configured to only run when certain values change. The types for this hook allow for either returning a cleanup function or not returning anything.
+
+## Typing DOM Events {/*typing-dom-events*/}
+
+When working with DOM events in React, the type of the event is inferred from the event handler. However, when you want to extract a function to be passed to an event handler, you will need to explicitly set the type of the event.
+
+<Sandpack>
+
+```tsx App.tsx active
+import { useState } from 'react';
+
+export default function Form() {
+  const [value, setValue] = useState("Change me");
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <>
+      <input value={value} onChange={handleChange} />
+      <p>Value: {value}</p>
+    </>
+  );
+}
+```
+
+```js App.js hidden
+import AppTSX from "./App.tsx";
+export default App = AppTSX;
+```
+
+</Sandpack>
+
+There are many types of events provided in React - the full list can be found [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b580df54c0819ec9df62b0835a315dd48b8594a9/types/react/index.d.ts#L1247C1-L1373) which is based on the [most popular events from the DOM](https://developer.mozilla.org/en-US/docs/Web/Events). If you need to use an event that is not included in this list, you can use the `React.SyntheticEvent` type, which is the base type for all events.

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -342,7 +342,11 @@ The [`useMemo`](/reference/react/useMemo) and [`useCallback`](/reference/react/u
 
 The [`useEffect` hook](/reference/react/useEffect) is used to perform side effects in a component. It is called after every render by default, but can be configured to only run when certain values change. The types for this hook allow for either returning a cleanup function or not returning anything.
 
-## Typing DOM Events {/*typing-dom-events*/}
+## Useful Types {/*useful-types*/}
+
+There is quite an expansive set of types which come from the `@types/react` package, it is worth a read when you feel comfortable with how React and TypeScript interact. You can find them [in React's folder in DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts). We will cover a few of the more common types here.
+
+### DOM Events {/*typing-dom-events*/}
 
 When working with DOM events in React, the type of the event is inferred from the event handler. However, when you want to extract a function to be passed to an event handler, you will need to explicitly set the type of the event.
 
@@ -374,4 +378,56 @@ export default App = AppTSX;
 
 </Sandpack>
 
-There are many types of events provided in React - the full list can be found [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b580df54c0819ec9df62b0835a315dd48b8594a9/types/react/index.d.ts#L1247C1-L1373) which is based on the [most popular events from the DOM](https://developer.mozilla.org/en-US/docs/Web/Events). If you need to use an event that is not included in this list, you can use the `React.SyntheticEvent` type, which is the base type for all events.
+There are many types of events provided in the React types - the full list can be found [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b580df54c0819ec9df62b0835a315dd48b8594a9/types/react/index.d.ts#L1247C1-L1373) which is based on the [most popular events from the DOM](https://developer.mozilla.org/en-US/docs/Web/Events). If you need to use an event that is not included in this list, you can use the `React.SyntheticEvent` type, which is the base type for all events.
+
+### Children {/*typing-children*/}
+
+There are three common paths to describing the children of a component. The first is to use the `React.ReactNode` type, which is a union of all the possible types that can be passed as children in JSX:
+
+```ts
+interface ModalRendererProps {
+  title: string;
+  children: React.ReactNode;
+}
+```
+
+The second is to use the `React.ReactElement` type, which is only JSX elements and not JavaScript primitives like strings or numbers:
+
+```ts
+interface ModalRendererProps {
+  title: string;
+  children: React.ReactElement;
+}
+```
+
+The third is to use `React.PropsWithChildren` which is a utility type that takes an object type and adds a optional `children` field of `React.ReactNode` to it:
+
+```ts
+type ModalRendererProps = React.PropsWithChildren<{
+  title: string;
+}>
+```
+
+Note, that you cannot use TypeScript to describe that the children are a certain type of elements. You can see all three of these in action with the type-checker in [this TypeScript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgIilQ3wChSB6CxYmAOmXRgDkIATJOdNJMGAZzgwAFpxAR+8YADswAVwGkZMJFEzpOjDKw4AFHGEEBvUnDhphwADZsi0gFw0mDWjqQBuUgF9yaCNMlENzgAXjgACjADfkctFnYkfQhDAEpQgD44AB42YAA3dKMo5P46C2tbJGkvLIpcgt9-QLi3AEEwMFCItJDMrPTTbIQ3dKywdIB5aU4kKyQQKpha8drhhIGzLLWODbNs3b3s8YAxKBQAcwXpAThMaGWDvbH0gFloGbmrgQfBzYpd1YjQZbEYARkB6zMwO2SHSAAlZlYIBCdtCRkZpHIrFYahQYQD8UYYFA5EhcfjyGYqHAXnJAsIUHlOOUbHYhMIIHJzsI0Qk4P9SLUBuRqXEXEwAKKfRZcNA8PiCfxWACecAAUgBlAAacFm80W-CU11U6h4TgwUv11yShjgJjMLMqDnN9Dilq+nh8pD8AXgCHdMrCkWisVoAet0R6fXqhWKhjKllZVVxMcavpd4Zg7U6Qaj+2hmdG4zeRF10uu-Aeq0LBfLMEe-V+T2L7zLVu+FBWLdLeq+lc7DYFf39deFVOotMCACNOCh1dq219a+30uC8YWoZsRyuEdjkevR8uvoVMdjyTWt4WiSSydXD4NqZP4AymeZE072ZzuUeZQKheRKGoMUbX4AB1YARAAYXfNlgEEJkoFVbheBgGRzjgGQMNkBQABpzAgBC0K4bE4AgTAXWCFBpDYOBpAgN8Kjsb0mj9cCoPfKoumDEpQ2cEC2OEaDGKqLIjC8dI8xyfJY2iBNhOqWpU2Y9M4gEoSk2kbMuMkgk1I46Qi1eVtewNKs8T0ioql0iDBP0htHk2bsPnbfsuyMns61cwcAXMmz1I4AzKSGCybCstcEBCgLMjgaFIqs3ckVWOLAq3ZKTyxHEkr8uzYuyyyDOvUlyTSoLqQASRwaRgDQFBsVVO4oHZThpBQBY8Jq6RiP4ei6OfRlmRgqpcvY-L+QGf8gA).
+
+### Style Props {/*typing-style-props*/}
+
+When using inline styles in React, you can use `React.CSSProperties` to describe the object passed to the `style` prop. This type is a union of all the possible CSS properties, and is a good way to ensure you are passing valid CSS properties to the `style` prop, and to get auto-complete in your editor.
+
+```ts
+interface MyComponentProps {
+  style: React.CSSProperties;
+}
+```
+
+## Further learning {/*further-learning*/}
+
+This guide has covered the basics of using TypeScript with React, but there is a lot more to learn. We recommend the following resources:
+
+ - [The TypeScript handbook](https://www.typescriptlang.org/docs/handbook/) is the official documentation for TypeScript, and covers most key language features.
+
+ - [The TypeScript release notes](https://devblogs.microsoft.com/typescript/) covers a each new features in-depth.
+
+ - [React TypeScript Cheatsheet](https://react-typescript-cheatsheet.netlify.app/) is a community-maintained cheatsheet for using TypeScript with React, covering a lot of useful edge cases and providing more breadth than this document.
+
+ - [TypeScript Community Discord](discord.com/invite/typescript) is a great place to ask questions and get help with TypeScript and React issues.

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -13,7 +13,7 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. Out
 
 * [TypeScript with React Components](/learn/typescript#typescript-with-react-components)
 * [Typing common hooks](/learn/typescript#typing-hooks)
-* [Typing Events](/learn/typescript/#typing-dom-events)
+* [Common types from `@types/react`](/learn/typescript/#useful-types)
 
 </YouWillLearn>
 

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -45,6 +45,10 @@ export default function MyApp() {
 }
 ```
 
+```js App.js hidden
+import AppTSX from "./App.tsx";
+export default App = AppTSX;
+```
 </Sandpack>
 
  <Note>
@@ -75,10 +79,15 @@ export default function MyApp() {
   return (
     <div>
       <h1>Welcome to my app</h1>
-      <MyButton title="I'm a button" disabled={false}/>
+      <MyButton title="I'm a disabled button" disabled={true}/>
     </div>
   );
 }
+```
+
+```js App.js hidden
+import AppTSX from "./App.tsx";
+export default App = AppTSX;
 ```
 
 </Sandpack>
@@ -92,7 +101,7 @@ The type definitions from `@types/react-dom` include types for the built-in hook
 
 ### `useState` {/*typing-usestate*/}
 
-The `useState` hook will re-use the value passed in as the initial state to determine what the type of the value should be. For example:
+The [`useState` hook](/reference/react/useReducer) will re-use the value passed in as the initial state to determine what the type of the value should be. For example:
 
 ```ts
 const [enabled, setEnabled] = useState(false);
@@ -124,12 +133,75 @@ type RequestState =
 const [requestState, setRequestState] = useState<RequestState>({ status: 'idle' });
 ```
 
+### `useReducer` {/*usereducer*/}
 
-## Add React to an existing project {/*add-react-to-an-existing-project*/}
+The [`useReducer` hook](/reference/react/useReducer) is a more complex hook that takes a reducer function and an initial state. The types for the reducer function are inferred from the initial state. You can optionally provide a type argument to the `useReducer` call to provide a type for the state, but it is often better to set the type on the initial state instead:
 
-If want to try using React in your existing app or a website, [add React to an existing project.](/learn/add-react-to-an-existing-project)
+<Sandpack>
 
-## Next steps {/*next-steps*/}
+```tsx App.tsx active
+import {useReducer, useCallback} from 'react';
 
-Head to the [Quick Start](/learn) guide for a tour of the most important React concepts you will encounter every day.
+interface State {
+   count: number 
+};
 
+type CounterAction =
+  | { type: "reset" }
+  | { type: "setCount"; value: State["count"] }
+
+const initialState: State = { count: 0 };
+
+function stateReducer(state: State, action: CounterAction): State {
+  switch (action.type) {
+    case "reset":
+      return initialState;
+    case "setCount":
+      return { ...state, count: action.value };
+    default:
+      throw new Error("Unknown action");
+  }
+}
+
+export default function App() {
+  const [state, dispatch] = useReducer(stateReducer, initialState);
+
+  const addFive = useCallback(() => dispatch({ type: "setCount", value: state.count + 5 }), [state.count]);
+  const reset = useCallback(() => dispatch({ type: "reset" }), []);
+
+  return (
+    <div>
+      <h1>Welcome to my counter</h1>
+
+      <p>Count: {state.count}</p>
+      <button onClick={addFive}>Add 5</button>
+      <button onClick={reset}>Reset</button>
+    </div>
+  );
+}
+
+```
+
+```js App.js hidden
+import AppTSX from "./App.tsx";
+export default App = AppTSX;
+```
+</Sandpack>
+
+
+We are using TypeScript in a few key places:
+
+ - `interface State` describes the shape of the reducer's state.
+ - `type CounterAction` describes the different actions which can be dispatched to the reducer.
+ - `const initialState: State` provides a type for the initial state, and also the type which is used by `useReducer` by default.
+ - `stateReducer(state: State, action: CounterAction): State` sets the types for the reducer function's arguments and return value.
+
+ An alternative to setting the type on `initialState` is to provide a type argument to `useReducer`:
+
+ ```ts
+const initialState = { count: 0 };
+
+export default function App() {
+  const [state, dispatch] = useReducer<State>(stateReducer, initialState);
+}
+ ```

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -1,28 +1,32 @@
 ---
 title: Using TypeScript
+re: https://github.com/reactjs/react.dev/issues/5960
 ---
 
 <Intro>
 
-TypeScript is a popular way to add type definitions to React projects. Out of the box, TypeScript [supports JSX](/learn/writing-markup-with-jsx) and you can get full React support by adding [`@types/react-dom`](https://www.npmjs.com/package/@types/react-dom) to your project.
+TypeScript is a popular way to add type definitions to JavaScript codebases. Out of the box, TypeScript [supports JSX](/learn/writing-markup-with-jsx) and you can get full React support by adding [`@types/react-dom`](https://www.npmjs.com/package/@types/react-dom) to your project.
 
 </Intro>
 
 <YouWillLearn isChapter={true}>
-* [How does ](/learn/start-a-new-react-project)
+* [How does it come together](/learn/start-a-new-react-project)
 * [How to add React to an existing project](/learn/add-react-to-an-existing-project)
 * [How to set up your editor](/learn/editor-setup)
 * [How to install React Developer Tools](/learn/react-developer-tools)
 
 </YouWillLearn>
 
-## Try React {/*try-react*/}
 
-You don't need to install anything to play with React. Try editing this sandbox!
+All of the production-grade frameworks mentioned in [Start a New React Project](/learn/start-a-new-react-project) offer support for using TypeScript with React, we recommend consulting their documentation for more information on setup. This guide assumes you have your project configured to support writing TypeScript React files as `*.tsx`.
+
+## TypeScript with React {/*typescript-with-react*/}
 
 <Sandpack>
 
 ```tsx App.tsx active
+const a = "";
+
 function Greeting({ name } : { name: string }) {
   return <h1>Hello, {name}</h1>;
 }
@@ -34,9 +38,12 @@ export default function App() {
 
 </Sandpack>
 
-You can edit it directly or open it in a new tab by pressing the "Fork" button in the upper right corner.
+ <Note>
 
-Most pages in the React documentation contain sandboxes like this. Outside of the React documentation, there are many online sandboxes that support React: for example, [CodeSandbox](https://codesandbox.io/s/new), [StackBlitz](https://stackblitz.com/fork/react), or [CodePen.](https://codepen.io/pen?&editors=0010&layout=left&prefill_data_id=3f4569d1-1b11-4bce-bd46-89090eed5ddb)
+These sandboxes can handle TypeScript code, but they do not run the type-checker. This means you can amend the TypeScript sandboxes to learn, but you won't get any type errors or warnings. To get type-checking, you can use the [TypeScript Playground](https://www.typescriptlang.org/play) or use an online sandbox.
+
+</Note>
+
 
 ### Try React locally {/*try-react-locally*/}
 

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -1,0 +1,56 @@
+---
+title: Using TypeScript
+---
+
+<Intro>
+
+TypeScript is a popular way to add type definitions to React projects. Out of the box, TypeScript [supports JSX](/learn/writing-markup-with-jsx) and you can get full React support by adding [`@types/react-dom`](https://www.npmjs.com/package/@types/react-dom) to your project.
+
+</Intro>
+
+<YouWillLearn isChapter={true}>
+* [How does ](/learn/start-a-new-react-project)
+* [How to add React to an existing project](/learn/add-react-to-an-existing-project)
+* [How to set up your editor](/learn/editor-setup)
+* [How to install React Developer Tools](/learn/react-developer-tools)
+
+</YouWillLearn>
+
+## Try React {/*try-react*/}
+
+You don't need to install anything to play with React. Try editing this sandbox!
+
+<Sandpack>
+
+```tsx App.tsx active
+function Greeting({ name } : { name: string }) {
+  return <h1>Hello, {name}</h1>;
+}
+
+export default function App() {
+  return <Greeting name="world" />
+}
+```
+
+</Sandpack>
+
+You can edit it directly or open it in a new tab by pressing the "Fork" button in the upper right corner.
+
+Most pages in the React documentation contain sandboxes like this. Outside of the React documentation, there are many online sandboxes that support React: for example, [CodeSandbox](https://codesandbox.io/s/new), [StackBlitz](https://stackblitz.com/fork/react), or [CodePen.](https://codepen.io/pen?&editors=0010&layout=left&prefill_data_id=3f4569d1-1b11-4bce-bd46-89090eed5ddb)
+
+### Try React locally {/*try-react-locally*/}
+
+To try React locally on your computer, [download this HTML page.](https://gist.githubusercontent.com/gaearon/0275b1e1518599bbeafcde4722e79ed1/raw/db72dcbf3384ee1708c4a07d3be79860db04bff0/example.html) Open it in your editor and in your browser!
+
+## Start a new React project {/*start-a-new-react-project*/}
+
+If you want to build an app or a website fully with React, [start a new React project.](/learn/start-a-new-react-project)
+
+## Add React to an existing project {/*add-react-to-an-existing-project*/}
+
+If want to try using React in your existing app or a website, [add React to an existing project.](/learn/add-react-to-an-existing-project)
+
+## Next steps {/*next-steps*/}
+
+Head to the [Quick Start](/learn) guide for a tour of the most important React concepts you will encounter every day.
+

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -9,9 +9,9 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. Out
 
 </Intro>
 
-<YouWillLearn isChapter={true}>
-* [How does it come together](/learn/start-a-new-react-project)
-* [How to add React to an existing project](/learn/add-react-to-an-existing-project)
+<YouWillLearn>
+* [TypeScript with React Components](/learn/typescript#typescript-with-react-components)
+* [Typing common hooks](/learn/add-react-to-an-existing-project)
 * [How to set up your editor](/learn/editor-setup)
 * [How to install React Developer Tools](/learn/react-developer-tools)
 
@@ -20,7 +20,7 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. Out
 
 All of the production-grade frameworks mentioned in [Start a New React Project](/learn/start-a-new-react-project) offer support for using TypeScript with React, we recommend consulting their documentation for more information on setup. This guide assumes you have your project configured to support writing `*.tsx` TypeScript React files, and have finished the Quick Start guide.
 
-## TypeScript with React {/*typescript-with-react*/}
+## TypeScript with React Components {/*typescript-with-react-components*/}
 
 Writing TypeScript with React is very similar to writing JavaScript with React. The key difference when working with a component is that you can provide types for your component's props. These types can be used for correctness checking and providing inline documentation in editors.
 
@@ -83,13 +83,47 @@ export default function MyApp() {
 
 </Sandpack>
 
-The type describing your component's props can be as simple or as complex as you need, though they should probably be object types. You can learn about how TypeScript describes objects in [Object Types](https://www.typescriptlang.org/docs/handbook/2/objects.html) but you may also be interested in using [Union Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) to describe a prop that can be one of a few different types and the 
-[Creating Types from Types](https://www.typescriptlang.org/docs/handbook/2/types-from-types.html) guide for more advanced use cases.
+The type describing your component's props can be as simple or as complex as you need, though they should probably be an object type. You can learn about how TypeScript describes objects in [Object Types](https://www.typescriptlang.org/docs/handbook/2/objects.html) but you may also be interested in using [Union Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) to describe a prop that can be one of a few different types and the [Creating Types from Types](https://www.typescriptlang.org/docs/handbook/2/types-from-types.html) guide for more advanced use cases.
 
 
-## Start a new React project {/*start-a-new-react-project*/}
+## Hooks {/*typing-hooks*/}
 
-If you want to build an app or a website fully with React, [start a new React project.](/learn/start-a-new-react-project)
+The type definitions from `@types/react-dom` include types for the built-in hooks, so you can use them in your components without any additional setup. They are built to take into account the code you write in your component, so you will get inferred types a lot of the time and ideally do not need to handle the minutiae of providing the types. However, we can look at a few examples of how to provide types for hooks.
+
+### `useState` {/*typing-usestate*/}
+
+The `useState` hook will re-use the value passed in as the initial state to determine what the type of the value should be. For example:
+
+```ts
+const [enabled, setEnabled] = useState(false);
+```
+
+Will assign the type of `boolean` to `enabled`, and `setEnabled` will be a function accepting either a `boolean` argument, or a function that returns a `boolean`. If you want to explicitly provide a type for the state, you can do so by providing a type argument to the `useState` call:
+
+```ts 
+const [enabled, setEnabled] = useState<boolean>(false);
+```
+
+This isn't very useful in this case, but a common case where you may want to provide a type is when you have a union type. For example, `status` here can be one of a few different strings:
+
+```ts
+type Status = "idle" | "loading" | "success" | "error";
+
+const [status, setStatus] = useState<Status>("idle");
+```
+
+Or, as recommended in [Principles for structuring state](/learn/choosing-the-state-structure#principles-for-structuring-state), you can group related state as an object and describe the different possibilities via object types:
+
+```ts
+type RequestState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success', data: any }
+  | { status: 'error', error: Error };
+
+const [requestState, setRequestState] = useState<RequestState>({ status: 'idle' });
+```
+
 
 ## Add React to an existing project {/*add-react-to-an-existing-project*/}
 

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -18,21 +18,30 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. Out
 </YouWillLearn>
 
 
-All of the production-grade frameworks mentioned in [Start a New React Project](/learn/start-a-new-react-project) offer support for using TypeScript with React, we recommend consulting their documentation for more information on setup. This guide assumes you have your project configured to support writing TypeScript React files as `*.tsx`.
+All of the production-grade frameworks mentioned in [Start a New React Project](/learn/start-a-new-react-project) offer support for using TypeScript with React, we recommend consulting their documentation for more information on setup. This guide assumes you have your project configured to support writing `*.tsx` TypeScript React files, and have finished the Quick Start guide.
 
 ## TypeScript with React {/*typescript-with-react*/}
+
+Writing TypeScript with React is very similar to writing JavaScript with React. The key difference when working with a component is that you can provide types for your component's props. These types can be used for correctness checking and providing inline documentation in editors.
+
+Taking the [`MyButton` functional component](/learn#components) from the [Quick Start](/learn) guide, we can add a type describing the `title` for the button:
 
 <Sandpack>
 
 ```tsx App.tsx active
-const a = "";
-
-function Greeting({ name } : { name: string }) {
-  return <h1>Hello, {name}</h1>;
+function MyButton({ title }: { title: string }) {
+  return (
+    <button>{title}</button>
+  );
 }
 
-export default function App() {
-  return <Greeting name="world" />
+export default function MyApp() {
+  return (
+    <div>
+      <h1>Welcome to my app</h1>
+      <MyButton title="I'm a button" />
+    </div>
+  );
 }
 ```
 
@@ -40,14 +49,43 @@ export default function App() {
 
  <Note>
 
-These sandboxes can handle TypeScript code, but they do not run the type-checker. This means you can amend the TypeScript sandboxes to learn, but you won't get any type errors or warnings. To get type-checking, you can use the [TypeScript Playground](https://www.typescriptlang.org/play) or use an online sandbox.
+These sandboxes can handle TypeScript code, but they do not run the type-checker. This means you can amend the TypeScript sandboxes to learn, but you won't get any type errors or warnings. To get type-checking, you can use the [TypeScript Playground](https://www.typescriptlang.org/play) or use a more fully-featured online sandbox.
 
 </Note>
 
+This inline syntax is the simplest way to provide types for a functional component, though once you start to have a few fields to describe it can become unwieldy. Instead, you can use an `interface` or `type` to describe the component's props:
 
-### Try React locally {/*try-react-locally*/}
+<Sandpack>
 
-To try React locally on your computer, [download this HTML page.](https://gist.githubusercontent.com/gaearon/0275b1e1518599bbeafcde4722e79ed1/raw/db72dcbf3384ee1708c4a07d3be79860db04bff0/example.html) Open it in your editor and in your browser!
+```tsx App.tsx active
+interface MyButtonProps {
+  /** The text to display inside the button */
+  title: string;
+  /** Whether the button can be interacted with */
+  disabled: boolean;
+}
+
+function MyButton({ title, disabled }: MyButtonProps) {
+  return (
+    <button disabled={disabled}>{title}</button>
+  );
+}
+
+export default function MyApp() {
+  return (
+    <div>
+      <h1>Welcome to my app</h1>
+      <MyButton title="I'm a button" disabled={false}/>
+    </div>
+  );
+}
+```
+
+</Sandpack>
+
+The type describing your component's props can be as simple or as complex as you need, though they should probably be object types. You can learn about how TypeScript describes objects in [Object Types](https://www.typescriptlang.org/docs/handbook/2/objects.html) but you may also be interested in using [Union Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) to describe a prop that can be one of a few different types and the 
+[Creating Types from Types](https://www.typescriptlang.org/docs/handbook/2/types-from-types.html) guide for more advanced use cases.
+
 
 ## Start a new React project {/*start-a-new-react-project*/}
 

--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -11,7 +11,7 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. Out
 
 <YouWillLearn>
 * [TypeScript with React Components](/learn/typescript#typescript-with-react-components)
-* [Typing common hooks](/learn/add-react-to-an-existing-project)
+* [Typing common hooks](/learn/typescript#typing-hooks)
 * [How to set up your editor](/learn/editor-setup)
 * [How to install React Developer Tools](/learn/react-developer-tools)
 
@@ -133,7 +133,7 @@ type RequestState =
 const [requestState, setRequestState] = useState<RequestState>({ status: 'idle' });
 ```
 
-### `useReducer` {/*usereducer*/}
+### `useReducer` {/*typing-usereducer*/}
 
 The [`useReducer` hook](/reference/react/useReducer) is a more complex hook that takes a reducer function and an initial state. The types for the reducer function are inferred from the initial state. You can optionally provide a type argument to the `useReducer` call to provide a type for the state, but it is often better to set the type on the initial state instead:
 
@@ -196,12 +196,16 @@ We are using TypeScript in a few key places:
  - `const initialState: State` provides a type for the initial state, and also the type which is used by `useReducer` by default.
  - `stateReducer(state: State, action: CounterAction): State` sets the types for the reducer function's arguments and return value.
 
- An alternative to setting the type on `initialState` is to provide a type argument to `useReducer`:
+A more explicit alternative to setting the type on `initialState` is to provide a type argument to `useReducer`:
 
- ```ts
+```ts
 const initialState = { count: 0 };
 
 export default function App() {
   const [state, dispatch] = useReducer<State>(stateReducer, initialState);
 }
- ```
+```
+
+### `useContext` {/*typing-usecontext*/}
+
+The [`useContext` hook](/reference/react/useContext) is a [...]

--- a/src/sidebarLearn.json
+++ b/src/sidebarLearn.json
@@ -37,6 +37,10 @@
           "path": "/learn/editor-setup"
         },
         {
+          "title": "Using TypeScript",
+          "path": "/learn/typescript"
+        },
+        {
           "title": "React Developer Tools",
           "path": "/learn/react-developer-tools"
         }


### PR DESCRIPTION
Re: #5960 

Adds a 1st draft of a React + TypeScript page. Covers:

- Describing React Components
- Hooks, with a special focus on first showing how the inference works and then how to override it 
- Using common React types for Event handling, describing children and typing `style`
- Jump off points for deeper understanding

I based this from @markerikson's list in #5960 but also went through a few of my react codebases and looked at what `React.` types had been used which I think gives a pretty pragmatic set to work from. Open to opinions though!

As there is no type-checking with Sandpack, I added a feature to the Sandpack component to open any `.tsx` files in the TypeScript playground. It only shows on `*.tsx` files, of which there are no others.

It is worth noting that the Playground is going to be getting a reduced feature set over time ( https://github.com/microsoft/TypeScript-Website/issues/2804 ) but that it's _very_ unlikely to be removing the set of features used in this document (JSX support, type-acquisition, URL hash links.) Regardless, I have been working with the owner of a popular link shortener to host a fully-featured copy of the current playground outside of the TypeScript website https://github.com/gillchristian/tsplay.dev/pull/115 as a backup which URLs could be switched to in the future.

