### PR TITLE
Add space for canary title

### DIFF
--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -77,7 +77,7 @@ export function SidebarLink({
         {title}{' '}
         {canary && (
           <IconCanary
-            title="This feature is available in the latest Canary"
+            title=" - This feature is available in the latest Canary"
             className="ms-2 text-gray-30 dark:text-gray-60 inline-block w-4 h-4 align-[-3px]"
           />
         )}

--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -34,7 +34,7 @@ function PageHeading({
           {title}
           {canary && (
             <IconCanary
-              title="This feature is available in the latest Canary"
+              title=" - This feature is available in the latest Canary"
               className="ms-4 mt-1 text-gray-50 dark:text-gray-40 inline-block w-6 h-6 align-[-1px]"
             />
           )}


### PR DESCRIPTION
Fix the fact that Algolia indices the page titles like this:
![CleanShot 2023-11-06 at 16 14 48@2x](https://github.com/reactjs/react.dev/assets/1309636/d49b8d0a-969a-4c7a-923b-ca61ebcc76dc)

Trying to fix by adding a space and dash for separation