### PR TITLE
Remove "canary: true" from `useTransition` in Sidebar

### DIFF
--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -82,8 +82,7 @@
         },
         {
           "title": "useTransition",
-          "path": "/reference/react/useTransition",
-          "canary": true
+          "path": "/reference/react/useTransition"
         }
       ]
     },


### PR DESCRIPTION
#6354 added "canary: true" to `useTransition.md` and `sidebarReference.json`, which I assume was a mistake.

One of them was reverted by #6389, but the sidebar still shows the canary icon. This PR fixes this problem.

CC @gaearon