### PR TITLE
Remove "robots=noindex" meta tag to allow translated pages in search results

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -26,14 +26,6 @@ const deployedTranslations = [
   // It must be the same between all translations.
 ];
 
-let shouldPreventIndexing = false;
-if (
-  siteConfig.languageCode !== 'en' &&
-  !deployedTranslations.includes(siteConfig.languageCode)
-) {
-  shouldPreventIndexing = true;
-}
-
 function getDomain(languageCode: string): string {
   const subdomain = languageCode === 'en' ? '' : languageCode + '.';
   return subdomain + 'react.dev';
@@ -69,7 +61,6 @@ export const Seo = withRouter(
           href={canonicalUrl.replace(siteDomain, getDomain('en'))}
           hrefLang="x-default"
         />
-        {shouldPreventIndexing && <meta name="robots" content="noindex" />}
         {deployedTranslations.map((languageCode) => (
           <link
             key={'alt-' + languageCode}


### PR DESCRIPTION
Currently, the translated content of each language version of the docs is set to explicitly opt-out from web crawlers until almost all of the site's translation are completed. The relevant code is as follows:

https://github.com/reactjs/react.dev/blob/3189529259e89240a88c05680849ce4a8c454ed2/src/components/Seo.tsx#L20-L35

https://github.com/reactjs/react.dev/blob/3189529259e89240a88c05680849ce4a8c454ed2/src/components/Seo.tsx#L72

Due to this, except for very few languages whose translation has been completed (currently only 2), most language versions are still not displayed in Google search results. They are still not linked from react.dev, either, so it's extremely hard to find the new translated site.

We have been translating the docs into Japanese for several months, but the results are still almost "invisible" on the web. Sadly, from what I can see on Twitter, many Japanese React users still believe that the effort to translate react.dev into Japanese hasn't even started!

Even if fewer than 10 articles have been translated, those articles *are* translated, and there is no need to hide them. If someone searches for "React useEffect" and there is a translated reference for it, they should be able to view it. After all, it's Google's job to evaluate the value of each page; there's no need for us to intentionally specify "robot=noindex".

What's worse, because of this "noindex", when you search for "React" in Japan (either with Google or Bing), the legacy Japanese version still happily comes at the top:

![image](https://github.com/reactjs/react.dev/assets/7779406/5920e924-901b-4262-b184-20bed45a9ec4)

According to @gaearon's comment [here](https://github.com/reactjs/react.dev/issues/4135#issuecomment-1487947111), the React team would rather have the latest content rank higher than the legacy Japanese content. However, Google's algorithm doesn't think so; it believes that the legacy Japanese site is more useful for average Japanese developers (which I must agree). Removing the meta tag will help the latest content appear near the top even if it's not translated yet.

For example, if you search for "React useEffect" in Japan, [the official legacy page](https://ja.legacy.reactjs.org/docs/hooks-effect.html) still comes at the top, followed by many unofficial articles. The [latest official reference (in English)](https://react.dev/reference/react/useEffect) is only ranked at the 11th position. [The Japanese translated version](https://ja.react.dev/reference/react/useEffect) has been published for more than 3 months, but it's nowhere to be found in the search results. Likewise, if you search for "React tutorial" in Japan, the [class-based legacy official tutorial](https://ja.legacy.reactjs.org/tutorial/tutorial.html) is still at the top, and the latest tutorial is at the 37th position because it's only available in English.