### PR TITLE
Fix flushSync.md grammar

### DIFF
--- a/src/content/reference/react-dom/flushSync.md
+++ b/src/content/reference/react-dom/flushSync.md
@@ -89,14 +89,14 @@ import { flushSync } from 'react-dom';
 
 export default function PrintApp() {
   const [isPrinting, setIsPrinting] = useState(false);
-  
+
   useEffect(() => {
     function handleBeforePrint() {
       flushSync(() => {
         setIsPrinting(true);
       })
     }
-    
+
     function handleAfterPrint() {
       setIsPrinting(false);
     }
@@ -108,7 +108,7 @@ export default function PrintApp() {
       window.removeEventListener('afterprint', handleAfterPrint);
     }
   }, []);
-  
+
   return (
     <>
       <h1>isPrinting: {isPrinting ? 'yes' : 'no'}</h1>
@@ -122,7 +122,7 @@ export default function PrintApp() {
 
 </Sandpack>
 
-Without `flushSync`, when the print dialog will display `isPrinting` as "no". This is because React batches the updates asynchronously and the print dialog is displayed before the state is updated.
+Without `flushSync`, the print dialog will display `isPrinting` as "no". This is because React batches the updates asynchronously and the print dialog is displayed before the state is updated.
 
 <Pitfall>
 


### PR DESCRIPTION
https://react-qj27nl57y-fbopensource.vercel.app/reference/react-dom/flushSync

Before:

<img width="1512" alt="Screenshot 2023-09-05 at 7 20 26 PM" src="https://github.com/reactjs/react.dev/assets/88391760/0167517d-008c-4e51-9927-223405fc8109">

After:

<img width="1512" alt="Screenshot 2023-09-05 at 7 20 00 PM" src="https://github.com/reactjs/react.dev/assets/88391760/15bce894-c7c8-494e-84ab-8d2e4d64b35a">
