### PR TITLE
[typo] syntax looks wrong

### DIFF
--- a/src/content/reference/react-dom/components/style.md
+++ b/src/content/reference/react-dom/components/style.md
@@ -14,7 +14,7 @@ React's extensions to `<style>` are currently only available in React's canary a
 The [built-in browser `<style>` component](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style) lets you add inline CSS stylesheets to your document.
 
 ```js
-<style> p { color: red; } </style>
+<style>{` p { color: red; } `}</style>
 ```
 
 </Intro>

--- a/src/content/reference/react-dom/components/style.md
+++ b/src/content/reference/react-dom/components/style.md
@@ -30,7 +30,7 @@ The [built-in browser `<style>` component](https://developer.mozilla.org/en-US/d
 To add inline styles to your document, render the [built-in browser `<style>` component](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style). You can render `<style>` from any component and React will [in certain cases](#special-rendering-behavior) place the corresponding DOM element in the document head and de-duplicate identical styles.
 
 ```js
-<style> p { color: red; } </style>
+<style>{` p { color: red; } `}</style>
 ```
 
 [See more examples below.](#usage)


### PR DESCRIPTION
Fixed `<style>` syntax according to the changes recommended.

From `<style> p { color: red; } </style>` to ``<style>{` p { color: red; } `}</style>``

Here's the image that shows the changes. Thank you!


<img width="1512" alt="Screenshot 2024-02-18 at 3 24 12 PM" src="https://github.com/reactjs/react.dev/assets/54698754/fb726aa2-f94a-48a8-9a2b-3f12970254c5">
