### PR TITLE
Fix: incorrect sample code in documentation related to Server action

### DIFF
--- a/src/content/reference/react-dom/hooks/useFormStatus.md
+++ b/src/content/reference/react-dom/hooks/useFormStatus.md
@@ -38,7 +38,7 @@ function Submit() {
   return <button disabled={status.pending}>Submit</button>
 }
 
-export default App() {
+export default function App() {
   return (
     <form action={action}>
       <Submit />

--- a/src/content/reference/react/use-server.md
+++ b/src/content/reference/react/use-server.md
@@ -116,10 +116,12 @@ async function requestUsername(formData) {
 }
 
 export default App() {
-  <form action={requestUsername}>
-    <input type="text" name="username" />
-    <button type="submit">Request</button>
-  </form>
+  return (
+    <form action={requestUsername}>
+      <input type="text" name="username" />
+      <button type="submit">Request</button>
+    </form>
+  )
 }
 ```
 

--- a/src/content/reference/react/use-server.md
+++ b/src/content/reference/react/use-server.md
@@ -115,13 +115,13 @@ async function requestUsername(formData) {
   // ...
 }
 
-export default App() {
+export default function App() {
   return (
     <form action={requestUsername}>
       <input type="text" name="username" />
       <button type="submit">Request</button>
     </form>
-  )
+  );
 }
 ```
 


### PR DESCRIPTION
In these documents, the App function may have forgotten to return JSX.Element and the function statement.

Before | After
-|-
<img width="977" alt="" src="https://github.com/reactjs/react.dev/assets/45055030/14f0da7f-a9ec-4ec0-87ca-a25c2c3b8b6c">|<img width="977" alt="" src="https://github.com/reactjs/react.dev/assets/45055030/80036b21-ef4a-47bd-b706-5d136686e1f8">
