### PR TITLE
Update Google Anaytics 4 tag on react.dev

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -9,6 +9,15 @@ const MyDocument = () => {
   return (
     <Html lang={siteConfig.languageCode}>
       <Head />
+      <script
+        async
+        src={`https://www.googletagmanager.com/gtag/js?id=${siteConfig.googleAnalyticsTagId}`}
+      />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '${siteConfig.googleAnalyticsTagId}');`,
+        }}
+      />
       <body className="font-text font-medium antialiased text-lg bg-wash dark:bg-wash-dark text-secondary dark:text-secondary-dark leading-base">
         <script
           dangerouslySetInnerHTML={{

--- a/src/siteConfig.js
+++ b/src/siteConfig.js
@@ -16,4 +16,5 @@ exports.siteConfig = {
     apiKey: 'e8451218980a351815563de007648b00',
     indexName: 'beta-react',
   },
+  googleAnalyticsTagId: 'G-B1E83PJ3RT',
 };


### PR DESCRIPTION
This PR adds the GA4 tag to our react.dev site.

Note that the GA4 dashboard is already setup, but the script wasn't added to populate the data. This PR adds it in following Google's installation steps. 

<img width="1218" alt="Screenshot 2023-10-12 at 5 21 50 PM" src="https://github.com/reactjs/react.dev/assets/20743223/32c1a0fc-c838-4c7a-b893-f922244caa69">

## Test plan
- `yarn check-all` passes
- Verified site visually looks ok
- Viewed page source and verified script is there
<img width="927" alt="Screenshot 2023-10-12 at 5 27 20 PM" src="https://github.com/reactjs/react.dev/assets/20743223/10be2b5d-4f87-48e4-8d6e-afc4ff807179">


- Verified the window.dataLayer has the correct config

<img width="559" alt="Screenshot 2023-10-12 at 5 08 54 PM" src="https://github.com/reactjs/react.dev/assets/20743223/e693c278-e5b6-4e54-a326-b34491284bbd">

