### PR TITLE
Enhanced the sentence's clarity by including the phrase 'an error'.

### DIFF
--- a/src/content/learn/synchronizing-with-effects.md
+++ b/src/content/learn/synchronizing-with-effects.md
@@ -611,7 +611,7 @@ useEffect(() => {
 
 Note that there is no cleanup needed in this case. In development, React will call the Effect twice, but this is not a problem because calling `setZoomLevel` twice with the same value does not do anything. It may be slightly slower, but this doesn't matter because it won't remount needlessly in production.
 
-Some APIs may not allow you to call them twice in a row. For example, the [`showModal`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal) method of the built-in [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) element throws if you call it twice. Implement the cleanup function and make it close the dialog:
+Some APIs may not allow you to call them twice in a row. For example, the [`showModal`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal) method of the built-in [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) element throws an error if you call it twice. Implement the cleanup function and make it close the dialog:
 
 ```js {4}
 useEffect(() => {


### PR DESCRIPTION
The initial sentence lacked clarity. Before modification, it read: "For example, the showModal method of the built-in <dialog> element throws if you call it twice" After revision, it reads as follows: "For example, the showModal method of the built-in <dialog> element throws an error if you call it twice."
