### PR TITLE
Remove deadcode in Link

### DIFF
--- a/src/components/MDX/Link.tsx
+++ b/src/components/MDX/Link.tsx
@@ -16,14 +16,6 @@ function Link({
 }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   const classes =
     'inline text-link dark:text-link-dark border-b border-link border-opacity-0 hover:border-opacity-100 duration-100 ease-in transition leading-normal';
-  const modifiedChildren = Children.toArray(children).map((child: any) => {
-    if (child.type?.mdxName && child.type?.mdxName === 'inlineCode') {
-      return cloneElement(child, {
-        isLink: true,
-      });
-    }
-    return child;
-  });
 
   if (!href) {
     // eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -33,16 +25,16 @@ function Link({
     <>
       {href.startsWith('https://') ? (
         <ExternalLink href={href} className={cn(classes, className)} {...props}>
-          {modifiedChildren}
+          {children}
         </ExternalLink>
       ) : href.startsWith('#') ? (
         // eslint-disable-next-line jsx-a11y/anchor-has-content
         <a className={cn(classes, className)} href={href} {...props}>
-          {modifiedChildren}
+          {children}
         </a>
       ) : (
         <NextLink href={href} className={cn(classes, className)} {...props}>
-          {modifiedChildren}
+          {children}
         </NextLink>
       )}
     </>


### PR DESCRIPTION
This PR removes deadcode in the Link Component when the Link component contains a `<code ... />` element. As seen in this [example](https://react.dev/reference/react-dom/components/input).

---

In the `modifiedChildren` array here https://github.com/reactjs/react.dev/blob/6ca0381a0762f1de4a49052700723664e92db030/src/components/MDX/Link.tsx#L19-L26

The `if` block always evaluates to `false` because `child.type?.mdxName === 'inlineCode'` for the `code` element is  `code` per https://github.com/reactjs/react.dev/blob/6ca0381a0762f1de4a49052700723664e92db030/src/components/MDX/MDXComponents.tsx#L403 https://github.com/reactjs/react.dev/blob/6ca0381a0762f1de4a49052700723664e92db030/src/components/MDX/MDXComponents.tsx#L452

An alternative would be to fix the code, but that wouldn't have any effect because the style set in https://github.com/reactjs/react.dev/blob/6ca0381a0762f1de4a49052700723664e92db030/src/styles/index.css#L447-L454 overrides what it would be set to in https://github.com/reactjs/react.dev/blob/6ca0381a0762f1de4a49052700723664e92db030/src/components/MDX/InlineCode.tsx#L21

I've also tested the site and it works just fine without it. The only other place `inlineCode` is mentioned is https://github.com/reactjs/react.dev/blob/6ca0381a0762f1de4a49052700723664e92db030/plugins/remark-smartypants.js#L39 but I'm unsure if that is related.