### PR TITLE
Remove redundant component

### DIFF
--- a/src/content/learn/responding-to-events.md
+++ b/src/content/learn/responding-to-events.md
@@ -176,31 +176,23 @@ To do this, pass a prop the component receives from its parent as the event hand
 <Sandpack>
 
 ```js
-function Button({ onClick, children }) {
-  return (
-    <button onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-
 function PlayButton({ movieName }) {
   function handlePlayClick() {
     alert(`Playing ${movieName}!`);
   }
 
   return (
-    <Button onClick={handlePlayClick}>
+    <button onClick={handlePlayClick}>
       Play "{movieName}"
-    </Button>
+    </button>
   );
 }
 
 function UploadButton() {
   return (
-    <Button onClick={() => alert('Uploading!')}>
+    <button onClick={() => alert('Uploading!')}>
       Upload Image
-    </Button>
+    </button>
   );
 }
 


### PR DESCRIPTION
The `Button` component in this example is premature and unnecessary, the previous examples in the article used `<button>`, the correct place to introduce `Button` is in the following example which describes "_Naming event handler props_"  (https://react.dev/learn/responding-to-events#naming-event-handler-props).