### PR TITLE
Please carefully look up to this here  as setIsActive is not defined yet but called inside code at line 163

### DIFF
--- a/src/content/learn/sharing-state-between-components.md
+++ b/src/content/learn/sharing-state-between-components.md
@@ -147,13 +147,20 @@ export default function Accordion() {
 }
 
 function Panel({ title, children, isActive }) {
+  // Please carefully look up to this here setIsActive is not defined yet
+  // isActive is only passing by props
+  // I added this lines and updated setIsActive to setCheckActive to remove errors
+  // Please take necessary step so that learners like myself don't get confused by error
+  
+  const [checkActive, setCheckActive] = useState(isActive);
+
   return (
     <section className="panel">
       <h3>{title}</h3>
       {isActive ? (
         <p>{children}</p>
       ) : (
-        <button onClick={() => setIsActive(true)}>
+        <button onClick={() => setCheckActive(true)}>
           Show
         </button>
       )}


### PR DESCRIPTION
Please carefully look up to this here setIsActive is not defined yet at line 163, isActive is only passing by props from Accordion, I know that what I did it's not best solution,I added this lines for proper understanding and updated setIsActive to setCheckActive to remove errors, Please take necessary steps so that learners like myself don't get confused by ReferenceError of variables which isn't declared yet and got curious about why it was like that

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
