### PR TITLE
chores: remove unused deps and args

### DIFF
--- a/src/content/learn/managing-state.md
+++ b/src/content/learn/managing-state.md
@@ -889,12 +889,14 @@ const initialTasks = [
 ```
 
 ```js AddTask.js
-import { useState, useContext } from 'react';
-import { useTasksDispatch } from './TasksContext.js';
+import { useState } from 'react';
+import { useTasks, useTasksDispatch } from './TasksContext.js';
 
-export default function AddTask({ onAddTask }) {
+export default function AddTask() {
   const [text, setText] = useState('');
   const dispatch = useTasksDispatch();
+  const tasks = useTasks();
+  nextId = tasks.length;
   return (
     <>
       <input
@@ -914,11 +916,11 @@ export default function AddTask({ onAddTask }) {
   );
 }
 
-let nextId = 3;
+let nextId = 0;
 ```
 
 ```js TaskList.js
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { useTasks, useTasksDispatch } from './TasksContext.js';
 
 export default function TaskList() {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

When I am learning this part from [react.dev](https://react.dev/learn/managing-state#scaling-up-with-reducer-and-context), I found some unused imports and args, so I remove them to make it clear.

