### PR TITLE
docs: add useEffectEvent to the sidebar menu

### DIFF
--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -40,6 +40,11 @@
           "path": "/reference/react/useEffect"
         },
         {
+          "title": "experimental_useEffectEvent",
+          "path": "/reference/react/experimental_useEffectEvent",
+          "canary": true
+        },
+        {
           "title": "useId",
           "path": "/reference/react/useId"
         },


### PR DESCRIPTION
This PR adds the `experimental_useEffectEvent` page to the API reference menu.
As this hook is being referenced in the learn section but the page wasn't visible in the menu (while other new experimental hooks are in the menu), it seemed like this hook is not planned anymore. Adding it to the menu states that this API is something the React core team aims to ship.

<img width="1792" alt="image" src="https://github.com/reactjs/react.dev/assets/12711091/1d52e51c-5859-4b74-ac44-50ff99add59b">


Thanks for all your hard work! :)