### PR TITLE
Add style for ellipsis in FooterLink component title

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -78,11 +78,19 @@ function FooterLink({
         className="text-tertiary dark:text-tertiary-dark inline group-focus:text-link dark:group-focus:text-link-dark"
         displayDirection={type === 'Previous' ? 'start' : 'end'}
       />
-      <span>
+      <span style={{maxWidth: 'calc(100% - 50px)'}}>
         <span className="block no-underline text-sm tracking-wide text-secondary dark:text-secondary-dark uppercase font-bold group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
           {type}
         </span>
-        <span className="block text-lg group-hover:underline">{title}</span>
+        <span
+          className="block text-lg group-hover:underline"
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}>
+          {title}
+        </span>
       </span>
     </NextLink>
   );


### PR DESCRIPTION
  Applied maxWidth style to the <span> element housing the title in the FooterLink component. Implemented overflow, textOverflow, and whiteSpace styles to ensure proper handling of long text by displaying ellipsis and preventing overflow of the container. Adjusted maxWidth value for layout compatibility.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

[ISSUE](https://github.com/reactjs/react.dev/issues/6460)
