### PR TITLE
Fix overflowing text content in footer link

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -69,7 +69,7 @@ function FooterLink({
     <NextLink
       href={href}
       className={cn(
-        'flex gap-x-4 md:gap-x-6 items-center w-full md:w-80 px-4 md:px-5 py-6 border-2 border-transparent text-base leading-base text-link dark:text-link-dark rounded-lg group focus:text-link dark:focus:text-link-dark focus:bg-highlight focus:border-link dark:focus:bg-highlight-dark dark:focus:border-link-dark focus:border-opacity-100 focus:border-2 focus:ring-1 focus:ring-offset-4 focus:ring-blue-40 active:ring-0 active:ring-offset-0 hover:bg-gray-5 dark:hover:bg-gray-80',
+        'flex gap-x-4 md:gap-x-6 items-center w-full md:min-w-80 md:w-fit md:max-w-md px-4 md:px-5 py-6 border-2 border-transparent text-base leading-base text-link dark:text-link-dark rounded-lg group focus:text-link dark:focus:text-link-dark focus:bg-highlight focus:border-link dark:focus:bg-highlight-dark dark:focus:border-link-dark focus:border-opacity-100 focus:border-2 focus:ring-1 focus:ring-offset-4 focus:ring-blue-40 active:ring-0 active:ring-offset-0 hover:bg-gray-5 dark:hover:bg-gray-80',
         {
           'flex-row-reverse justify-self-end text-end': type === 'Next',
         }

--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -82,9 +82,7 @@ function FooterLink({
         <span className="text-sm font-bold tracking-wide no-underline uppercase text-secondary dark:text-secondary-dark group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
           {type}
         </span>
-        <span
-          className="text-lg break-words group-hover:underline"
-          title={title}>
+        <span className="text-lg break-words group-hover:underline">
           {title}
         </span>
       </div>

--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -27,7 +27,7 @@ export const DocsPageFooter = memo<DocsPageFooterProps>(
       <>
         {prevRoute?.path || nextRoute?.path ? (
           <>
-            <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-4 py-4 md:py-12">
+            <div className="grid grid-cols-1 gap-4 py-4 mx-auto max-w-7xl md:grid-cols-2 md:py-12">
               {prevRoute?.path ? (
                 <FooterLink
                   type="Previous"
@@ -75,14 +75,18 @@ function FooterLink({
         }
       )}>
       <IconNavArrow
-        className="text-tertiary dark:text-tertiary-dark inline group-focus:text-link dark:group-focus:text-link-dark"
+        className="inline text-tertiary dark:text-tertiary-dark group-focus:text-link dark:group-focus:text-link-dark"
         displayDirection={type === 'Previous' ? 'start' : 'end'}
       />
       <div className="flex flex-col overflow-hidden">
-        <span className="no-underline text-sm tracking-wide text-secondary dark:text-secondary-dark uppercase font-bold group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
+        <span className="text-sm font-bold tracking-wide no-underline uppercase text-secondary dark:text-secondary-dark group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
           {type}
         </span>
-        <span className="overflow-hidden whitespace-nowrap text-ellipsis text-lg group-hover:underline" title={title}>{title}</span>
+        <span
+          className="text-lg break-words group-hover:underline"
+          title={title}>
+          {title}
+        </span>
       </div>
     </NextLink>
   );

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -24,6 +24,7 @@ const deployedTranslations = [
   'es',
   'fr',
   'ja',
+  'tr',
   // We'll add more languages when they have enough content.
   // Please DO NOT edit this list without a discussion in the reactjs/react.dev repo.
   // It must be the same between all translations.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,7 +57,12 @@ module.exports = {
         'meta-gradient-dark': "url('/images/meta-gradient-dark.png')",
       },
       maxWidth: {
+        ...defaultTheme.maxWidth,
         xs: '21rem',
+      },
+      minWidth:{
+        ...defaultTheme.minWidth,
+        80: '20rem',
       },
       outline: {
         blue: ['1px auto ' + colors.link, '3px'],


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
# 💫 Changelog
:star: Fixes issue: #6460 
:star: Added `text-overflow: ellipsis` to show ellipsis on lengthy strings, with the addition of `title` attribute on the `span` element that shows the complete string on a tooltip on hovering the truncated string.
:star: `block` property is now removed from the `span` element as `span`s are inherently `inline` and I feel making them behave as a `block` level element is semantically wrong. Instead, now we render the elements in a column-oriented flex container. 
:star: The parent container of the link string and the "Next/Previous" string is now housed by a `div` instead of a `span`

## Existing UI
![next-react](https://github.com/reactjs/react.dev/assets/22348265/ae9dbf85-2b11-43c4-a743-425c0d24f929)
![previous-react](https://github.com/reactjs/react.dev/assets/22348265/322e8749-b4d0-4ec2-9999-7c92a483f707)

## Updated UI
![previous-fixed-react](https://github.com/reactjs/react.dev/assets/22348265/7a2a0d31-f769-4af7-a226-1dba8a5dc40d)
![next-fixed-react](https://github.com/reactjs/react.dev/assets/22348265/5523ce76-85ee-4c48-ae54-9541d070744f)
