### PR TITLE
Add `useFormStatus` Hook API reference documentation

### DIFF
--- a/src/content/reference/react-dom/hooks/index.md
+++ b/src/content/reference/react-dom/hooks/index.md
@@ -20,7 +20,7 @@ Form Hooks are currently only available in React's canary and experimental chann
 
 *Forms* let you create interactive controls for submitting information.  To manage forms in your components, use one of these Hooks:
 
-* [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) allows you to make updates the UI based on the status of a form.
+* [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) allows you to make updates to the UI based on the status of the a form.
 * `useFormState` allows you to manage state inside a form.
 
 ```js

--- a/src/content/reference/react-dom/hooks/index.md
+++ b/src/content/reference/react-dom/hooks/index.md
@@ -1,0 +1,48 @@
+---
+title: "React DOM Hooks"
+---
+
+<Intro>
+
+The `react-dom` package contains Hooks that are only supported for web applications (which run in the browser DOM environment). These Hooks are not supported in non-browser environments like iOS, Android, or Windows applications. If you are looking for Hooks that are supported in web browsers *and other environments* see [the React Hooks page](/reference/react). This page lists all the Hooks in the `react-dom` packakge.
+
+</Intro>
+
+---
+
+## Form Hooks {/*form-hooks*/}
+
+<Canary>
+
+Form Hooks are currently only available in React's canary and experimental channels. Learn more about [React's release channels here](/community/versioning-policy#all-release-channels).
+
+</Canary>
+
+*Forms* let you create interactive controls for submitting information.  To manage forms in your components, use one of these Hooks:
+
+* [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) allows you to make updates the UI based on the status of a form.
+* `useFormState` allows you to manage state inside a form.
+
+```js
+function Form({ action }) {
+  async function increment(n) {
+    return n + 1;
+  }
+  const [count, incrementFormAction] = useFormState(increment, 0);
+  return (
+    <form action={action}>
+      <button formAction={incrementFormAction}>Count: {count}</button>
+      <Button />
+    </form>
+  );
+}
+
+function Button() {
+  const { pending } = useFormStatus();
+  return (
+    <button disabled={pending} type="submit">
+      Submit
+    </button>
+  );
+}
+```

--- a/src/content/reference/react-dom/hooks/useFormStatus.md
+++ b/src/content/reference/react-dom/hooks/useFormStatus.md
@@ -29,7 +29,7 @@ const { pending, data, method, action } = useFormStatus();
 
 The `useFormStatus` Hook provides status information of the last form submission.
 
-```js [[1, 5, "status.pending"]]
+```js {4},[[1, 5, "status.pending"]]
 import action from './actions';
 
 function Submit() {
@@ -61,11 +61,13 @@ In the above example, `Submit` uses this information to disable `<button>` press
 A `status` object with the following properties:
 
 * `pending`: A boolean. If `true`, this means the parent `<form>` is pending submission. Otherwise, `false`.
-* `data`: An object implementing the [`FormData interface`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) that contains the data the parent `<form>` is submitting. `null` if there is no active submission or no parent `<form>`.
-* `method`: A string value of either `'get'` or `'post'`. This represents whether the parent `<form>` is submitting with either `GET` or `POST` [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods). By default, a `<form>` will use `GET` method and can be specified by the [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attributes_for_form_submission) property.
+
+* `data`: An object implementing the [`FormData interface`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) that contains the data the parent `<form>` is submitting. If there is no active submission or no parent `<form>`, it will be `null`.
+
+* `method`: A string value of either `'get'` or `'post'`. This represents whether the parent `<form>` is submitting with either a `GET` or `POST` [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods). By default, a `<form>` will use the `GET` method and can be specified by the [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method) property.
 
 [//]: # (Link to `<form>` documentation. "Read more on the `action` prop on `<form>`.")
-* `action`: A reference to the function passed to the `action` prop on the parent `<form>` which is called during submission. If `action` is unset on `<form>` or there is no parent `<form>`, the property is `null`.
+* `action`: A reference to the function passed to the `action` prop on the parent `<form>`. If there is no parent `<form>`, the property is `null`. If there is a URI value provided to the `action` prop, or no `action` prop specified, `status.action` will be `null`.
 
 #### Caveats {/*caveats*/}
 
@@ -138,8 +140,8 @@ The `useFormStatus` Hook only returns status information for a parent `<form>` a
 function Form() {
   // 🚩 `pending` will never be true
   // useFormStatus does not track the form rendered in this component
-  const { pending } = useFormStatus() 
-  return <form action={submit}></form>
+  const { pending } = useFormStatus();
+  return <form action={submit}></form>;
 }
 ```
 
