### PR TITLE
Fix rounded corners for code sandbox.

### DIFF
--- a/src/components/MDX/Sandpack/CustomPreset.tsx
+++ b/src/components/MDX/Sandpack/CustomPreset.tsx
@@ -74,7 +74,7 @@ const SandboxShell = memo(function SandboxShell({
   return (
     <>
       <div
-        className="shadow-lg dark:shadow-lg-dark rounded-lg"
+        className="shadow-lg dark:shadow-lg-dark rounded-2xl"
         ref={containerRef}
         style={{
           contain: 'content',


### PR DESCRIPTION
The rounded corners in code examples don't match the ones in code sandboxes. This PR fixes it by aligning the rounded borders of the code sandbox (`<CustomPreset>`) with the ones from code examples (`CodeBlock`).

<table>
<tr>
 <td>
	**Before**
 <td>
    **After**
<tr>
 <td>
<img width="324" alt="CleanShot 2023-07-06 at 07 01 44@2x" src="https://github.com/reactjs/react.dev/assets/13352/8fa658fd-2cb4-41f8-86dc-2fa5846eb2bf">
 <td>
<img width="324" alt="CleanShot 2023-07-06 at 07 01 23@2x" src="https://github.com/reactjs/react.dev/assets/13352/a77ac2a6-fd51-460b-a4e5-52aaebdad254">
</table>

Screenshot of the whole box:
<img width="910" alt="CleanShot 2023-07-06 at 07 02 20@2x" src="https://github.com/reactjs/react.dev/assets/13352/55d713af-a89a-4609-95de-95727575a768">


Notice how in the before screenshot the bottom box has a different rounded border, and in the after screenshot the borders are the same.

This has been driving me a bit crazy since the new docs launched 😅