### PR TITLE
Fix root-unmount returns

### DIFF
--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -107,7 +107,7 @@ Calling `root.unmount` will unmount all the components in the root and "detach" 
 
 #### Returns {/*root-unmount-returns*/}
 
-`render` returns `null`.
+`root.unmount` returns `undefined`.
 
 #### Caveats {/*root-unmount-caveats*/}
 


### PR DESCRIPTION
The `root.unmount() Returns` in "hydrateRoot" reference was incorrect. The correct Returns should be "`root.unmount` returns `undefined`". 
