### PR TITLE
Fix option color in react-conf dropdown (Home section)

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -1508,8 +1508,8 @@ function ConferenceLayout({conf, children}) {
             backgroundImage:
               'linear-gradient(45deg,transparent 50%,currentColor 50%),linear-gradient(135deg,currentColor 50%,transparent 50%)',
           }}>
-          <option value="react-conf-2021">React Conf 2021</option>
-          <option value="react-conf-2019">React Conf 2019</option>
+          <option className="text-black" value="react-conf-2021">React Conf 2021</option>
+          <option className="text-black" value="react-conf-2019">React Conf 2019</option>
         </select>
       </Cover>
       <div className="px-4 pb-4" key={conf.id}>


### PR DESCRIPTION
Currently the text is white on a white background when the field is not selected, the text color has been fixed to be black on white

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below
27816

-->
