### PR TITLE
chore: log heading missing url error on dev only

### DIFF
--- a/src/components/Layout/Toc.tsx
+++ b/src/components/Layout/Toc.tsx
@@ -27,8 +27,7 @@ export function Toc({headings}: {headings: Toc}) {
         <ul className="space-y-2 pb-16">
           {headings.length > 0 &&
             headings.map((h, i) => {
-              if (h.url == null) {
-                // TODO: only log in DEV
+              if (!h.url && process.env.NODE_ENV === 'development') {
                 console.error('Heading does not have URL');
               }
               return (


### PR DESCRIPTION
### Summary
This Pull Request modifies the `Toc.tsx` component to log errors for missing URLs only when the application is running in the development environment.

### Changes
- Replaced the previous check for missing `url` in the `Toc` component.
- Added a conditional to log the error message only when `NODE_ENV` is set to `'development'`.

### Background
Before this change, the `Toc.tsx` component would log an error whenever a heading was missing a URL, regardless of the environment in which the application was running.

### Purpose
This PR cleans up a TODO we had in place in this codebase.

### How to Test
1. Set your `NODE_ENV` to `'development'`.
2. Run the application.
3. Observe that the console logs an error if a heading lacks a URL.
4. Set your `NODE_ENV` to `'production'`.
5. Run the application again.
6. Verify that the console does not log any errors for missing URLs in headings.

Please review and let me know if any changes are required. Thank you!