### PR TITLE
Remove unused variable nextId from updating arrays in state lesson

### DIFF
--- a/src/content/learn/updating-arrays-in-state.md
+++ b/src/content/learn/updating-arrays-in-state.md
@@ -409,7 +409,6 @@ For example:
 ```js
 import { useState } from 'react';
 
-let nextId = 3;
 const initialList = [
   { id: 0, title: 'Big Bellies' },
   { id: 1, title: 'Lunar Landscape' },


### PR DESCRIPTION
**Issue**: In `Updating Arrays in State` lesson in one of the code example there is a unused variable called `nextId`.

**Fix**: As it's not required, I've removed it.

**Before**: 
<img width="1464" alt="Screenshot 2023-12-09 at 11 45 04 AM" src="https://github.com/reactjs/react.dev/assets/46070267/d274995c-e7f5-477b-a7ee-73d7a0c0a195">


**After**: 
<img width="1470" alt="Screenshot 2023-12-09 at 11 46 51 AM" src="https://github.com/reactjs/react.dev/assets/46070267/b5eb2492-3571-4fa5-af17-94cf062febff">

