### PR TITLE
Update tutorial-tic-tac-toe.md added import statement for react

### DIFF
--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -330,7 +330,7 @@ Click on the file labeled `styles.css` in the _Files_ section of CodeSandbox. Th
 Click on the file labeled `index.js` in the _Files_ section of CodeSandbox. You won't be editing this file during the tutorial but it is the bridge between the component you created in the `App.js` file and the web browser.
 
 ```jsx
-import { StrictMode } from 'react';
+import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles.css';
 


### PR DESCRIPTION
I encountered an error in my React application that said: "Line 2: 'React' must be in scope when using JSX."

To resolve this issue, I made sure to import React at the beginning of my JavaScript file, along with StrictMode.

