### PR TITLE
Link to Next.js `/learn` instead of docs as more beginners friendly 

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -24,7 +24,7 @@ If you want to build a new app or a new website fully with React, we recommend p
 npx create-next-app@latest
 </TerminalBlock>
 
-If you're new to Next.js, check out the [Next.js documentation.](https://nextjs.org/docs)
+If you're new to Next.js, check out the [learn Next.js course.](https://nextjs.org/learn)
 
 Next.js is maintained by [Vercel](https://vercel.com/). You can [deploy a Next.js app](https://nextjs.org/docs/app/building-your-application/deploying) to any Node.js or serverless hosting, or to your own server. Next.js also supports a [static export](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports) which doesn't require a server.
 


### PR DESCRIPTION
Resolve https://github.com/reactjs/react.dev/pull/6467#discussion_r1417973252


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
