### PR TITLE
Fix Sandpack wiht HTML output to use src dir

### DIFF
--- a/src/components/MDX/SandpackWithHTMLOutput.tsx
+++ b/src/components/MDX/SandpackWithHTMLOutput.tsx
@@ -20,7 +20,7 @@ export default function ShowRenderedHTML({children}) {
         {formatHTML(markup)}
       </pre>
     </>
-  );  
+  );
 }`;
 
 const formatHTML = `
@@ -77,8 +77,8 @@ export default memo(function SandpackWithHTMLOutput(
 ) {
   const children = [
     ...Children.toArray(props.children),
-    createFile('ShowRenderedHTML.js', ShowRenderedHTML),
-    createFile('formatHTML.js hidden', formatHTML),
+    createFile('src/ShowRenderedHTML.js', ShowRenderedHTML),
+    createFile('src/formatHTML.js hidden', formatHTML),
     createFile('package.json hidden', packageJSON),
   ];
   return <Sandpack {...props}>{children}</Sandpack>;

--- a/src/content/reference/react-dom/components/link.md
+++ b/src/content/reference/react-dom/components/link.md
@@ -96,7 +96,7 @@ In addition, if the `<link>` is to a stylesheet (namely, it has `rel="stylesheet
 
 There are two exception to this special behavior:
 
-* If the link doesn't have a `precedence` prop, there is no special behavior, because the order of stylesheets within the document is significant, so React needs to know how to order this stylesheet relative to others, which you specify using the `precedence` prop.  
+* If the link doesn't have a `precedence` prop, there is no special behavior, because the order of stylesheets within the document is significant, so React needs to know how to order this stylesheet relative to others, which you specify using the `precedence` prop.
 * If you supply any of the `onLoad`, `onError`, or `disabled` props, there is no special behavior, because these props indicate that you are managing the loading of the stylesheet manually within your component.
 
 This special treatment comes with two caveats:
@@ -114,7 +114,7 @@ You can annotate the document with links to related resources such as an icon, c
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 export default function BlogPage() {
@@ -141,7 +141,7 @@ When you want to use a stylesheet, it can be beneficial to call the [preinit](/r
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 export default function SiteMapPage() {
@@ -164,7 +164,7 @@ Stylesheets can conflict with each other, and when they do, the browser goes wit
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 export default function HomePage() {
@@ -195,7 +195,7 @@ If you render the same stylesheet from multiple components, React will place onl
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 export default function HomePage() {

--- a/src/content/reference/react-dom/components/meta.md
+++ b/src/content/reference/react-dom/components/meta.md
@@ -72,7 +72,7 @@ You can render the `<meta>` component from any component. React will put a `<met
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 export default function SiteMapPage() {

--- a/src/content/reference/react-dom/components/script.md
+++ b/src/content/reference/react-dom/components/script.md
@@ -91,7 +91,7 @@ If you supply an `src` and `async` prop, your component will suspend while the s
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 function Map({lat, long}) {
@@ -124,7 +124,7 @@ To include an inline script, render the `<script>` component with the script sou
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 function Tracking() {

--- a/src/content/reference/react-dom/components/style.md
+++ b/src/content/reference/react-dom/components/style.md
@@ -73,7 +73,7 @@ If you supply an `href` and `precedence` prop, your component will suspend while
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 import { useId } from 'react';
 

--- a/src/content/reference/react-dom/components/title.md
+++ b/src/content/reference/react-dom/components/title.md
@@ -66,7 +66,7 @@ Render the `<title>` component from any component with text as its children. Rea
 
 <SandpackWithHTMLOutput>
 
-```js App.js active
+```js src/App.js active
 import ShowRenderedHTML from './ShowRenderedHTML.js';
 
 export default function ContactUsPage() {


### PR DESCRIPTION
The `SandpackWithHTMLOutput` is broken, likely since #6496 this PR fixes the component by prefixing all files except `package.json` with `src` so the files are all in the place CodeSandbox expects. This broke 9 sandpacks across 5 pages. Fixes #6612

### Preview links

#### `<link>` page

* [Linking to related resources](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/link#linking-to-related-resources)
* [Linking to a stylesheet](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/link#linking-to-a-stylesheet)
* [Controlling stylesheet precedence](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/link#controlling-stylesheet-precedence)
* [Deduplicated stylesheet rendering](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/link#deduplicated-stylesheet-rendering)

#### `<meta>` page

* [Annotating the document with metadata](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/meta#annotating-the-document-with-metadata)

#### `<script>` page

* [Rendering an external script](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/script#rendering-an-external-script)
* [Rendering an inline script](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/script#rendering-an-inline-script)

#### `<style>` page

* [Rendering an inline CSS stylesheet](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/style#rendering-an-inline-css-stylesheet)


#### `<title>` page

* [Set the document title](https://react-dev-git-fork-mattcarrollcode-fix-sandbox-fbopensource.vercel.app/reference/react-dom/components/title#set-the-document-title)

