### PR TITLE
Fix broken link for Typescript Discord invite

### DIFF
--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -460,4 +460,4 @@ We recommend the following resources:
 
  - [React TypeScript Cheatsheet](https://react-typescript-cheatsheet.netlify.app/) is a community-maintained cheatsheet for using TypeScript with React, covering a lot of useful edge cases and providing more breadth than this document.
 
- - [TypeScript Community Discord](discord.com/invite/typescript) is a great place to ask questions and get help with TypeScript and React issues.
+ - [TypeScript Community Discord](https://discord.com/invite/typescript) is a great place to ask questions and get help with TypeScript and React issues.


### PR DESCRIPTION
This fixes the malfunctioning Discord invite link under "Installation/Using TypeScript".
Previously, the link directed to "https://react.dev/discord.com/invite/typescript", leading to a 'Not Found' error page:
![image](https://github.com/reactjs/react.dev/assets/16272579/c9a32c73-ab82-4cea-9381-f2a7518bb345)

With the correction:
![image](https://github.com/reactjs/react.dev/assets/16272579/627bda9c-d7f6-4ef2-abd3-5bee4eae2345)