### PR TITLE
In hydrateRoot added timeout for state change

### DIFF
--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -301,7 +301,7 @@ export default function App() {
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
-    setIsClient(true);
+    setTimeout(() => setIsClient(true), 1000);
   }, []);
 
   return (


### PR DESCRIPTION
##Bug Fix

- In hydrateRoot added 1 second timeout for state change
- so that the server renderd isServer text can be seen before the client side changes the text to isClient

fixed   #6190

![ezgif com-video-to-gif](https://github.com/reactjs/react.dev/assets/122166595/c1dc0a83-e18d-4e66-bbc0-26eaebd56677)


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
