### PR TITLE
fixes #6220 scrollbar issue

### DIFF
--- a/src/components/Layout/SidebarNav/SidebarNav.tsx
+++ b/src/components/Layout/SidebarNav/SidebarNav.tsx
@@ -34,7 +34,7 @@ export default function SidebarNav({
         'sticky top-0 lg:bottom-0 lg:h-[calc(100vh-4rem)] flex flex-col'
       )}>
       <div
-        className="overflow-y-scroll no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark"
+        className="overflow-y-scroll lg:w-[330px] grow bg-wash dark:bg-wash-dark"
         style={{
           overscrollBehavior: 'contain',
         }}>


### PR DESCRIPTION
This fixes issue #6220, I think there was an element overlap happening and that was causing the scrollBar in the left navigation to not function on mouse click and drag, just changed the width by 12px and removed the no-bg-scroll class


https://github.com/reactjs/react.dev/assets/24520095/0163fff5-cc88-44b2-98b1-7f0fb02c8629

