### PR TITLE
Side bar nav fixed "fixed #3171"

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -120,7 +120,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
       <div
         className={cn(
           hasColumns &&
-            'grid grid-cols-only-content lg:grid-cols-sidebar-content 2xl:grid-cols-sidebar-content-toc'
+            'grid grid-cols-only-content lg:grid-cols-sidebar-content gap-3 2xl:grid-cols-sidebar-content-toc'
         )}>
         {showSidebar && (
           <div className="lg:-mt-16">


### PR DESCRIPTION
gap-3 was added as sidebar-nav and the content was overlapping and due to that scroll bar was not working when scroll with a mouse click

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
