### PR TITLE
Update and fix gh actions

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -55,7 +55,7 @@ jobs:
           name: bundle_analysis.json
 
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         if: success() && github.event.number
         with:
           workflow: analyze.yml

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Upload analysis comment
         uses: actions/upload-artifact@v4
+        if: success() && github.event.number
         with:
           name: analysis_comment.txt
           path: .next/analyze/__bundle_analysis_comment.txt

--- a/.github/workflows/analyze_comment.yml
+++ b/.github/workflows/analyze_comment.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: analyze.yml
           run_id: ${{ github.event.workflow_run.id }}
@@ -22,7 +22,7 @@ jobs:
           path: analysis_comment.txt
 
       - name: Download PR number
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: analyze.yml
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/analyze_comment.yml
+++ b/.github/workflows/analyze_comment.yml
@@ -10,8 +10,8 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download base branch bundle stats
         uses: dawidd6/action-download-artifact@v6


### PR DESCRIPTION
- Updated external actions to the latest version (~~except for the `upload-artifact`~~). Close #6651
  - ~~`upload-artifact` was bumped to v3, as I'm not sure about the required unique artifact names in v4, though v3 still uses node16. Also close #7148~~
- Fixed the warning of uploading missing files if previous comparing analysis steps were canceled. (As an example, you may check this warning in the annotations section here: https://github.com/reactjs/react.dev/actions/runs/7980888987 or directly in the logs here: https://github.com/reactjs/react.dev/actions/runs/7980888987/job/21791474787 in the `Upload analysis comment` step)
- Fixed `Analyze Bundle (Comment)` action failure on the default branch by rewriting the condition, as [GitHub's runner evaluation is tricky and sometimes provides false positives](https://github.com/actions/runner/issues/1173). Close #5801

NOTE: analyze-comment depends on `workflow_run` and thus will be used only after merging updates into the default branch. This is why the deprecation warning is still present (https://github.com/reactjs/react.dev/actions/runs/7980542658). To check the proposed fix in a condition, you may look over the [same fix in my test repo](https://github.com/alinkedd/test-repo/commit/4f3fe0c75aef179ff2927de17c4a554916c9e2fb) and then [dependant workflow respecting that condition](https://github.com/alinkedd/test-repo/actions/runs/7990165729).

Thorough review is welcomed, as I'm no GitHub Actions professional :)

UPD
I added folded block to `if` condition without expression to shorten the line, and it seems to work file. Links to my latest test results are updated.

UPD 2
#7277 has already updated most of the actions, so it closes #5961 by updating dawidd6/action-download-artifact at last

