### PR TITLE
Remove useMemo from useFormStatus example

### DIFF
--- a/src/content/reference/react-dom/hooks/useFormStatus.md
+++ b/src/content/reference/react-dom/hooks/useFormStatus.md
@@ -182,36 +182,17 @@ import {useFormStatus} from 'react-dom';
 export default function UsernameForm() {
   const {pending, data} = useFormStatus();
 
-  const [showSubmitted, setShowSubmitted] = useState(false);
-  const submittedUsername = useRef(null);
-  const timeoutId = useRef(null);
-
-  useMemo(() => {
-    if (pending) {
-      submittedUsername.current = data?.get('username');
-      if (timeoutId.current != null) {
-        clearTimeout(timeoutId.current);
-      }
-
-      timeoutId.current = setTimeout(() => {
-        timeoutId.current = null;
-        setShowSubmitted(false);
-      }, 2000);
-      setShowSubmitted(true);
-    }
-  }, [pending, data]);
-
   return (
-    <>
-      <label>Request a Username: </label><br />
-      <input type="text" name="username" />
+    <div>
+      <label>Request a Username: </label>
+      <br />
+      <input type="text" name="username" disabled={pending}/>
       <button type="submit" disabled={pending}>
-        {pending ? 'Submitting...' : 'Submit'}
+        Submit
       </button>
-      {showSubmitted ? (
-        <p>Submitted request for username: {submittedUsername.current}</p>
-      ) : null}
-    </>
+      <br />
+      <p>{pending ? `Requesting ${data?.get("username")}...`: ''}</p>
+    </div>
   );
 }
 ```
@@ -219,10 +200,15 @@ export default function UsernameForm() {
 ```js src/App.js
 import UsernameForm from './UsernameForm';
 import { submitForm } from "./actions.js";
+import {useRef} from 'react';
 
 export default function App() {
+  const ref = useRef(null);
   return (
-    <form action={submitForm}>
+    <form ref={ref} action={async (formData) => {
+      await submitForm(formData);
+      ref.current.reset();
+    }}>
       <UsernameForm />
     </form>
   );
@@ -231,8 +217,26 @@ export default function App() {
 
 ```js src/actions.js hidden
 export async function submitForm(query) {
-    await new Promise((res) => setTimeout(res, 1000));
+    await new Promise((res) => setTimeout(res, 2000));
 }
+```
+
+```css
+p {
+    height: 14px;
+    padding: 0;
+    margin: 2px 0 0 0 ;
+    font-size: 14px
+}
+
+button {
+    margin-left: 2px;
+}
+
+input {
+    margin-top: 2px;
+}
+
 ```
 
 ```json package.json hidden

--- a/src/content/reference/react-dom/hooks/useFormStatus.md
+++ b/src/content/reference/react-dom/hooks/useFormStatus.md
@@ -184,14 +184,13 @@ export default function UsernameForm() {
 
   return (
     <div>
-      <label>Request a Username: </label>
-      <br />
+      <h3>Request a Username: </h3>
       <input type="text" name="username" disabled={pending}/>
       <button type="submit" disabled={pending}>
         Submit
       </button>
       <br />
-      <p>{pending ? `Requesting ${data?.get("username")}...`: ''}</p>
+      <p>{data ? `Requesting ${data?.get("username")}...`: ''}</p>
     </div>
   );
 }
@@ -231,10 +230,6 @@ p {
 
 button {
     margin-left: 2px;
-}
-
-input {
-    margin-top: 2px;
 }
 
 ```


### PR DESCRIPTION
## Overview

The useMemo here breaks the rules of React, is unnecessary and makes a worse experience:

- **Breaks the rules of React**: setting a timer in memo, setting state, and reading/writing to refs are all side effects in render, which is unsafe. useMemo must be a pure function with no side effects.
- **Unnecessary**: the formData is automatically updated as state, so there's no need to store it in a ref ref, you can just read it. The `showSubmitted` state is also unnecessary since the `pending` state already tells you if it's being submitted.
- **Worse experience**: by using a timer, there is an extra state update to show the submitted state (causing a multi-pass render update), and there is an artificial delay between when the form submission completes and when the "Submitted request" text dismisses. By using the `pending` and `formData` values directly, the "Submitted request` text is tied directly to the form submission transition "pending" state, so the disabled state and the text update in the same commit.

## Additional improvements
I also made a couple more improvements:
- CSS to space things out
- Reset the form after submission
- Increase form submission time to 2 seconds

## Before


https://github.com/reactjs/react.dev/assets/2440089/7352d743-a9c7-4025-a16b-26185530af37

## After

https://github.com/reactjs/react.dev/assets/2440089/e70f0603-7be0-44ed-be4a-4122374b65ed


