### PR TITLE
Improve documentation for __html

### DIFF
--- a/src/content/reference/react-dom/components/common.md
+++ b/src/content/reference/react-dom/components/common.md
@@ -982,6 +982,8 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 
 </Sandpack>
 
+The `{__html}` object should be created as close to where the HTML is generated as possible, like the above example does in the `renderMarkdownToHTML` function. This ensures that all raw HTML being used in your code is explicitly marked as such, and that only variables that you expect to contain HTML are passed to `dangerouslySetInnerHTML`. It is not recommended to create the object inline like `<div dangerouslySetInnerHTML={{__html: markup}} />`.
+
 To see why rendering arbitrary HTML is dangerous, replace the code above with this:
 
 ```js {1-4,7,8}


### PR DESCRIPTION
The intent of the `__html` object for `dangerouslySetInnerHTML` is to act as a marker for which strings can be rendered as HTML. It should be wrapped in the `__html` wrapper at the point that it is produced.

For use cases of `dangerouslySetInnerHTML` on Facebook, `__html` rarely appears in the  JavaScript code, as often we render the HTML server-side and return the `__html` object JSON-encoded as part of the network response. For client-side generated HTML, there's a sanitization function that strips out bad things (scripts, etc) then returns the `__html` object. We've also got a lint rule ensuring that `__html` is not explicitly written in JavaScript code. This means that if we see an object with a `__html` property, it *should* be OK to render it via `dangerouslySetInnerHTML`.

Because of this, it doesn't make sense to create it inline like `<div dangerouslySetInnerHTML={{__html: markup}} />`. This bypasses the main purpose of using `__html` as a marker. There's no way to tell if `markup` is expected to be rendered as HTML (e.g. it was produced by a Markdown library, ran through a HTML sanitizer, etc) or if could be totally unsafe to use it.

This was documented in the React 0.x docs, but the latest documentation no longer mentions it. I've added a paragraph about it to the current docs.