### PR TITLE
Add default case for useReducer form example

### DIFF
--- a/src/content/reference/react/useReducer.md
+++ b/src/content/reference/react/useReducer.md
@@ -273,8 +273,10 @@ function reducer(state, action) {
         age: state.age
       };
     }
+    default: {
+      throw Error('Unknown action: ' + action.type);
+    }
   }
-  throw Error('Unknown action: ' + action.type);
 }
 
 const initialState = { name: 'Taylor', age: 42 };


### PR DESCRIPTION
The current example's reducer function doesn't have a default case, so I thought I'd add one and put the error throwing inside it. :)