### PR TITLE
Bug-fix-UI-Link-Button-InFooter  #6460

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -82,7 +82,9 @@ function FooterLink({
         <span className="block no-underline text-sm tracking-wide text-secondary dark:text-secondary-dark uppercase font-bold group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
           {type}
         </span>
-        <span className="block text-lg group-hover:underline">{title}</span>
+        <span className="block break-all text-lg group-hover:underline">
+          {title}
+        </span>
       </span>
     </NextLink>
   );


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Fix of issue : #6460 
Issue was happening at : https://react.dev/reference/react/startTransition

![Screenshot from 2023-12-03 00-38-30](https://github.com/reactjs/react.dev/assets/119731754/45c87480-ef96-4bb2-9a65-5723138524e3)

Fix : Each text link in the footer button was overflowing with large link-text .

Solution : Added break-word property to the span tag to word wrap and fix the overflow issue.

![Screenshot from 2023-12-03 00-02-32](https://github.com/reactjs/react.dev/assets/119731754/11e12242-7684-4d01-b516-3a856b9990c5)


Issue : resolved :+1: 
