### PR TITLE
Fix TerminalBlock overflow

### DIFF
--- a/src/components/MDX/TerminalBlock.tsx
+++ b/src/components/MDX/TerminalBlock.tsx
@@ -70,7 +70,7 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
           </div>
         </div>
       </div>
-      <div className="px-8 pt-4 pb-6 text-primary-dark dark:text-primary-dark font-mono text-code whitespace-pre">
+      <div className="px-8 pt-4 pb-6 text-primary-dark dark:text-primary-dark font-mono text-code whitespace-pre overflow-x-scroll">
         <LevelText type={level} />
         {message}
       </div>


### PR DESCRIPTION
## Before

<img width="402" alt="Screenshot 2023-08-09 at 3 19 39 PM" src="https://github.com/reactjs/react.dev/assets/2440089/8405783c-d4cf-4da5-a812-af54f5c26d1e">

## After

<img width="402" alt="Screenshot 2023-08-09 at 3 19 46 PM" src="https://github.com/reactjs/react.dev/assets/2440089/564a1ba8-9840-48ef-ba28-afea2450ecfd">
