### PR TITLE
fix: moved lastCategory assignment inside the if condition for efficiency and logic

### DIFF
--- a/src/content/learn/thinking-in-react.md
+++ b/src/content/learn/thinking-in-react.md
@@ -117,13 +117,13 @@ function ProductTable({ products }) {
           category={product.category}
           key={product.category} />
       );
+      lastCategory = product.category;
     }
     rows.push(
       <ProductRow
         product={product}
         key={product.name} />
     );
-    lastCategory = product.category;
   });
 
   return (
@@ -364,13 +364,13 @@ function ProductTable({ products, filterText, inStockOnly }) {
           category={product.category}
           key={product.category} />
       );
+      lastCategory = product.category;
     }
     rows.push(
       <ProductRow
         product={product}
         key={product.name} />
     );
-    lastCategory = product.category;
   });
 
   return (
@@ -563,13 +563,13 @@ function ProductTable({ products, filterText, inStockOnly }) {
           category={product.category}
           key={product.category} />
       );
+      lastCategory = product.category;
     }
     rows.push(
       <ProductRow
         product={product}
         key={product.name} />
     );
-    lastCategory = product.category;
   });
 
   return (


### PR DESCRIPTION
In `thinking-in-react` moved `lastCategory = product.category` inside the `if (product.category !== lastCategory)` condition which is more efficient and logical. This ensures that `lastCategory` is only updated when a new category is encountered, which is precisely the condition under which you want to update it.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->