### PR TITLE
Fix incorrect component naming

### DIFF
--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -322,7 +322,7 @@ export default function Search() {
 
 Displaying a form submission error message before the JavaScript bundle loads for progressive enhancement requires that:
 
-1. `<form>` be rendered by a [Server Component](/reference/react/use-client)
+1. `<form>` be rendered by a [Client Component](/reference/react/use-client)
 1. the function passed to the `<form>`'s `action` prop be a [Server Action](/reference/react/use-server)
 1. the `useFormState` Hook be used to display the error message
 


### PR DESCRIPTION
`<form>` must be rendered in a client component, since it uses a hook. This was correct in link href (`use client`) but not in link copy.