### PR TITLE
fixed a typo from queueing to queuing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 
+# yarn
+.yarn
+.yarnrc.yml
+
 # vercel
 .vercel
 

--- a/src/content/learn/queueing-a-series-of-state-updates.md
+++ b/src/content/learn/queueing-a-series-of-state-updates.md
@@ -1,10 +1,10 @@
 ---
-title: Queueing a Series of State Updates
+title: queuing a Series of State Updates
 ---
 
 <Intro>
 
-Setting a state variable will queue another render. But sometimes you might want to perform multiple operations on the value before queueing the next render. To do this, it helps to understand how React batches state updates.
+Setting a state variable will queue another render. But sometimes you might want to perform multiple operations on the value before queuing the next render. To do this, it helps to understand how React batches state updates.
 
 </Intro>
 


### PR DESCRIPTION

fixes #6272 
It is fixing a typo in documentation, where there is a use of a word _queueing_ , but now in english it is mostly used and writen as _queuing_

Initial there was something like this:
![Screenshot from 2023-09-04 13-48-06](https://github.com/reactjs/react.dev/assets/105695160/e54e1cae-3f72-470e-b847-def1e61477d7)

after correcting the spelling, it is like this:
![Screenshot from 2023-09-04 13-47-51](https://github.com/reactjs/react.dev/assets/105695160/f9444b35-dd72-4a01-b94a-210216079e84)

