### PR TITLE
Added margin between main heading on 404 and 500 pages to ease reading.

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -13,7 +13,7 @@ export default function NotFound() {
     <Page toc={[]} meta={{title: 'Not Found'}} routeTree={sidebarLearn}>
       <MaxWidth>
         <Intro>
-          <P>This page doesn’t exist.</P>
+          <P className="mt-8">This page doesn’t exist.</P>
           <P>
             If this is a mistake{', '}
             <A href="https://github.com/reactjs/react.dev/issues/new">

--- a/src/pages/500.js
+++ b/src/pages/500.js
@@ -16,7 +16,7 @@ export default function NotFound() {
       meta={{title: 'Something Went Wrong'}}>
       <MaxWidth>
         <Intro>
-          <P>Something went very wrong.</P>
+          <P className="mt-8">Something went very wrong.</P>
           <P>Sorry about that.</P>
           <P>
             If you’d like, please{' '}


### PR DESCRIPTION
I am new to this so I don't expect that my edits were correct but I think that this styling update, while small, makes the 404 and 500 pages a little easier on the eyes. I added a slight amount of margin from the page title and the paragraph below it to give it a little more separation to make it an easier transition when reading. I noticed that the P tags were aliases from the MDXComponents so I made the changes directly on the 404 and 500 pages so I didn't alter every P tag used across the site. 

Not sure where the best place was to make those adjustments but I am open to any feedback.

![old_404](https://github.com/reactjs/react.dev/assets/18154577/02ae548d-46cf-4e1d-a051-f06352c295e4)
![new_404](https://github.com/reactjs/react.dev/assets/18154577/1efafc17-d715-4d6c-9213-bb0728a26bc3)
