### PR TITLE
fixes: scrollbar on the sidebar not clickable with the mouse - now made clickable , issue no : #6604

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -141,7 +141,7 @@ export function Page({children, toc, routeTree, meta, section}: PageProps) {
         )}
         {/* No fallback UI so need to be careful not to suspend directly inside. */}
         <Suspense fallback={null}>
-          <main className="min-w-0 isolate">
+          <main className="min-w-0 isolate" style={{marginLeft: '1.2rem'}}>
             <article
               className="font-normal break-words text-primary dark:text-primary-dark"
               key={asPath}>

--- a/src/styles/sandpack.css
+++ b/src/styles/sandpack.css
@@ -211,7 +211,6 @@ html.dark .sp-wrapper {
 }
 
 .sandpack .sp-code-editor .cm-content {
-  overflow-x: auto;
   padding-bottom: 18px;
 }
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

This is the fix for the issue no : #6604 
The "main" was hiding the "scrollbar of the sidebar".  So to fix this, I just added margin-left as 1.2 rem to the main element.
