### PR TITLE
Update to CodePen URL

### DIFF
--- a/src/content/learn/installation.md
+++ b/src/content/learn/installation.md
@@ -37,7 +37,7 @@ export default function App() {
 
 You can edit it directly or open it in a new tab by pressing the "Fork" button in the upper right corner.
 
-Most pages in the React documentation contain sandboxes like this. Outside of the React documentation, there are many online sandboxes that support React: for example, [CodeSandbox](https://codesandbox.io/s/new), [StackBlitz](https://stackblitz.com/fork/react), or [CodePen.](https://codepen.io/pen?&editors=0010&layout=left&prefill_data_id=3f4569d1-1b11-4bce-bd46-89090eed5ddb)
+Most pages in the React documentation contain sandboxes like this. Outside of the React documentation, there are many online sandboxes that support React: for example, [CodeSandbox](https://codesandbox.io/s/new), [StackBlitz](https://stackblitz.com/fork/react), or [CodePen.](https://codepen.io/pen?template=QWYVwWN)
 
 ### Try React locally {/*try-react-locally*/}
 


### PR DESCRIPTION
Updating to [CodePen's official documented format](https://blog.codepen.io/documentation/templates/#api) for starting Pens with prefilled content. There is also [a Prefill API](https://blog.codepen.io/documentation/prefill/), but that requires a POST, so this URL format is easier to use. But it does require that there is already an existing Pen that it copies the content out of. The Pen in this PR is [this one](https://codepen.io/chriscoyier/pen/QWYVwWN) owned by me. I can promise I'll never update that Pen, but if you want to go with this approach, you might wanna update the "slug" to a Pen owned by React on CodePen. Let me know there are any questions!  
