### PR TITLE
Fix: Common components typo in example event handler, `onScroll` → `onWheel` 

### DIFF
--- a/src/content/reference/react-dom/components/common.md
+++ b/src/content/reference/react-dom/components/common.md
@@ -694,7 +694,7 @@ An event handler type for the `onWheel` event.
 
 ```js
 <div
-  onScroll={e => console.log('onScroll')}
+  onWheel={e => console.log('onWheel')}
 />
 ```
 


### PR DESCRIPTION
Very small typo fix visible here:
<img width="930" alt="Screenshot 2023-10-20 at 12 35 00 PM" src="https://github.com/reactjs/react.dev/assets/951011/f1e1cabf-0ce0-4956-b9a7-b524785a0545">
