### PR TITLE
docs: Add test scenario to exercise in queueing-a-series-of-state-updates.md

### DIFF
--- a/src/content/learn/queueing-a-series-of-state-updates.md
+++ b/src/content/learn/queueing-a-series-of-state-updates.md
@@ -535,6 +535,12 @@ export default function App() {
       />
       <hr />
       <TestCase
+        baseState={1}
+        queue={[3, 1, 2]}
+        expected={2}
+      />
+      <hr />
+      <TestCase
         baseState={0}
         queue={[
           increment,


### PR DESCRIPTION
I've found a wrong solution through a reduce() operation when solving this exercise as follows:
```javascript
export function getFinalState(baseState, queue) {
  let finalState = queue.reduce((accumulator, currentChange) => {
    if ('function' === typeof currentChange) {
      return currentChange(accumulator);
    } else {
      return baseState + currentChange;
    }
  }, baseState);

  return finalState;
}
```

All tests were passing successfully.
The return statement for queued numbers should've been this instead: `return currentChange;`

This change introduces a new test case to fail in this case :') 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
