### PR TITLE
Add code mark for refs on forwardRef page

### DIFF
--- a/src/content/reference/react/forwardRef.md
+++ b/src/content/reference/react/forwardRef.md
@@ -20,7 +20,7 @@ const SomeComponent = forwardRef(render)
 
 ### `forwardRef(render)` {/*forwardref*/}
 
-Call `forwardRef()` to let your component receive a ref and forward it to a child component:
+Call `forwardRef()` to let your component receive a `ref` and forward it to a child component:
 
 ```js
 import { forwardRef } from 'react';
@@ -131,15 +131,15 @@ function Form() {
 }
 ```
 
-This `Form` component [passes a ref](/reference/react/useRef#manipulating-the-dom-with-a-ref) to `MyInput`. The `MyInput` component *forwards* that ref to the `<input>` browser tag. As a result, the `Form` component can access that `<input>` DOM node and call [`focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) on it.
+This `Form` component [passes a ref](/reference/react/useRef#manipulating-the-dom-with-a-ref) to `MyInput`. The `MyInput` component *forwards* that `ref` to the `<input>` browser tag. As a result, the `Form` component can access that `<input>` DOM node and call [`focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) on it.
 
-Keep in mind that exposing a ref to the DOM node inside your component makes it harder to change your component's internals later. You will typically expose DOM nodes from reusable low-level components like buttons or text inputs, but you won't do it for application-level components like an avatar or a comment.
+Keep in mind that exposing a `ref` to the DOM node inside your component makes it harder to change your component's internals later. You will typically expose DOM nodes from reusable low-level components like buttons or text inputs, but you won't do it for application-level components like an avatar or a comment.
 
 <Recipes titleText="Examples of forwarding a ref">
 
 #### Focusing a text input {/*focusing-a-text-input*/}
 
-Clicking the button will focus the input. The `Form` component defines a ref and passes it to the `MyInput` component. The `MyInput` component forwards that ref to the browser `<input>`. This lets the `Form` component focus the `<input>`.
+Clicking the button will focus the input. The `Form` component defines a `ref` and passes it to the `MyInput` component. The `MyInput` component forwards that `ref` to the browser `<input>`. This lets the `Form` component focus the `<input>`.
 
 <Sandpack>
 
@@ -193,7 +193,7 @@ input {
 
 #### Playing and pausing a video {/*playing-and-pausing-a-video*/}
 
-Clicking the button will call [`play()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and [`pause()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause) on a `<video>` DOM node. The `App` component defines a ref and passes it to the `MyVideoPlayer` component. The `MyVideoPlayer` component forwards that ref to the browser `<video>` node. This lets the `App` component play and pause the `<video>`.
+Clicking the button will call [`play()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and [`pause()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause) on a `<video>` DOM node. The `App` component defines a `ref` and passes it to the `MyVideoPlayer` component. The `MyVideoPlayer` component forwards that `ref` to the browser `<video>` node. This lets the `App` component play and pause the `<video>`.
 
 <Sandpack>
 
@@ -252,7 +252,7 @@ button { margin-bottom: 10px; margin-right: 10px; }
 
 ---
 
-### Forwarding a ref through multiple components {/*forwarding-a-ref-through-multiple-components*/}
+### Forwarding a `ref` through multiple components {/*forwarding-a-ref-through-multiple-components*/}
 
 Instead of forwarding a `ref` to a DOM node, you can forward it to your own component like `MyInput`:
 
@@ -268,7 +268,7 @@ const FormField = forwardRef(function FormField(props, ref) {
 });
 ```
 
-If that `MyInput` component forwards a ref to its `<input>`, a ref to `FormField` will give you that `<input>`:
+If that `MyInput` component forwards a `ref` to its `<input>`, a `ref` to `FormField` will give you that `<input>`:
 
 ```js {2,5,10}
 function Form() {
@@ -289,7 +289,7 @@ function Form() {
 }
 ```
 
-The `Form` component defines a ref and passes it to `FormField`. The `FormField` component forwards that ref to `MyInput`, which forwards it to a browser `<input>` DOM node. This is how `Form` accesses that DOM node.
+The `Form` component defines a `ref` and passes it to `FormField`. The `FormField` component forwards that `ref` to `MyInput`, which forwards it to a browser `<input>` DOM node. This is how `Form` accesses that DOM node.
 
 
 <Sandpack>
@@ -369,7 +369,7 @@ input, button {
 
 ### Exposing an imperative handle instead of a DOM node {/*exposing-an-imperative-handle-instead-of-a-dom-node*/}
 
-Instead of exposing an entire DOM node, you can expose a custom object, called an *imperative handle,* with a more constrained set of methods. To do this, you'd need to define a separate ref to hold the DOM node:
+Instead of exposing an entire DOM node, you can expose a custom object, called an *imperative handle,* with a more constrained set of methods. To do this, you'd need to define a separate `ref` to hold the DOM node:
 
 ```js {2,6}
 const MyInput = forwardRef(function MyInput(props, ref) {
@@ -404,7 +404,7 @@ const MyInput = forwardRef(function MyInput(props, ref) {
 });
 ```
 
-If some component gets a ref to `MyInput`, it will only receive your `{ focus, scrollIntoView }` object instead of the DOM node. This lets you limit the information you expose about your DOM node to the minimum.
+If some component gets a `ref` to `MyInput`, it will only receive your `{ focus, scrollIntoView }` object instead of the DOM node. This lets you limit the information you expose about your DOM node to the minimum.
 
 <Sandpack>
 
@@ -520,7 +520,7 @@ const MyInput = forwardRef(function MyInput({ label, showInput }, ref) {
 });
 ```
 
-If `showInput` is `false`, then the ref won't be forwarded to any node, and a ref to `MyInput` will remain empty. This is particularly easy to miss if the condition is hidden inside another component, like `Panel` in this example:
+If `showInput` is `false`, then the `ref` won't be forwarded to any node, and a `ref` to `MyInput` will remain empty. This is particularly easy to miss if the condition is hidden inside another component, like `Panel` in this example:
 
 ```js {5,7}
 const MyInput = forwardRef(function MyInput({ label, showInput }, ref) {


### PR DESCRIPTION
I don't know if it is a issue, but I found some inconsistency on `ref` word when it is mentioned on forwardRef page

### Page: https://react.dev/reference/react/forwardRef 


### Example

#### Before 
![image](https://github.com/reactjs/react.dev/assets/38632174/ecb72926-1199-4d6b-802b-97c8400f75d0)


#### After
![image](https://github.com/reactjs/react.dev/assets/38632174/6dcaa535-f496-4e5c-ae0c-e1d9df2fa0b6)


