### PR TITLE
Added "Contribution Guidelines" and "How to Contribute" docs to the newer site

### DIFF
--- a/src/content/community/contributing-guidelines.md
+++ b/src/content/community/contributing-guidelines.md
@@ -1,0 +1,130 @@
+---
+title: Contributing Guidelines
+---
+
+<Intro>
+
+Thank you for your interest in contributing to the React Docs!
+</Intro>
+
+## Guidelines for Text {/*guidelines-for-text*/}
+
+**Different sections intentionally have different styles.**
+
+The documentation is divided into sections to cater to different learning styles and use cases. When editing an article, try to match the surrounding text in tone and style. When creating a new article, try to match the tone of the other articles in the same section. Learn about the motivation behind each section below.
+
+**[Learn React](https://react.dev/learn)** is designed to introduce fundamental concepts in a step-by-step way. Each individual article in Learn React builds on the knowledge from the previous ones, so make sure not to add any "cyclical dependencies" between them. It is important that the reader can start with the first article and work their way to the last Learn React article without ever having to "look ahead" for a definition. This explains some ordering choices (e.g. that state is explained before events, or that "thinking in React" doesn't use refs). Learn React also serves as a reference manual for React concepts, so it is important to be very strict about their definitions and relationships between them.
+
+**[API Reference](https://react.dev/reference/react)** is organized by APIs rather than concepts. It is intended to be exhaustive. Any corner cases or recommendations that were skipped for brevity in Learn React should be mentioned in the reference documentation for the corresponding APIs.
+
+**Try to follow your own instructions.**
+
+When writing step-by-step instructions (e.g. how to install something), try to forget everything you know about the topic, and actually follow the instructions you wrote, a single step at time. Often you will discover that there is implicit knowledge that you forgot to mention, or that there are missing or out-of-order steps in the instructions. Bonus points for getting *somebody else* to follow the steps and watching what they struggle with. Often it would be something very simple that you have not anticipated.
+
+## Guidelines for Code Examples
+
+### Syntax
+
+#### Prefer JSX to `createElement`.
+
+Ignore this if you're specifically describing `createElement`.
+
+#### Use `const` where possible, otherwise `let`. Don't use `var`.
+
+Ignore this if you're specifically writing about ES5.
+
+#### Don't use ES6 features when equivalent ES5 features have no downsides.
+
+Remember that ES6 is still new to a lot of people. While we use it in many places (`const` / `let`, classes, arrow functions), if the equivalent ES5 code is just as straightforward and readable, consider using it.
+
+In particular, you should prefer named `function` declarations over `const myFunction = () => ...` arrows for top-level functions. However, you *should* use arrow functions where they provide a tangible improvement (such as preserving `this` context inside a component). Consider both sides of the tradeoff when deciding whether to use a new feature.
+
+#### Don't use features that aren't standardized yet.
+
+For example, **don't** write this:
+
+```jsx
+class MyComponent extends React.Component {
+  state = {value: ''};
+  handleChange = (e) => {
+    this.setState({value: e.target.value});
+  };
+}
+```
+
+Instead, **do** write this:
+
+```jsx
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.state = {value: ''};
+  }
+  handleChange(e) {
+    this.setState({value: e.target.value});
+  }
+}
+```
+
+Ignore this rule if you're specifically describing an experimental proposal. Make sure to mention its experimental nature in the code and in the surrounding text.
+
+### Style
+
+- Use semicolons.
+- No space between function names and parens (`method() {}` not `method () {}`).
+- When in doubt, use the default style favored by [Prettier](https://prettier.io/playground/).
+
+### Highlighting
+
+Use `js` as the highlighting language in Markdown code blocks:
+
+````
+```jsx
+// code
+```
+````
+
+Sometimes you'll see blocks with numbers.  
+They tell the website to highlight specific lines.
+
+You can highlight a single line:
+
+````
+```jsx {2}
+function hello() {
+  // this line will get highlighted
+}
+```
+````
+
+A range of lines:
+
+````
+```jsx {2-4}
+function hello() {
+  // these lines
+  // will get
+  // highlighted
+}
+```
+````
+
+Or even multiple ranges:
+
+````
+```jsx {2-4,6}
+function hello() {
+  // these lines
+  // will get
+  // highlighted
+  console.log('hello');
+  // also this one
+  console.log('there');
+}
+```
+````
+
+Be mindful that if you move some code in an example with highlighting, you also need to update the highlighting.
+
+Don't be afraid to often use highlighting! It is very valuable when you need to focus the reader's attention on a particular detail that's easy to miss.

--- a/src/content/community/contributing-guidelines.md
+++ b/src/content/community/contributing-guidelines.md
@@ -21,25 +21,25 @@ The documentation is divided into sections to cater to different learning styles
 
 When writing step-by-step instructions (e.g. how to install something), try to forget everything you know about the topic, and actually follow the instructions you wrote, a single step at time. Often you will discover that there is implicit knowledge that you forgot to mention, or that there are missing or out-of-order steps in the instructions. Bonus points for getting *somebody else* to follow the steps and watching what they struggle with. Often it would be something very simple that you have not anticipated.
 
-## Guidelines for Code Examples
+## Guidelines for Code Examples {/*guidelines-for-code-examples*/}
 
-### Syntax
+### Syntax {/*-syntax*/}
 
-#### Prefer JSX to `createElement`.
+#### Prefer JSX to `createElement` {/*prefer-jsx-to-createelement*/}
 
 Ignore this if you're specifically describing `createElement`.
 
-#### Use `const` where possible, otherwise `let`. Don't use `var`.
+#### Use `const` where possible, otherwise `let`. Don't use `var` {/*use-const-or-let*/}
 
 Ignore this if you're specifically writing about ES5.
 
-#### Don't use ES6 features when equivalent ES5 features have no downsides.
+#### Don't use ES6 features when equivalent ES5 features have no downsides {/*dont-use-es6-when-equivalent-es5-has-no-downsides*/}
 
 Remember that ES6 is still new to a lot of people. While we use it in many places (`const` / `let`, classes, arrow functions), if the equivalent ES5 code is just as straightforward and readable, consider using it.
 
 In particular, you should prefer named `function` declarations over `const myFunction = () => ...` arrows for top-level functions. However, you *should* use arrow functions where they provide a tangible improvement (such as preserving `this` context inside a component). Consider both sides of the tradeoff when deciding whether to use a new feature.
 
-#### Don't use features that aren't standardized yet.
+#### Don't use features that aren't standardized yet {/*avoid-non-standardized-features*/}
 
 For example, **don't** write this:
 
@@ -69,13 +69,13 @@ class MyComponent extends React.Component {
 
 Ignore this rule if you're specifically describing an experimental proposal. Make sure to mention its experimental nature in the code and in the surrounding text.
 
-### Style
+### Style {/*style*/}
 
 - Use semicolons.
 - No space between function names and parens (`method() {}` not `method () {}`).
 - When in doubt, use the default style favored by [Prettier](https://prettier.io/playground/).
 
-### Highlighting
+### Highlighting {/*highlighting*/}
 
 Use `js` as the highlighting language in Markdown code blocks:
 

--- a/src/content/community/how-to-contribute.md
+++ b/src/content/community/how-to-contribute.md
@@ -7,7 +7,7 @@ title: How To Contribute
 React is one of Facebook's first open source projects that is both under very active development and is also being used to ship code to everybody on [facebook.com](https://www.facebook.com). We're still working out the kinks to make contributing to this project as easy and transparent as possible, but we're not quite there yet. Hopefully this document makes the process for contributing clear and answers some questions that you may have.
 </Intro>
 
-### Code of Conduct {/*code-of-conduct*/}
+## Code of Conduct {/*code-of-conduct*/}
 
 Facebook has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct, and we expect project participants to adhere to it. Please read [the full text](https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 

--- a/src/content/community/how-to-contribute.md
+++ b/src/content/community/how-to-contribute.md
@@ -15,19 +15,19 @@ Facebook has adopted the [Contributor Covenant](https://www.contributor-covenant
 
 All work on React happens directly on [Github](https://github.com/facebook/react). Both core team members and external contributors send pull requests which go through the same review process.
 
-### Semantic Versioning
+### Semantic Versioning {/*semantic-versioning*/}
 
 React follows [semantic versioning](https://semver.org/). We release patch versions for critical bugfixes, minor versions for new features or non-essential changes, and major versions for any breaking changes. When we make breaking changes, we also introduce deprecation warnings in a minor version so that our users learn about the upcoming changes and migrate their code in advance. Learn more about our commitment to stability and incremental migration in our [versioning policy](https://react.dev/community/versioning-policy).
 
 Every significant change is documented in the [changelog file](https://github.com/facebook/react/blob/main/CHANGELOG.md).
 
-### Branch Organization
+### Branch Organization {/*branch-organization*/}
 
 Submit all changes directly to the [`main branch`](https://github.com/facebook/react/tree/main). We don’t use separate branches for development or for upcoming releases. We do our best to keep `main` in good shape, with all tests passing.
 
 Code that lands in `main` must be compatible with the latest stable release. It may contain additional features, but no breaking changes. We should be able to release a new minor version from the tip of `main` at any time.
 
-### Feature Flags
+### Feature Flags {/*feature-flags*/}
 
 To keep the main branch in a releasable state, breaking changes and experimental features must be gated behind a feature flag.
 
@@ -35,34 +35,34 @@ Feature flags are defined in [`packages/shared/ReactFeatureFlags.js`](https://gi
 
 React’s build system will strip out disabled feature branches before publishing. A continuous integration job runs on every commit to check for changes in bundle size. You can use the change in size as a signal that a feature was gated correctly.
 
-### Bugs
+### Bugs {/*bugs*/}
 
-#### Where to Find Known Issues
+#### Where to Find Known Issues {/*where-to-find-known-issues*/}
 
 We are using [GitHub Issues](https://github.com/facebook/react/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
 
-#### Reporting New Issues
+#### Reporting New Issues {/*reporting-new-issues*/}
 
 The best way to get your bug fixed is to provide a reduced test case. This [JSFiddle template](https://jsfiddle.net/Luktwrdm/) is a great starting point.
 
-#### Security Bugs
+#### Security Bugs {/*security-bugs*/}
 
 Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe disclosure of security bugs. With that in mind, please do not file public issues; go through the process outlined on that page.
 
-### How to Get in Touch
+### How to Get in Touch {/*how-to-get-in-touch*/}
 
 * IRC: [#reactjs on freenode](https://webchat.freenode.net/?channels=reactjs)
 * [Discussion forums](/community/#popular-discussion-forums)
 
 There is also [an active community of React users on the Discord chat platform](https://www.reactiflux.com/) in case you need help with React.
 
-### Proposing a Change
+### Proposing a Change {/*proposing-a-change*/}
 
 If you intend to change the public API, or make any non-trivial changes to the implementation, we recommend [filing an issue](https://github.com/facebook/react/issues/new). This lets us reach an agreement on your proposal before you put significant effort into it.
 
 If you’re only fixing a bug, it’s fine to submit a pull request right away but we still recommend to file an issue detailing what you’re fixing. This is helpful in case we don’t accept that specific fix but want to keep track of the issue
 
-### Your First Pull Request
+### Your First Pull Request {/*your-first-pull-request*/}
 
 Working on your first Pull Request? You can learn how from this free video series:
 
@@ -74,7 +74,7 @@ If you decide to fix an issue, please be sure to check the comment thread in cas
 
 If somebody claims an issue but doesn't follow up for more than two weeks, it's fine to take it over but you should still leave a comment.
 
-### Sending a Pull Request
+### Sending a Pull Request {/*sending-a-pull-request*/}
 
 The core team is monitoring for pull requests. We will review your pull request and either merge it, request changes to it, or close it with an explanation. For API changes we may need to fix our internal uses at Facebook.com, which could cause some delay. We'll do our best to provide updates and feedback throughout the process.
 
@@ -95,13 +95,14 @@ In order to accept your pull request, we need you to submit a CLA. You only need
 
 [**Complete your CLA here**](https://code.facebook.com/cla)
 
-### Contribution Prerequisites
+### Contribution Prerequisites {/*contribution-prerequisites*/}
 
 - You have [Node](https://nodejs.org/) installed at LTS and [Yarn](https://yarnpkg.com/en/) at v1.2.0+
 - You have `gcc` installed or are comfortable installing a compiler if needed. Some of our dependencies may require a compilation step. On OS X, the Xcode Command Line Tools will cover this. On Ubuntu, `apt-get-install build essential` will install the required packages. Similar Commands should work on other Linux distros. Windows will require some additional steps, see the [`node-gyp` installation instructions](https://github.com/nodejs/node-gyp#installation) for details.
 - You are familiar with Git.
 
-### Development Workflow
+### Development Workflow {/*development-workflow*/}
+
 After cloning React, run `yarn` to fetch its dependencies. Then, you can run several commands: 
 - `yarn lint` checks the code style.
 - yarn linc is like `yarn lint` but faster because it only checks files that differ in your branch.
@@ -141,7 +142,7 @@ If some package is still missing (e.g. maybe you use `react-dom/server` in your 
 
 We still require that your pull request contains unit tests for any new functionality. This way we can ensure that we don't break your code in the future.
 
-### Style Guide 
+### Style Guide {/*style-guide*/}
 
 We use an automatic code formatter called [Prettier](https://prettier.io/). Run `yarn prettier` after making any changes to the code.
 
@@ -149,7 +150,7 @@ Then, our linter will catch most issues that may exist in your code. You can che
 
 However, there are still some styles that the linter cannot pick up. If you are unsure about something, looking at [Airbnb's Style Guide](https://github.com/airbnb/javascript) will guide you in the right direction.
 
-### Request for Comments (RFC)
+### Request for Comments (RFC) {/*request-for-comments*/}
 
 Many changes, including bug fixes and documentation improvements can be implemented and reviewed via the normal GitHub pull request workflow.
 
@@ -157,6 +158,6 @@ Some changes though are "substantial", and we ask that these be put through a bi
 
 The "RFC" (request for comments) process is intended to provide a consistent and controlled path for new features to enter the project. You can contribute by visiting the [rfcs repository](https://github.com/reactjs/rfcs).
 
-### License
+### License {/*license*/}
 
 By contributing to React, you agree that your contributions will be Licensed under its MIT License.

--- a/src/content/community/how-to-contribute.md
+++ b/src/content/community/how-to-contribute.md
@@ -1,0 +1,162 @@
+---
+title: How To Contribute
+---
+
+<Intro>
+
+React is one of Facebook's first open source projects that is both under very active development and is also being used to ship code to everybody on [facebook.com](https://www.facebook.com). We're still working out the kinks to make contributing to this project as easy and transparent as possible, but we're not quite there yet. Hopefully this document makes the process for contributing clear and answers some questions that you may have.
+</Intro>
+
+### Code of Conduct {/*code-of-conduct*/}
+
+Facebook has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct, and we expect project participants to adhere to it. Please read [the full text](https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+
+### Open Development {/*open-development*/}
+
+All work on React happens directly on [Github](https://github.com/facebook/react). Both core team members and external contributors send pull requests which go through the same review process.
+
+### Semantic Versioning
+
+React follows [semantic versioning](https://semver.org/). We release patch versions for critical bugfixes, minor versions for new features or non-essential changes, and major versions for any breaking changes. When we make breaking changes, we also introduce deprecation warnings in a minor version so that our users learn about the upcoming changes and migrate their code in advance. Learn more about our commitment to stability and incremental migration in our [versioning policy](https://react.dev/community/versioning-policy).
+
+Every significant change is documented in the [changelog file](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+
+### Branch Organization
+
+Submit all changes directly to the [`main branch`](https://github.com/facebook/react/tree/main). We don’t use separate branches for development or for upcoming releases. We do our best to keep `main` in good shape, with all tests passing.
+
+Code that lands in `main` must be compatible with the latest stable release. It may contain additional features, but no breaking changes. We should be able to release a new minor version from the tip of `main` at any time.
+
+### Feature Flags
+
+To keep the main branch in a releasable state, breaking changes and experimental features must be gated behind a feature flag.
+
+Feature flags are defined in [`packages/shared/ReactFeatureFlags.js`](https://github.com/facebook/react/blob/main/packages/shared/ReactFeatureFlags.js). Some builds of React may enable different sets of feature flags; for example, the React Native build may be configured differently than React DOM. These flags are found in [`packages/shared/forks`](https://github.com/facebook/react/tree/main/packages/shared/forks). Feature flags are statically typed by Flow, so you can run yarn flow to confirm that you’ve updated all the necessary files.
+
+React’s build system will strip out disabled feature branches before publishing. A continuous integration job runs on every commit to check for changes in bundle size. You can use the change in size as a signal that a feature was gated correctly.
+
+### Bugs
+
+#### Where to Find Known Issues
+
+We are using [GitHub Issues](https://github.com/facebook/react/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
+
+#### Reporting New Issues
+
+The best way to get your bug fixed is to provide a reduced test case. This [JSFiddle template](https://jsfiddle.net/Luktwrdm/) is a great starting point.
+
+#### Security Bugs
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe disclosure of security bugs. With that in mind, please do not file public issues; go through the process outlined on that page.
+
+### How to Get in Touch
+
+* IRC: [#reactjs on freenode](https://webchat.freenode.net/?channels=reactjs)
+* [Discussion forums](/community/#popular-discussion-forums)
+
+There is also [an active community of React users on the Discord chat platform](https://www.reactiflux.com/) in case you need help with React.
+
+### Proposing a Change
+
+If you intend to change the public API, or make any non-trivial changes to the implementation, we recommend [filing an issue](https://github.com/facebook/react/issues/new). This lets us reach an agreement on your proposal before you put significant effort into it.
+
+If you’re only fixing a bug, it’s fine to submit a pull request right away but we still recommend to file an issue detailing what you’re fixing. This is helpful in case we don’t accept that specific fix but want to keep track of the issue
+
+### Your First Pull Request
+
+Working on your first Pull Request? You can learn how from this free video series:
+
+**[How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)**
+
+To help you get your feet wet and get you familiar with our contribution process, we have a list of **[good first issues](https://github.com/facebook/react/issues?q=is:open+is:issue+label:"good+first+issue")** that contain bugs that have a relatively limited scope. This is a great place to get started.
+
+If you decide to fix an issue, please be sure to check the comment thread in case somebody is already working on a fix. If nobody is working on it at the moment, please leave a comment stating that you intend to work on it so other people don't accidentally duplicate your effort.
+
+If somebody claims an issue but doesn't follow up for more than two weeks, it's fine to take it over but you should still leave a comment.
+
+### Sending a Pull Request
+
+The core team is monitoring for pull requests. We will review your pull request and either merge it, request changes to it, or close it with an explanation. For API changes we may need to fix our internal uses at Facebook.com, which could cause some delay. We'll do our best to provide updates and feedback throughout the process.
+
+**Before submitting a pull request,** please make sure the following is done:
+1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
+2. Run `yarn` in the repository root.
+3. If you've fixed a bug or added a code that should be tested, add tests!
+4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName`, is helpful in development.
+5. Run `yarn test --prod` to test in the production environment.
+6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
+7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
+8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
+9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
+10. If you haven't already, complete the CLA.
+
+
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you’ve done this for another Facebook open source project, you’re good to go. If you are submitting a pull request for the first time, just let us know that you have completed the CLA and we can cross-check with your GitHub username.
+
+[**Complete your CLA here**](https://code.facebook.com/cla)
+
+### Contribution Prerequisites
+
+- You have [Node](https://nodejs.org/) installed at LTS and [Yarn](https://yarnpkg.com/en/) at v1.2.0+
+- You have `gcc` installed or are comfortable installing a compiler if needed. Some of our dependencies may require a compilation step. On OS X, the Xcode Command Line Tools will cover this. On Ubuntu, `apt-get-install build essential` will install the required packages. Similar Commands should work on other Linux distros. Windows will require some additional steps, see the [`node-gyp` installation instructions](https://github.com/nodejs/node-gyp#installation) for details.
+- You are familiar with Git.
+
+### Development Workflow
+After cloning React, run `yarn` to fetch its dependencies. Then, you can run several commands: 
+- `yarn lint` checks the code style.
+- yarn linc is like `yarn lint` but faster because it only checks files that differ in your branch.
+- `yarn test` runs the complete test suite.
+- `yarn test --watch` runs an interactive test watcher.
+- `yarn test --prod` runs tests in the production environment.
+- `yarn test <patter>` runs tests with matching filenames.
+- `yarn debug-test` is just like `yarn test` but with a debugger. Open `chrome://inspect` and press "Inspect".
+- `yarn flow` runs the [`Flow`](https://flowtype.org/) typechecks.
+- `yarn build` creates a `build` folder with all the packages.
+- `yarn build react/index,react-dom/index --type=UMD` creates UMD builds of just React and ReactDOM.
+
+We recommend running `yarn test` (or its variations above) to make sure you don’t introduce any regressions as you work on your change. However, it can be handy to try your build of React in a real project.
+
+First, run `yarn build`. This will produce pre-built bundles in `build` folder, as well as prepare npm packages inside `build/packages`.
+
+The easiest way to try your changes is to run `yarn build react/index,react-dom/index --type=UMD` and then open `fixtures/packaging/babel-standalone/dev.html`. This file aready uses `react.development.js` from the `build` folder so it will pick up your changes.
+
+If your project uses React from npm, you may delete `react` and `react-dom` in its dependencies and use `yarn link` to point them to your local `build` folder. Note that **instead of --type=UMD you’ll want to pass --type=NODE when building**. You’ll also need to build the scheduler package:
+```sh
+cd ~/path_to_your_react_clone/
+yarn build build react/index,react/jsx,react-dom/index,scheduler --type=NODE
+
+cd build/node_modules/react
+yarn link 
+cd build/node_modules/react-dom
+yarn link 
+
+cd ~/path/to/your/project
+yarn link react react-dom
+
+```
+
+Every time you run `yarn build` in the React folder, the updated versions will appear in your project's `node_modules`. You can then rebuild your project to try your changes.
+
+If some package is still missing (e.g. maybe you use `react-dom/server` in your project), you can always do a full build with `yarn build`. Note that running `yarn build` without options takes a long time.
+
+We still require that your pull request contains unit tests for any new functionality. This way we can ensure that we don't break your code in the future.
+
+### Style Guide 
+
+We use an automatic code formatter called [Prettier](https://prettier.io/). Run `yarn prettier` after making any changes to the code.
+
+Then, our linter will catch most issues that may exist in your code. You can check the status of your code styling by simply running `yarn linc`.
+
+However, there are still some styles that the linter cannot pick up. If you are unsure about something, looking at [Airbnb's Style Guide](https://github.com/airbnb/javascript) will guide you in the right direction.
+
+### Request for Comments (RFC)
+
+Many changes, including bug fixes and documentation improvements can be implemented and reviewed via the normal GitHub pull request workflow.
+
+Some changes though are "substantial", and we ask that these be put through a bit of a design process and produce a consensus among the React core team.
+
+The "RFC" (request for comments) process is intended to provide a consistent and controlled path for new features to enter the project. You can contribute by visiting the [rfcs repository](https://github.com/reactjs/rfcs).
+
+### License
+
+By contributing to React, you agree that your contributions will be Licensed under its MIT License.

--- a/src/sidebarCommunity.json
+++ b/src/sidebarCommunity.json
@@ -12,6 +12,14 @@
       "skipBreadcrumb": true,
       "routes": [
         {
+          "title": "Contributing",
+          "path": "/community/contributing-guidelines"
+        },
+        {
+          "title": "How To Contribute",
+          "path": "/community/how-to-contribute"
+        },
+        {
           "title": "React Conferences",
           "path": "/community/conferences"
         },


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Added `Contribution guidelines` and `How To Contribute`. The contents of the docs is written with reference to the [Legacy ReactJS Docs](https://legacy.reactjs.org/) and the [React.dev Repo](https://github.com/reactjs/react.dev/tree/main).  

1) Added the new contents to the sidebar in the community tab
![image](https://github.com/reactjs/react.dev/assets/83471520/e9767537-13ef-4e40-869d-9e32b958c57a)

2) Added the contents of Contributing Guidelines (Ref: [React.dev Repo's `CONTRIBUTING.md`](https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md#guidelines-for-text)) 
![image](https://github.com/reactjs/react.dev/assets/83471520/92aa6f08-26f9-4986-bab0-9a6281053956)

3) Added a "How To Contribute" doc with reference to the [Legacy React JS docs](https://legacy.reactjs.org/docs/how-to-contribute.html)
![image](https://github.com/reactjs/react.dev/assets/83471520/34893008-c686-4f68-8fe5-1a6ec7aeccc1)
