### PR TITLE
Add Experimental Taint API Docs

### DIFF
--- a/src/content/reference/react/experimental_taintObjectReference.md
+++ b/src/content/reference/react/experimental_taintObjectReference.md
@@ -1,0 +1,125 @@
+---
+title: experimental_taintObjectReference
+---
+
+<Wip>
+
+**This API is experimental and is not available in a stable version of React yet.**
+
+You can try it by upgrading React packages to the most recent experimental version:
+
+- `react@experimental`
+- `react-dom@experimental`
+- `eslint-plugin-react-hooks@experimental`
+
+Experimental versions of React may contain bugs. Don't use them in production.
+
+This API is only available inside React Server Components.
+
+</Wip>
+
+
+<Intro>
+
+`taintObjectReference` lets you prevent a passing a specific object instance to a Client Component by mistake.
+
+```js
+experimental_taintObjectReference(message, object);
+```
+
+To prevent passing a crypto key, hash or token, see [`taintUniqueValue`](/reference/react/experimental_taintUniqueValue).
+
+</Intro>
+
+<InlineToc />
+
+---
+
+## Reference {/*reference*/}
+
+### `taintObjectReference(message, object)` {/*taintobjectreference*/}
+
+Call `taintObjectReference` with an object to register it with React as something that should not be allowed to be passed to the Client as is:
+
+```js
+import {experimental_taintObjectReference} from 'react';
+
+experimental_taintObjectReference(
+  'Do not pass ALL environment variables to the client.',
+  process.env
+);
+```
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+* `message`: The message you want to display if the object gets passed to a Client Component. It's logged as any other Error that is thrown.
+
+* `object`: Any kind of object that should be tainted. You can pass functions and class instances here too. They're already blocked from being passed to Client Components but this lets you customize the error message. You can also taint a specific instance of a Typed Array without tainting the value in other Typed Array copies.
+
+#### Returns {/*returns*/}
+
+`experimental_taintObjectReference` returns `undefined`.
+
+---
+
+## Usage {/*usage*/}
+
+If you're running a Server Components that has access to sensitive data, you have to be careful not to pass objects straight through:
+
+```js
+export async function getUser(id) {
+  const user = await db`SELECT * FROM users WHERE id = ${id}`;
+  return user;
+}
+```
+
+```js
+import { getUser } from '...';
+import { InfoCard } from '...';
+
+export async function Profile(props) {
+  const user = await getUser(props.userId);
+  // DO NOT DO THIS
+  return <InfoCard user={user} />;
+}
+```
+
+```js
+"use client";
+
+export async function InfoCard({ user }) {
+  return <div>{user.name}</div>;
+}
+```
+
+A `"use client"` component should never accept objects that might be carrying sensitive data. Ideally, the getUser helper should not expose data that the current user can't see. Sometimes mistakes happen during refactoring.
+
+To protect against this mistakes happening down the line we can "taint" the user object in our data API.
+
+```js
+import {experimental_taintObjectReference} from 'react';
+
+export async function getUser(id) {
+  const user = await db`SELECT * FROM users WHERE id = ${id}`;
+  experimental_taintObjectReference(
+    'Do not pass the entire user object to the client. ' +
+      'Instead, pick off the specific properties you need for this use case.',
+    user,
+  );
+  return user;
+}
+```
+
+Now whenever anyone tries to pass this object to a Client Component, or bound to a Server Action, it'll error with the passed in error message instead.
+
+<Pitfall>
+
+**Do not rely on just tainting for security.** You should design your data access APIs and access to private keys in an isolated way such that you don't easily leak it into the Component rendering in the first place. Tainting is opt-in and easy to forget.
+
+Tainting provides an extra layer of protection if someone on your team still makes a mistake but it's not intended as the primary solution.
+
+Tainting an object doesn't prevent leaking of every possible derived value. For example, `const userInfo = {name: user.name, ssn: user.ssn}` create a new object which is not tainted. Creating a new object by just cloning it means it's no longer tainted `{...object}`. It only protects against simple mistakes when the object is passed straight through unchanged.
+
+</Pitfall>

