### PR TITLE
Fix missing closing </p> tag in Form component

### DIFF
--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -632,7 +632,7 @@ class Form extends Component {
     return (
       <>
         <input value={this.state.name} onChange={this.handleNameChange} />
-        <p>Hello, {this.state.name}.
+        <p>Hello, {this.state.name}.</p>
       </>
     );
   }


### PR DESCRIPTION
This PR adds a missing closing tag in Form component in setState section:
https://react.dev/reference/react/Component#setstate

Before merging this PR:
<img width="607" alt="image" src="https://github.com/reactjs/react.dev/assets/26892904/9e782d33-752e-45bb-af4d-8a22be610172">

After merging this PR:
<img width="602" alt="image" src="https://github.com/reactjs/react.dev/assets/26892904/7cfc1f5c-0b6a-4710-8789-645c55ab1a75">

