### PR TITLE
Fix missing id properties in docs example

### DIFF
--- a/src/content/learn/rendering-lists.md
+++ b/src/content/learn/rendering-lists.md
@@ -113,9 +113,11 @@ const people = [{
   name: 'Mohammad Abdus Salam',
   profession: 'physicist',
 }, {
+  id: 3,
   name: 'Percy Lavon Julian',
   profession: 'chemist',  
 }, {
+  id: 4,
   name: 'Subrahmanyan Chandrasekhar',
   profession: 'astrophysicist',
 }];


### PR DESCRIPTION
The [docs page for rendering lists](https://react.dev/learn/rendering-lists#filtering-arrays-of-items) uses a list of people as example. Where `id` properties are first introduced (i.e. the "data is structured"), two of the objects in the list are missing ids. This might cause confusion to new readers.

The absence of or these two objects appears to be a mistake. Where the list of people is next referenced, all 5 objects have ids. They are not added as an exercise or example anywhere in between.

This change adds those two missing ids. Thanks!

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
