### PR TITLE
Remove meta description from most pages

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -36,7 +36,6 @@ function getDomain(languageCode: string): string {
 export const Seo = withRouter(
   ({
     title,
-    description = 'The library for web and native user interfaces',
     image = '/images/og-default.png',
     router,
     children,
@@ -50,11 +49,15 @@ export const Seo = withRouter(
     const pageTitle = isHomePage ? title : title + ' – React';
     // Twitter's meta parser is not very good.
     const twitterTitle = pageTitle.replace(/[<>]/g, '');
+    let description = isHomePage
+      ? 'React is the library for web and native user interfaces. Build user interfaces out of individual pieces called components written in JavaScript. React is designed to let you seamlessly combine components written by independent people, teams, and organizations.'
+      : 'The library for web and native user interfaces';
     return (
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         {title != null && <title key="title">{pageTitle}</title>}
-        {description != null && (
+        {isHomePage && (
+          // Let Google figure out a good description for each page.
           <meta name="description" key="description" content={description} />
         )}
         <link rel="canonical" href={canonicalUrl} />


### PR DESCRIPTION
Google uses this on many of our API doc pages and it's not a good snippet. Only put this on the homepage but leave the og:description and twitter:description.
