### PR TITLE
Fix scrollbar of SidebarNav to make it tappable

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -129,7 +129,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
             'grid grid-cols-only-content lg:grid-cols-sidebar-content 2xl:grid-cols-sidebar-content-toc'
         )}>
         {showSidebar && (
-          <div className="lg:-mt-16">
+          <div className="lg:-mt-16 z-10">
             <div className="fixed top-0 py-0 shadow lg:pt-16 lg:sticky start-0 end-0 lg:shadow-none">
               <SidebarNav
                 key={section}


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fixes #3171
Fixes #5727 
Fixes #6469
- fixed scrollbar of SidebarNav to make it tappable by assigning `z-10`
- it was under the main content layer so that you could not drag it


https://github.com/reactjs/react.dev/assets/27883373/7c027fa6-e991-4a1a-ac8c-cb1e9801e9ef


