### PR TITLE
Refactor: Remove unused 'index' variable

### DIFF
--- a/src/content/learn/choosing-the-state-structure.md
+++ b/src/content/learn/choosing-the-state-structure.md
@@ -527,7 +527,7 @@ export default function Menu() {
     <>
       <h2>What's your travel snack?</h2>
       <ul>
-        {items.map((item, index) => (
+        {items.map((item) => (
           <li key={item.id}>
             <input
               value={item.title}


### PR DESCRIPTION
In this commit, the 'index' variable was removed from the map function within the JSX. The 'index' variable was previously used for mapping over the 'items' array, but it became unnecessary as it wasn't utilized within the loop. This change improves code readability and eliminates potential confusion. No functional impact is expected.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
