### PR TITLE
Fix feedback gtag value

### DIFF
--- a/src/components/Layout/Feedback.tsx
+++ b/src/components/Layout/Feedback.tsx
@@ -45,13 +45,14 @@ const thumbsDownIcon = (
 );
 
 function sendGAEvent(isPositive: boolean) {
+  const value = isPositive ? 1 : 0;
   // Fragile. Don't change unless you've tested the network payload
   // and verified that the right events actually show up in GA.
   // @ts-ignore
   gtag('event', 'feedback', {
     event_category: 'button',
     event_label: window.location.pathname,
-    value: isPositive ? 1 : 0,
+    value,
   });
 }
 


### PR DESCRIPTION
Feedback event wasn't displaying the parameter value in google analytics. By checking the boolean before passing to gtag fixes it. I've verified we're now seeing param values of the feedback event 'button' in google analytics

![Screenshot 2023-11-06 at 6 23 19 PM](https://github.com/reactjs/react.dev/assets/20743223/097905fe-4836-461b-be53-c501dcee8c8e)
