### PR TITLE
fix(SandpackRoot): useFormState Example throwing runtime Error

### DIFF
--- a/src/components/MDX/Sandpack/SandpackRoot.tsx
+++ b/src/components/MDX/Sandpack/SandpackRoot.tsx
@@ -83,6 +83,10 @@ function SandpackRoot(props: SandpackProps) {
         theme={CustomTheme}
         customSetup={{
           environment: 'create-react-app',
+          dependencies: {
+            'react-dom': '18.3.0-canary-0cdfef19b-20231211',
+            react: '18.3.0-canary-0cdfef19b-20231211',
+          },
         }}
         options={{
           autorun,


### PR DESCRIPTION
This solves the issue that users can't view the useFormState demo from CodeSandbox. Closes #6491 

Specifying dependencies and their versions for a Sandpack demo using the "customSetup.dependencies" property.[👍](https://sandpack.codesandbox.io/docs/advanced-usage/components#extending-expect)

