### PR TITLE
Fix pluralization issue in Counter component

### DIFF
--- a/src/content/blog/2023/03/16/introducing-react-dev.md
+++ b/src/content/blog/2023/03/16/introducing-react-dev.md
@@ -488,7 +488,7 @@ export default function Counter() {
 
   return (
     <button onClick={handleClick}>
-      You pressed me {count} times
+      You pressed me {count} {count === 1? "time":"times"}
     </button>
   );
 }


### PR DESCRIPTION
**Hey there**,

I've made a small fix to the Counter component in the react.dev site blog. The issue was related to the pluralization of the word "times" in the button text. When the count is 1, it should display "time" instead of "times".

Here's the changed code snippet:

`import { useState } from 'react';

export default function Counter() {
  const [count, setCount] = useState(0);

  function handleClick() {
    setCount(count + 1);
  }

  return (
    <button onClick={handleClick}>
      You pressed me {count} {count === 1 ? 'time' : 'times'}
    </button>
  );
}
`
This small modification ensures that the button text displays the correct singular or plural form based on the count value. Please review and merge this pull request if everything looks good.

Thanks!
Maneth