### PR TITLE
Bug-fix-Sidbar-scrollbar-auto-hides-incorrrectly

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -141,7 +141,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
         )}
         {/* No fallback UI so need to be careful not to suspend directly inside. */}
         <Suspense fallback={null}>
-          <main className="min-w-0 isolate">
+          <main className="min-w-0 isolate ml-6">
             <article
               className="break-words font-normal text-primary dark:text-primary-dark"
               key={asPath}>


### PR DESCRIPTION
**Bug : #6469 Sidbar scrollbar auto hides incorrrectly**

Issue happening at : https://react.dev/reference/react/useState
Every time in the of sidebar whenver scroll comes from any Nav Link section.
![Screenshot from 2023-12-10 01-11-39](https://github.com/reactjs/react.dev/assets/119731754/75da00a4-9915-45a0-872b-ff586ccdf22b)
[Screencast from 10-12-23 01:13:41 AM IST.webm](https://github.com/reactjs/react.dev/assets/119731754/0b441979-8f3d-41b1-a8d2-1be6c4fdd6eb)





Solution :
Added a margin -left attribute in Page.tsx file.

![Screenshot from 2023-12-10 01-15-20](https://github.com/reactjs/react.dev/assets/119731754/0c760dc9-548e-424e-806b-5859edd574cf)
[Screencast from 10-12-23 01:14:41 AM IST.webm](https://github.com/reactjs/react.dev/assets/119731754/c7457da1-39d0-4b21-81b6-82b6aff97827)


Issue Resolved :+1: 
Browser and device :
Google-chrome : Version 120.0.6099.71
OS : Ubuntu 22.04.3 LTS
