### PR TITLE
Update 'optimizing re-renders' section

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -1339,6 +1339,61 @@ function MyApp() {
 
 As a result of this change, even if `MyApp` needs to re-render, the components calling `useContext(AuthContext)` won't need to re-render unless `currentUser` has changed.
 
+Note that although <CodeStep step={2}>context value</CodeStep> doesn't change, when `MyApp` re-renders, React still re-renders all of its children. To skip re-rendering of a child component, you must wrap it with `memo`.
+
+<Sandpack>
+
+```js
+import { createContext, memo, useContext, useState, useCallback, useMemo } from 'react';
+
+const AuthContext = createContext(null);
+
+export default function MyApp() {
+  console.log("MyApp was rendered at ", new Date().toLocaleTimeString());
+  const [currentUser, setCurrentUser] = useState(null);
+
+  const login = useCallback((response) => {
+    setCurrentUser(response.user);
+  }, []);
+
+  const contextValue = useMemo(() => ({
+    currentUser,
+    login
+  }), [currentUser, login]);
+
+  const [unrelatedState, setUnrelatedState] = useState(false);
+  const toggleUnrelatedState = () => setUnrelatedState(state => !state);
+
+  return (
+    <AuthContext.Provider value={contextValue}>
+      <WithoutMemo />
+      <WithMemo />
+      <button onClick={toggleUnrelatedState}>Re-render MyApp</button>
+    </AuthContext.Provider>
+  );
+}
+
+const WithoutMemo = () => {
+  console.log("WithoutMemo was rendered at ", new Date().toLocaleTimeString());
+  const contextValue = useContext(AuthContext);
+  return (
+    <h3>Without Memo</h3>
+  );
+};
+
+const WithMemo = memo(() => {
+  console.log("WithMemo was rendered at ", new Date().toLocaleTimeString());
+  const contextValue = useContext(AuthContext);
+  return (
+    <h3>With Memo</h3>
+  );
+});
+```
+
+</Sandpack>
+
+In the example above, clicking the button will cause `MyApp` to re-render. The child component without `memo` re-renders, while the other one doesn't. You can check the console to see details.
+
 Read more about [`useMemo`](/reference/react/useMemo#skipping-re-rendering-of-components) and [`useCallback`.](/reference/react/useCallback#skipping-re-rendering-of-components)
 
 ---


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React awesome!
Please see the Contribution Guide for guidelines:
https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md
If your PR references an existing issue, please add the issue number below
-->

Just adding some minor changes. I hope it can help.
I see that the doc already mention skipping re-rendering in 'memo', 'useCallback', 'useMemo'. But in this section of 'useContext', the explanation stops at memoizing the context value and say that the children will not re-render, without warning the developer that if a parent component re-renders, its children will be re-render even if props and context value are the same.
So I think we should mention the use of 'memo' here. I know, experienced developers can clearly see the problem. But for a novice developer starting to learn React, it can be a bit misleading.
If there are anything I should improve, please let me know. Thanks.