### PR TITLE
Wrong client detection in example

### DIFF
--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2528,7 +2528,7 @@ You can use this to opt out some components from rendering on the server. To do 
 </Suspense>
 
 function Chat() {
-  if (typeof window === 'undefined') {
+  if (typeof document === 'undefined') {
     throw Error('Chat should only render on the client.');
   }
   // ...


### PR DESCRIPTION
Issue link : [#6489](https://github.com/reactjs/react.dev/issues/6489)

Updated `window` object to `document` in `src/content/reference/react/Suspense.md` at line no. 2531.
