### PR TITLE
fix showing of feedback container when submitted

### DIFF
--- a/src/components/Layout/Feedback.tsx
+++ b/src/components/Layout/Feedback.tsx
@@ -2,15 +2,41 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useRouter} from 'next/router';
 import {ga} from '../../utils/analytics';
 
-export function Feedback({onSubmit = () => {}}: {onSubmit?: () => void}) {
+export function Feedback({onSubmit}: {onSubmit?: () => void}) {
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [showFeedback, setShowFeedback] = useState(true);
   const {asPath} = useRouter();
+
   const cleanedPath = asPath.split(/[\?\#]/)[0];
+
+  function handleSubmit() {
+    onSubmit?.();
+    setIsSubmitted(true);
+
+    setTimeout(() => {
+      setShowFeedback(false);
+    }, 2000);
+  }
+
+  useEffect(() => {
+    setIsSubmitted((prev) => !prev);
+    setShowFeedback((prev) => !prev);
+  }, [cleanedPath]);
+
   // Reset on route changes.
-  return <SendFeedback key={cleanedPath} onSubmit={onSubmit} />;
+  return (
+    showFeedback && (
+      <SendFeedback
+        key={cleanedPath}
+        handleSubmit={handleSubmit}
+        isSubmitted={isSubmitted}
+      />
+    )
+  );
 }
 
 const thumbsUpIcon = (
@@ -58,11 +84,18 @@ function sendGAEvent(isPositive: boolean) {
   );
 }
 
-function SendFeedback({onSubmit}: {onSubmit: () => void}) {
-  const [isSubmitted, setIsSubmitted] = useState(false);
+function SendFeedback({
+  handleSubmit,
+  isSubmitted,
+}: {
+  handleSubmit: () => void;
+  isSubmitted: boolean;
+}) {
   return (
     <div className="max-w-xs w-80 lg:w-auto py-3 shadow-lg rounded-lg m-4 bg-wash dark:bg-gray-95 px-4 flex">
-      <p className="w-full font-bold text-primary dark:text-primary-dark text-lg me-4">
+      <p
+        className="w-full font-bold text-primary dark:text-primary-dark text-lg me-4"
+        key={+isSubmitted}>
         {isSubmitted ? 'Thank you for your feedback!' : 'Is this page useful?'}
       </p>
       {!isSubmitted && (
@@ -70,8 +103,7 @@ function SendFeedback({onSubmit}: {onSubmit: () => void}) {
           aria-label="Yes"
           className="bg-secondary-button dark:bg-secondary-button-dark rounded-lg text-primary dark:text-primary-dark px-3 me-2"
           onClick={() => {
-            setIsSubmitted(true);
-            onSubmit();
+            handleSubmit();
             sendGAEvent(true);
           }}>
           {thumbsUpIcon}
@@ -82,8 +114,7 @@ function SendFeedback({onSubmit}: {onSubmit: () => void}) {
           aria-label="No"
           className="bg-secondary-button dark:bg-secondary-button-dark rounded-lg text-primary dark:text-primary-dark px-3"
           onClick={() => {
-            setIsSubmitted(true);
-            onSubmit();
+            handleSubmit();
             sendGAEvent(false);
           }}>
           {thumbsDownIcon}


### PR DESCRIPTION
What's the problem here?

- After a user submits feedback, the feedback container remains persistent and does not disappear.
- If a user provides feedback for a specific page and then revisits that page, the feedback container reappears, prompting for feedback again.

This PR will solve the above two issues.

