### PR TITLE
Fix server/client typo in <form> docs

### DIFF
--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -322,7 +322,7 @@ export default function Search() {
 
 Displaying a form submission error message before the JavaScript bundle loads for progressive enhancement requires that:
 
-1. `<form>` be rendered by a [Server Component](/reference/react/use-client)
+1. `<form>` be rendered by a [Client Component](/reference/react/use-client)
 1. the function passed to the `<form>`'s `action` prop be a [Server Action](/reference/react/use-server)
 1. the `useFormState` Hook be used to display the error message
 


### PR DESCRIPTION
Fixes #6601

With this change the example makes sense, since you can't call `useFormState` in a server component.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
