### PR TITLE
Intrust to install `@types/*` packages as devPependencies

### DIFF
--- a/src/content/learn/typescript.md
+++ b/src/content/learn/typescript.md
@@ -32,7 +32,7 @@ All [production-grade React frameworks](https://react-dev-git-fork-orta-typescri
 To install the latest version of React's type definitions:
 
 <TerminalBlock>
-npm install @types/react @types/react-dom
+npm install @types/react @types/react-dom --save-dev
 </TerminalBlock>
 
 The following compiler options need to be set in your `tsconfig.json`:


### PR DESCRIPTION
It is likely that people will want to install `@types/react` and `@types/react-dom` as `devDependencies`.

If we document this without using `--save-dev`, we might confuse developers who aren't yet proficient in TypeScript or dependency management, leading them to install it as a production dependency - which is probably unnecessary and suboptimal.