### PR TITLE
Fix style in React Reference Overview

### DIFF
--- a/src/content/reference/react/index.md
+++ b/src/content/reference/react/index.md
@@ -3,28 +3,32 @@ title: React Reference Overview
 ---
 
 <Intro>
-This section provides detailed reference documentation for working with React. 
-For an introduction to React, please visit the [Learn](/learn) section. 
+
+This section provides detailed reference documentation for working with React. For an introduction to React, please visit the [Learn](/learn) section.
+
 </Intro>
 
-Our The React reference documentation is broken down into functional subsections: 
+Our The React reference documentation is broken down into functional subsections:
 
 ## React {/*react*/}
-Programmatic React features:  
+
+Programmatic React features:
+
 * [Hooks](/reference/react/hooks) - Use different React features from your components.
 * [Components](/reference/react/components) - Documents built-in components that you can use in your JSX.
-* [APIs](/reference/react/apis) - APIs that are useful for defining components. 
+* [APIs](/reference/react/apis) - APIs that are useful for defining components.
 * [Directives](/reference/react/directives) - Provide instructions to bundlers compatible with React Server Components.
 
 ## React DOM {/*react-dom*/}
-React-dom contains features that are only supported for web applications 
-(which run in the browser DOM environment). This section is broken into the following:
+
+React-dom contains features that are only supported for web applications (which run in the browser DOM environment). This section is broken into the following:
 
 * [Hooks](/reference/react-dom/hooks) - Hooks for web applications which run in the browser DOM environment.
 * [Components](/reference/react-dom/components) - React supports all of the browser built-in HTML and SVG components.
 * [APIs](/reference/react-dom) - The `react-dom` package contains methods supported only in web applications.
-* [Client APIs](/reference/react-dom/client) - The `react-dom/client` APIs let you render React components on the client (in the browser). 
+* [Client APIs](/reference/react-dom/client) - The `react-dom/client` APIs let you render React components on the client (in the browser).
 * [Server APIs](/reference/react-dom/server) - The `react-dom/server` APIs let you render React components to HTML on the server.
 
 ## Legacy APIs {/*legacy-apis*/}
-* [Legacy APIs](/reference/react/legacy) - Exported from the react package, but not recommended for use in newly written code. 
+
+* [Legacy APIs](/reference/react/legacy) - Exported from the `react` package, but not recommended for use in newly written code.


### PR DESCRIPTION
This PR fixes some styling problems with the newly added article "React Reference Overview".

- Removed line breaks that existed in the middle of a paragraph. This might be irrelevant to English speakers, but it presents an issue that cannot be ignored when translating into other languages.
- Added blank lines appropriately to match the styles of other articles.
- Removed whitespaces at the end of some lines.
- Changed lowercase `react` to `` `react` `` (package name).