### PR TITLE
doc(cloneElement): fix example log

### DIFF
--- a/src/content/reference/react/cloneElement.md
+++ b/src/content/reference/react/cloneElement.md
@@ -40,7 +40,7 @@ const clonedElement = cloneElement(
   'Goodbye'
 );
 
-console.log(clonedElement); // <Row title="Cabbage">Goodbye</Row>
+console.log(clonedElement); // <Row title="Cabbage" isHighlighted >Goodbye</Row>
 ```
 
 [See more examples below.](#usage)


### PR DESCRIPTION
## bug

https://react.dev/reference/react/cloneElement#cloneelement

![Screenshot 2023-07-13 at 15 08 15](https://github.com/reactjs/react.dev/assets/14308293/9a4cec5b-031a-4734-93a3-4b76d1a5e0e9)

missing override props from `{ isHighlighted: true }`