### PR TITLE
Using strict equality in the JS example for City Quiz

### DIFF
--- a/src/content/learn/reacting-to-input-with-state.md
+++ b/src/content/learn/reacting-to-input-with-state.md
@@ -84,7 +84,7 @@ function submitForm(answer) {
   // Pretend it's hitting the network.
   return new Promise((resolve, reject) => {
     setTimeout(() => {
-      if (answer.toLowerCase() == 'istanbul') {
+      if (answer.toLowerCase() === 'istanbul') {
         resolve();
       } else {
         reject(new Error('Good guess but a wrong answer. Try again!'));


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
**Description:**

This PR addresses the issue where the quiz answer is verified using loose equality. You can find this in the very first sandbox example used (City Quiz) in the "Learn React" -> "Managing State" -> "Reacting to Input with State" section of the documentation.

![image](https://github.com/reactjs/react.dev/assets/128571356/9082c782-b6e4-4ecb-9918-8cf9923d7cdb)

**Review:**

The updated code uses the strict equality operator (===) for comparison.

**Overall Assessment:**

Based on the review, the use of the strict equality operator is a good practice in JavaScript and should be implemented in the code. However, please address the checklist items and any comments before this PR can be approved.