### PR TITLE
Update confusing conditional-rendering.md

### DIFF
--- a/src/content/learn/conditional-rendering.md
+++ b/src/content/learn/conditional-rendering.md
@@ -315,13 +315,15 @@ A [JavaScript && expression](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 <Pitfall>
 
-**Don't put numbers on the left side of `&&`.**
+**Be cautious when using numbers on the left side of && in conditional rendering.**
 
-To test the condition, JavaScript converts the left side to a boolean automatically. However, if the left side is `0`, then the whole expression gets that value (`0`), and React will happily render `0` rather than nothing.
+To test the condition, JavaScript converts the left side to a boolean automatically.
 
-For example, a common mistake is to write code like `messageCount && <p>New messages</p>`. It's easy to assume that it renders nothing when `messageCount` is `0`, but it really renders the `0` itself!
+While numbers generally evaluate to truthy values, there's a caveat when the number is 0. If the left side evaluates to 0, React will render the 0 itself instead of nothing.
 
-To fix it, make the left side a boolean: `messageCount > 0 && <p>New messages</p>`.
+For example, a common mistake is writing code like messageCount && <p>New messages</p>. It might be expected that it renders nothing when messageCount is 0, but in reality, it renders the 0 itself.
+
+To handle this correctly, ensure that the left side is explicitly a boolean by using a comparison: messageCount > 0 && <p>New messages</p>. This guarantees the expected behavior, rendering the element only when messageCount is greater than 0."
 
 </Pitfall>
 


### PR DESCRIPTION
This pull request addresses a potential confusion in the documentation regarding conditional rendering in React. The original warning stated not to put numbers on the left side of '&&,' but the provided example still included a number to the left of '&&'. This caused confusion.

Changes Made:

    Updated the wording in the documentation to emphasize the importance of having a boolean expression on the left side of '&&' for conditional rendering.
    Provided a clearer example to illustrate the issue with using numbers, especially 0, on the left side of '&&.'
    Ensured that the revised explanation accurately reflects the behavior of conditional rendering in React.

Why:
The goal is to improve the clarity of the documentation and prevent potential misunderstandings for developers using React. The revised wording better communicates the nuances of using '&&' for conditional rendering, especially when dealing with numbers.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
