### PR TITLE
Rephrase for clarity

### DIFF
--- a/src/content/learn/understanding-your-ui-as-a-tree.md
+++ b/src/content/learn/understanding-your-ui-as-a-tree.md
@@ -259,7 +259,7 @@ Identifying these categories of components are useful for understanding data flo
 
 ## The Module Dependency Tree {/*the-module-dependency-tree*/}
 
-Another relationship in a React app that can be modeled with a tree are an app's module dependencies. As we [break up our components](/learn/importing-and-exporting-components#exporting-and-importing-a-component) and logic into separate files, we create [JS modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) where we may export components, functions, or constants.
+Another relationship in a React app that can be modeled with a tree is the set of an app’s module dependencies. As we [break up our components](/learn/importing-and-exporting-components#exporting-and-importing-a-component) and logic into separate files, we create [JS modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) where we may export components, functions, or constants.
 
 Each node in a module dependency tree is a module and each branch represents an `import` statement in that module.
 


### PR DESCRIPTION
The sentence "Another relationship in a React app that can be modeled with a tree are an app’s module dependencies." has a grammatical inconsistency and could be clearer. The subject "relationship" is singular, but the verb "are" is plural, which is confusing.