### PR TITLE
Bug-fix-UI-Link-Button-#6460

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -82,7 +82,9 @@ function FooterLink({
         <span className="block no-underline text-sm tracking-wide text-secondary dark:text-secondary-dark uppercase font-bold group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
           {type}
         </span>
-        <span className="block text-lg group-hover:underline">{title}</span>
+        <span className="block text-lg group-hover:underline break-all">
+          {title}
+        </span>
       </span>
     </NextLink>
   );


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->


Issue haapening at  https://react.dev/reference/react/startTransition


Issue : Overflow of button link text from parent span box.

Solution : By adding text break-work css property to the link text **span** tag.
![Screenshot from 2023-12-03 00-02-32](https://github.com/reactjs/react.dev/assets/119731754/4ab0af4e-8e86-434f-a66f-763141676210)

Issue : Resolved
