### PR TITLE
Update Footer.tsx

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -327,7 +327,7 @@ export function Footer() {
           <FooterLink isHeader={true}>More</FooterLink>
           <FooterLink href="/blog">Blog</FooterLink>
           <FooterLink href="https://reactnative.dev/">React Native</FooterLink>
-          <FooterLink href="https://opensource.facebook.com/legal/privacy">
+          <FooterLink href="https://opensource.fb.com/legal/privacy">
             Privacy
           </FooterLink>
           <FooterLink href="https://opensource.fb.com/legal/terms/">


### PR DESCRIPTION
The privacy policy link in footer points to https://opensource.facebook.com/legal/privacy however the link is redirected to the domain https://opensource.fb.com/legal/privacy/

My simple PR adjusts this.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
