### PR TITLE
Use 'trim()' method in `useContext` page to prevent form from accepting whitespaces

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -457,7 +457,6 @@ function LoginForm() {
   const {setCurrentUser} = useContext(CurrentUserContext);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  // use trim method to prevent form from accepting whitespaces
   const canLogin = firstName.trim() !== '' && lastName.trim() !== '';
   return (
     <>

--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -457,7 +457,8 @@ function LoginForm() {
   const {setCurrentUser} = useContext(CurrentUserContext);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  const canLogin = firstName !== '' && lastName !== '';
+  // use trim method to prevent form from accepting whitespaces
+  const canLogin = firstName.trim() !== '' && lastName.trim() !== '';
   return (
     <>
       <label>


### PR DESCRIPTION
This pull request fixes #6284

As per the issue author's suggestion:
It performs the `trim()` on both `firstName` and `lastName` of form in multiple contexts example of `useContext` page.
Also a comment was added for readers briefly explaining that it prevents spaces etc from being considered valid input.