### PR TITLE
Revert "Add useState semicolon"

### DIFF
--- a/src/content/reference/react/useState.md
+++ b/src/content/reference/react/useState.md
@@ -7,7 +7,7 @@ title: useState
 `useState` is a React Hook that lets you add a [state variable](/learn/state-a-components-memory) to your component.
 
 ```js
-const [state, setState] = useState(initialState);
+const [state, setState] = useState(initialState)
 ```
 
 </Intro>


### PR DESCRIPTION
Reverts reactjs/react.dev#5823

None of these intros have semicolons, as it's a brief description, not runnable or syntactically correct code. For example, the effects are like:

```
useLayoutEffect(setup, dependencies?)
```

Reverting so this is consistent with all the other pages.