### PR TITLE
refac: Search component type improvements

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
+import {DocSearchProps} from '@docsearch/react';
 import Head from 'next/head';
 import Link from 'next/link';
 import Router from 'next/router';
@@ -20,8 +21,10 @@ export interface SearchProps {
   onClose: () => void;
 }
 
-function Hit({hit, children}: any) {
-  return <Link href={hit.url.replace()}>{children}</Link>;
+type HitProps = Parameters<NonNullable<DocSearchProps['hitComponent']>>[0];
+
+function Hit({hit, children}: HitProps) {
+  return <Link href={hit.url}>{children}</Link>;
 }
 
 // Copy-pasted from @docsearch/react to avoid importing the whole bundle.


### PR DESCRIPTION
Improved the type of `Hit` type in the Search component.

Instead of being of type `any`, it is now of type `props` of the actual `hitComponent` of `DocSearchProps`. 
https://github.com/algolia/docsearch/blob/main/packages/docsearch-react/src/DocSearch.tsx#L26
```ts
export interface DocSearchProps {
    // ...
    hitComponent?(props: {
        hit: InternalDocSearchHit | StoredDocSearchHit;
        children: React.ReactNode;
    }): JSX.Element;
}
```

<br />

The type of `url` is `string`.
https://github.com/algolia/docsearch/blob/main/packages/docsearch-react/src/types/DocSearchHit.ts#L45
```ts
export declare type DocSearchHit = {
    // ...
    url: string;
};
```

`hit.url.replace()`, `hit.url` will return the same result. However, `replace()` throws a type error because it actually needs to take `2 arguments`, so only hit.url is sufficient.

```ts
interface String {
  // ...
  replace(searchValue: { [Symbol.replace](string: string, replaceValue: string): string; }, replaceValue: string): string;
}

```

<img width="745" alt="스크린샷 2023-10-23 오후 10 56 27" src="https://github.com/reactjs/react.dev/assets/64779472/e8ddcd01-d3a4-4b46-bea8-11eb561eb40b">