--- a/src/content/reference/react/experimental_taintObjectReference.md
+++ b/src/content/reference/react/experimental_taintObjectReference.md
@@ -66,7 +66,7 @@ experimental_taintObjectReference(
 
 ## Usage {/*usage*/}
 
-If you're running a Server Components that has access to sensitive data, you have to be careful not to pass objects straight through:
+If you're running a Server Components environment that has access to sensitive data, you have to be careful not to pass objects straight through:
 
 ```js
 export async function getUser(id) {

--- a/src/content/reference/react/experimental_taintObjectReference.md
+++ b/src/content/reference/react/experimental_taintObjectReference.md
@@ -37,7 +37,7 @@ To prevent passing a key, hash or token, see [`taintUniqueValue`](/reference/rea
 
 ## Reference {/*reference*/}
 
-### `taintObjectReference(errMessage, object)` {/*taintobjectreference*/}
+### `taintObjectReference(message, object)` {/*taintobjectreference*/}
 
 Call `taintObjectReference` with an object to register it with React as something that should not be allowed to be passed to the Client as is:
 
@@ -54,9 +54,9 @@ experimental_taintObjectReference(
 
 #### Parameters {/*parameters*/}
 
-* `errMessage`: The message you want to display if the object gets passed to a Client Component. This message will the be contents of an Error that will be thrown if the object gets passed to a Client Component.
+* `message`: The message you want to display if the object gets passed to a Client Component. This message will be displayed as a part of the Error that will be thrown if the object gets passed to a Client Component.
 
-* `object`: The object to be tainted.
+* `object`: The object to be tainted. Functions and class instances can be passed to `taintObjectReference` as `object`. Functions and classes are already blocked from being passed to Client Components but the React's default error message will be replaced by what you defined in `message`. When a specific instance of a Typed Array is passed to `taintObjectReference` as `object`, any other copies of the Typed Array will not be tainted.
 
 #### Returns {/*returns*/}
 
@@ -64,9 +64,7 @@ experimental_taintObjectReference(
 
 #### Caveats {/*caveats*/}
 
-- Recreating or cloning a tainting object creates a new untained object which main contain sensetive data. For example, if you have a tainted `user` object, `const userInfo = {name: user.name, ssn: user.ssn}` or `{...user}` will create new objects which are not tainted.  `taintObjectReference` only protects against simple mistakes when the object is passed through to a Client Component unchanged.
-- Functions and class instances can be passed to `taintObjectReference` as `object`. Functions and classes are already blocked from being passed to Client Components but the React's default error message will be replaced by what you defined in `errMessage`. 
-- If you taint a specific instances of a Typed Array any other copies of the Typed Array will not be tainted.
+- Recreating or cloning a tainted object creates a new untained object which main contain sensetive data. For example, if you have a tainted `user` object, `const userInfo = {name: user.name, ssn: user.ssn}` or `{...user}` will create new objects which are not tainted. `taintObjectReference` only protects against simple mistakes when the object is passed through to a Client Component unchanged.
 
 <Pitfall>
 

--- a/src/content/reference/react/experimental_taintUniqueValue.md
+++ b/src/content/reference/react/experimental_taintUniqueValue.md
@@ -69,7 +69,7 @@ experimental_taintUniqueValue(
 
 ## Usage {/*usage*/}
 
-If you're running a Server Components that has access to private keys or passwords such as database passwords, you have to be careful not to pass that to a Client Component.
+If you're running a Server Components environment that has access to private keys or passwords such as database passwords, you have to be careful not to pass that to a Client Component.
 
 ```js
 export async function Dashboard(props) {

--- a/src/content/reference/react/experimental_taintUniqueValue.md
+++ b/src/content/reference/react/experimental_taintUniqueValue.md
@@ -1,0 +1,162 @@
+---
+title: experimental_taintUniqueValue
+---
+
+<Wip>
+
+**This API is experimental and is not available in a stable version of React yet.**
+
+You can try it by upgrading React packages to the most recent experimental version:
+
+- `react@experimental`
+- `react-dom@experimental`
+- `eslint-plugin-react-hooks@experimental`
+
+Experimental versions of React may contain bugs. Don't use them in production.
+
+This API is only available inside React Server Components.
+
+</Wip>
+
+
+<Intro>
+
+`taintUniqueValue` lets you prevent a passing a password, crypto graphic key or token, as a string, bigint or typed array, to a Client Component. It blocks this string completely so it cannot be a value that's also used in other contexts. It needs to be unique.
+
+```js
+taintUniqueValue(message, lifetime, value)
+```
+
+To prevent passing an object containing sensitive data, see [`taintObjectReference`](/reference/react/experimental_taintObjectReference).
+
+</Intro>
+
+<InlineToc />
+
+---
+
+## Reference {/*reference*/}
+
+### `taintUniqueValue(message, lifetime, value)` {/*taintuniquevalue*/}
+
+Call `taintUniqueValue` with a password, token, key or hash to register it with React as something that should not be allowed to be passed to the Client as is:
+
+```js
+import {experimental_taintUniqueValue} from 'react';
+
+experimental_taintUniqueValue(
+  'Do not pass super secret keys to the client.',
+  process,
+  process.env.SUPER_SECRET_KEY
+);
+```
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+* `message`: The message you want to display if the object gets passed to a Client Component. It's logged as any other Error that is thrown.
+
+* `lifetime`: Any object that indicates how long to block it. The value remains blocked as long as this object is still around. For example, passing `globalThis` blocks the value for the life time of an app. Typically it would an object whose properties contains the value.
+
+* `value`: A string, bigint or TypedArray. This value must be a unique sequence of characters/bytes with high entropy such as a cryptographic token, private key, hash or a long password. This value gets banned for passing to any Client Component in the whole app.
+
+#### Returns {/*returns*/}
+
+`experimental_taintUniqueValue` returns `undefined`.
+
+---
+
+## Usage {/*usage*/}
+
+If you're running a Server Components that has access to private keys or passwords such as database passwords, you have to be careful not to pass that to a Client Component.
+
+```js
+export async function Dashboard(props) {
+  // DO NOT DO THIS
+  return <Overview password={process.env.API_PASSWORD} />;
+}
+```
+
+```js
+"use client";
+
+import {useEffect} from '...'
+
+export async function Overview({ password }) {
+  useEffect(() => {
+    const headers = { Authorization: password };
+    fetch(url, { headers }).then(...);
+  }, [password]);
+  ...
+}
+```
+
+This example would leak the secret API token to the client. If this API token can be used to access data this particular user shouldn't have access to, it's a security problem.
+
+Ideally, secrets like this are abstracted into a single helper file that can only be imported by trusted data utilities on the server. The helper can even be tagged with `server-only` to ensure that this file isn't imported on the client.
+
+```js
+import "server-only";
+
+export function fetchAPI(url) {
+  const headers = { Authorization: process.env.API_PASSWORD };
+  return fetch(url, { headers });
+}
+```
+
+Sometimes mistakes happen during refactoring and not all of your colleagues might know about this. 
+To protect against this mistakes happening down the line we can "taint" the actual password:
+
+```js
+import "server-only";
+import {experimental_taintUniqueValue} from 'react';
+
+experimental_taintUniqueValue(
+  'Do not pass the API token password to the client. ' +
+    'Instead do all fetches on the server.'
+  process,
+  process.env.API_PASSWORD
+);
+```
+
+Now whenever anyone tries to pass this password to a Client Component, or bound to a Server Action, it'll error with the passed in error message instead.
+
+#### Lifetime {/*lifetime*/}
+
+Whenever we taint a value, we need to provide a lifetime argument to define how long the value should be tainted. Otherwise, it might just grow indefinitely in memory until you run out of memory. In many cases, such as the examples above, this is just fine. We can pass an object that lives forever such as `globalThis` or `process` for this use case.
+
+If we're tainting a value that just lives for one request or for the lifetime of some cached object, or if we don't know how long it'll be kept around, we need to provide a different object.
+
+Typically this would be the object that ends up getting passed around and cached.
+
+```js
+import {experimental_taintUniqueValue} from 'react';
+
+export async function getUser(id) {
+  const user = await db`SELECT * FROM users WHERE id = ${id}`;
+  experimental_taintUniqueValue(
+    'Do not pass a user session token to the client.',
+    user,
+    user.session.token,
+  );
+  return user;
+}
+```
+
+This ensures that if this `user` object gets stored in some global store, and another request can read from it, the token is still tainted. If it gets cleaned up then we don't end up leaking memory.
+
+If the lifetime object gets GC:ed during an on-going request, React will still keep the value tainted for the duration of this request.
+
+
+<Pitfall>
+
+**Do not rely on just tainting for security.** You should design your data access APIs and access to private keys in an isolated way such that you don't easily leak it into the Component rendering in the first place. Tainting is opt-in and easy to forget.
+
+Tainting provides an extra layer of protection if someone on your team still makes a mistake but it's not intended as the primary solution.
+
+Tainting a value doesn't block every possible derived value. For example, converting it to upper case, concatenating it into a larger string, converting it to base64, returning a substring etc, will still be allowed. It only protects against simple mistakes like passing it straight through.
+
+If you cache the value in a global store outside of React, without the corresponding lifetime object, the value will be untainted eventually.
+
+</Pitfall>

--- a/src/content/reference/react/experimental_taintUniqueValue.md
+++ b/src/content/reference/react/experimental_taintUniqueValue.md
@@ -55,7 +55,7 @@ experimental_taintUniqueValue(
 
 #### Parameters {/*parameters*/}
 
-* `errMessage`: The message you want to display if the object gets passed to a Client Component. If `value` is passed to a Client Component an Error will be thrown. `errMessage` let's you define the message displayed by this Error.
+* `message`: The message you want to display if `value` is passed to a Client Component. This message will be displayed as a part of the Error that will be thrown if `value` is passed to a Client Component.
 
 * `lifetime`: Any object that indicates how long `value` should be tainted. `value` will be blocked from being sent to any Client Component while this object still exists. For example, passing `globalThis` blocks the value for the lifetime of an app. `lifetime` is typically an object whose properties contains `value`.
 
@@ -67,7 +67,7 @@ experimental_taintUniqueValue(
 
 #### Caveats {/*caveats*/}
 
-- Modifying tainted values can invalidate tainting protection. Converting tainted values to upper case, concatenating tainted string values into a larger string, converting tainted values to base64, returning a substring, and similar transformations will lose tainting protection.
+- Deriving new values from tainted values can compromise tainting protection. New values created by uppercasing tainted values, concatenating tainted string values into a larger string, converting tainted values to base64, substringing tainted values, and other similar transformations are not tainted unless you explicity call `taintUniqueValue` on these newly created values.
 
 <Pitfall>
 

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -113,6 +113,14 @@
           "path": "/reference/react/createContext"
         },
         {
+          "title": "experimental_taintObjectReference",
+          "path": "/reference/react/experimental_taintObjectReference"
+        },
+        {
+          "title": "experimental_taintUniqueValue",
+          "path": "/reference/react/experimental_taintUniqueValue"
+        },
+        {
           "title": "forwardRef",
           "path": "/reference/react/forwardRef"
         },

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -113,14 +113,6 @@
           "path": "/reference/react/createContext"
         },
         {
-          "title": "experimental_taintObjectReference",
-          "path": "/reference/react/experimental_taintObjectReference"
-        },
-        {
-          "title": "experimental_taintUniqueValue",
-          "path": "/reference/react/experimental_taintUniqueValue"
-        },
-        {
           "title": "forwardRef",
           "path": "/reference/react/forwardRef"
         },
@@ -135,6 +127,14 @@
         {
           "title": "startTransition",
           "path": "/reference/react/startTransition"
+        },
+        {
+          "title": "experimental_taintObjectReference",
+          "path": "/reference/react/experimental_taintObjectReference"
+        },
+        {
+          "title": "experimental_taintUniqueValue",
+          "path": "/reference/react/experimental_taintUniqueValue"
         }
       ]
     },


### PR DESCRIPTION
These are still experimental. I haven't linked to them from anywhere yet.

Previews:
* [taintUniqueValue](https://react-dev-git-fork-sebmarkbage-taintapis-fbopensource.vercel.app/reference/react/experimental_taintUniqueValue)
* [taintObjectReference](https://react-dev-git-fork-sebmarkbage-taintapis-fbopensource.vercel.app/reference/react/experimental_taintObjectReference)