@@ -147,10 +149,9 @@ Instead call `useFormStatus` from inside a component that is located inside `<fo
 
 ```js
 function Submit() {
-    // ✅ `pending` will be derived from the 
-    // form that wraps the Submit component
-    const { pending } = useFormStatus() 
-    return <button disabled={pending}>...</button>
+  // ✅ `pending` will be derived from the form that wraps the Submit component
+  const { pending } = useFormStatus(); 
+  return <button disabled={pending}>...</button>;
 }
 
 function Form() {
@@ -254,6 +255,6 @@ export async function submitForm(query) {
 
 `useFormStatus` will only return status information for a parent `<form>`. 
 
-If the component that calls `useFormStatus` is not nested in a `<form>`, the returned `status` object will always return `false` for the `pending` property. 
+If the component that calls `useFormStatus` is not nested in a `<form>`, `status.pending` will always return `false`. Verify `useFormStatus` is called in a component that is a child of a `<form>` element.
 
 `useFormStatus` will not track the status of a `<form>` rendered in the same component. See [Pitfall](#useformstatus-will-not-return-status-information-for-a-form-rendered-in-the-same-component) for more details.

--- a/src/content/reference/react-dom/hooks/useFormStatus.md
+++ b/src/content/reference/react-dom/hooks/useFormStatus.md
@@ -32,7 +32,7 @@ The `useFormStatus` Hook provides status information of the last form submission
 ```js [[1, 5, "status.pending"]]
 import action from './actions';
 
-function Button() {
+function Submit() {
   const status = useFormStatus();
   return <button disabled={status.pending}>Submit</button>
 }
@@ -40,15 +40,15 @@ function Button() {
 export default App() {
   return (
     <form action={action}>
-      <Button />
+      <Submit />
     </form>
   );
 }
 ```
 
-To get status information, the `Button` component must be rendered within a `<form>`. The Hook returns information like the <CodeStep step={1}>`pending`</CodeStep> property which tells you if the form is actively submitting. 
+To get status information, the `Submit` component must be rendered within a `<form>`. The Hook returns information like the <CodeStep step={1}>`pending`</CodeStep> property which tells you if the form is actively submitting. 
 
-In the above example, `Button` uses this information to disable `<button>` presses while the form is submitting.
+In the above example, `Submit` uses this information to disable `<button>` presses while the form is submitting.
 
 [See more examples below.](#usage)
 
@@ -87,7 +87,7 @@ Here, we use the `pending` property to indicate the form is submitting.
 import { useFormStatus } from "react-dom";
 import { submitForm } from "./actions.js";
 
-function Button() {
+function Submit() {
   const { pending } = useFormStatus();
   return (
     <button type="submit" disabled={pending}>
@@ -99,7 +99,7 @@ function Button() {
 function Form({ action }) {
   return (
     <form action={action}>
-      <Button />
+      <Submit />
     </form>
   );
 }
@@ -146,9 +146,9 @@ function Form() {
 Instead call `useFormStatus` from inside a component that is located inside `<form>`.
 
 ```js
-function Button() {
+function Submit() {
     // ✅ `pending` will be derived from the 
-    // form that wraps the Button component
+    // form that wraps the Submit component
     const { pending } = useFormStatus() 
     return <button disabled={pending}>...</button>
 }
@@ -157,7 +157,7 @@ function Form() {
   // This is the <form> `useFormStatus` tracks
   return (
     <form action={submit}>
-      <Button />
+      <Submit />
     </form>
   );
 }

--- a/src/content/reference/react-dom/hooks/useFormStatus.md
+++ b/src/content/reference/react-dom/hooks/useFormStatus.md
@@ -1,0 +1,166 @@
+---
+title: useFormStatus
+canary: true
+---
+
+<Canary>
+
+The `useFormStatus` Hook is currently only available in React's canary and experimental channels. Learn more about [React's release channels here](/community/versioning-policy#all-release-channels).
+
+</Canary>
+
+<Intro>
+
+`useFormStatus` is a Hook that allows you to make updates to the UI based on the status of a form.
+
+```js
+const { pending } = useFormStatus();
+```
+
+</Intro>
+
+<InlineToc />
+
+---
+
+## Reference {/*reference*/}
+
+### `useFormStatus()` {/*usformstatus*/}
+
+
+Call `useFormStatus` at the top level of your component to subscribe to the status of the form that wraps your component.
+
+```js
+function Button() {
+  const { pending } = useFormStatus();
+  return <button disabled={pending}>Submit</button>
+}
+```
+
+The `useFormStatus` Hook provides information on the form's status, like when the form is pending. The `pending` property indicates whether the form is currently in the process of being submitted. You can use this property to update the UI while the form is being submitted like disabling form submission buttons or the wording in your UI.
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+`useFormStatus` does not take any parameters.
+
+#### Returns {/*returns*/}
+
+* `pending`: A boolean. If true, the form wrapping the Component calling `useFormStatus` is pending submission.
+
+#### Caveats {/*caveats*/}
+
+* The `useFormStatus` Hook must be called from a Component that is located inside `<form>`. You cannot call `useFormStatus` from the same Component that returns `<form>`.
+
+---
+
+## Usage {/*usage*/}
+
+### Display a pending state during form submission {/*display-a-pending-state-during-form-submission*/}
+To display a pending state while a form is submitting, call the `useFormStatus` Hook at the top level of a component that is wraped in the form. The `useFormStatus` Hook provides the `pending` property which is `true` when the form is in the process of being submitted and `false` otherwise. You can use this property to disable the submit button when a form is already being submitted. You can also change the text of the UI to indicate the form is submitting, like changing the text of a button from "Submit" to "Submitting".
+
+<Sandpack>
+
+```js App.js
+import { experimental_useFormStatus as useFormStatus } from "react-dom";
+import { submitForm } from "./actions.js";
+
+function Button() {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? "Submitting..." : "Submit"}
+    </button>
+  );
+}
+
+function Form({ action }) {
+  return (
+    <form action={action}>
+      <Button />
+    </form>
+  );
+}
+
+export default function App() {
+  return <Form action={submitForm} />;
+}
+```
+
+```js actions.js hidden
+export async function submitForm(query) {
+    await new Promise((res) => setTimeout(res, 1000));
+}
+```
+
+```json package.json hidden
+{
+  "dependencies": {
+    "react": "experimental",
+    "react-dom": "experimental",
+    "react-scripts": "^5.0.0"
+  },
+  "main": "/index.js",
+  "devDependencies": {}
+}
+```
+</Sandpack>  
+
+<Pitfall>
+
+The `useFormStatus` Hook must be called from a Component that is located inside `<form>`. You cannot call `useFormStatus` from the same Component that returns `<form>`.
+
+```js
+function Form() {
+  const { pending } = useFormStatus() // 🚩 `pending` will never be `true`
+  return <form action={submit}></form>
+}
+```
+
+Instead call `useFormStatus` from inside a Component that is located inside `<form>`.
+
+```js
+function Button(){
+    // ✅ `pending` will be derived from the 
+    // form that wraps the Button Component
+    const { pending } = useFormStatus() 
+    return <button disabled={pending}> //...
+}
+
+function Form() {
+  return <form><Button /></form>
+}
+```
+
+</Pitfall>
+
+---
+
+## Troubleshooting {/*troubleshooting*/}
+
+### `pending` is never `true` {/*pending-is-never-true*/}
+
+The `pending` attribute will always have the value `true` if the `useFormStatus` Hook is called from the same component that returns `<form>`. The `useFormStatus` Hook must be called from a Component that is located inside `<form>`. You cannot call `useFormStatus` from the same Component that returns `<form>`.
+
+```js
+function Form() {
+  const { pending } = useFormStatus() // 🚩 `pending` will never be `true`
+  return <form action={submit}> //...
+}
+```
+
+Instead call `useFormStatus` from inside a Component that is located inside `<form>`.
+
+```js
+function Button(){
+    // ✅ `pending` will be derived from the 
+    // form that wraps the Button Component
+    const { pending } = useFormStatus() 
+    return <button disabled={pending}> //...
+}
+
+function Form() {
+  return <form><Button /></form>
+}
+```

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -152,6 +152,17 @@
       "sectionHeader": "react-dom@18.2.0"
     },
     {
+      "title": "Hooks",
+      "path": "/reference/react-dom/hooks",
+      "routes": [
+        {
+          "title": "useFormStatus",
+          "path": "/reference/react-dom/hooks/useFormStatus",
+          "canary": true
+        }
+      ]
+    },
+    {
       "title": "Components",
       "path": "/reference/react-dom/components",
       "routes": [


### PR DESCRIPTION
Add initial reference documentation for the `useFormStatus` Hook

Preview: https://react-dev-git-useformstatus-fbopensource.vercel.app/reference/react-dom/hooks/useFormStatus