### PR TITLE
Add 'ja' to deployedTranslations

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -22,6 +22,7 @@ const deployedTranslations = [
   'zh-hans',
   'es',
   'fr',
+  'ja',
   // We'll add more languages when they have enough content.
   // Please DO NOT edit this list without a discussion in the reactjs/react.dev repo.
   // It must be the same between all translations.


### PR DESCRIPTION
The core translations of https://ja.react.dev/ (Japanese) is now complete, so this PR adds 'ja' to the `deployedTranslations` list.