### PR TITLE
chore: Improve readability of function memoisation sentence

### DIFF
--- a/src/content/reference/react/memo.md
+++ b/src/content/reference/react/memo.md
@@ -319,7 +319,7 @@ const CallToAction = memo(function CallToAction({ hasGroups }) {
 });
 ```
 
-When you need to pass a function to memoized component, either declare it outside your component so that it never changes, or [`useCallback`](/reference/react/useCallback#skipping-re-rendering-of-components) to cache its definition between re-renders.
+When you need to pass a function to memoized component, either declare it outside your component so that it never changes, or use [`useCallback`](/reference/react/useCallback#skipping-re-rendering-of-components) to cache its definition between re-renders.
 
 ---
 


### PR DESCRIPTION
PR for improving the readability of a sentence relating to function memoisation in the "Minimizing props changes" section of the `memo` API reference. 

This pull request adds the word "use" in front of `useCallback`. Without this, I don't think the clause really makes sense. The intent is clear, but I noticed this and thought I'd submit a pull request to address it.

### Before

> When you need to pass a function to memoized component, either declare it outside your component so that it never changes, or `useCallback` to cache its definition between re-renders.

### After

> When you need to pass a function to memoized component, either declare it outside your component so that it never changes, or use `useCallback` to cache its definition between re-renders.

Thanks 🙂  