### PR TITLE
Clarify that `false` still affects the render tree by occupying a position

### DIFF
--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -894,8 +894,8 @@ h1 {
 
 </Sandpack>
 
-* Initially, `isPlayerA` is `true`. So the first position contains `Counter` state, and the second one is empty.
-* When you click the "Next player" button the first position clears but the second one now contains a `Counter`.
+* Initially, `isPlayerA` is `true`. The first position contains a `Counter` and the second position contains a `false` value. The `false` value occupies a position in the render tree even though it doesn't appear on the screen.
+* When you click the "Next player" button, the first position is replaced by a `false` value and the second one now contains a `Counter`.
 
 <DiagramGroup>
 


### PR DESCRIPTION
From https://stackoverflow.com/questions/70253988/react-resetting-and-preserving-state and https://stackoverflow.com/questions/77718975/why-would-two-react-components-seemingly-in-the-same-position-get-different-stat, it seems that the ["Resetting state at the same position"](https://react.dev/learn/preserving-and-resetting-state#resetting-state-at-the-same-position) section has confused a few people, including myself. I have clarified the text to hopefully reduce the chance of this confusion, which centers around whether the `false` created by the evaluation of the `&&` expression influences the calculated positions in the render tree.