### PR TITLE
Fix reducer solution unneccesary spread in changed_selection action under challenge 1 in extracting-state-logic-into-a-reducer

### DIFF
--- a/src/content/learn/extracting-state-logic-into-a-reducer.md
+++ b/src/content/learn/extracting-state-logic-into-a-reducer.md
@@ -1170,7 +1170,6 @@ export function messengerReducer(state, action) {
   switch (action.type) {
     case 'changed_selection': {
       return {
-        ...state,
         selectedId: action.contactId,
         message: '',
       };
@@ -1320,7 +1319,6 @@ export function messengerReducer(state, action) {
   switch (action.type) {
     case 'changed_selection': {
       return {
-        ...state,
         selectedId: action.contactId,
         message: '',
       };


### PR DESCRIPTION
Spreading the state was unnecessary, as we're going to explicitly set all the properties again anyway, (the explicit values will overwrite any values copied over from old state.)
Screenshot before changes:
<img width="1438" alt="Screenshot before changes" src="https://github.com/reactjs/react.dev/assets/78201744/802b66c4-fc3e-46a2-aa97-c47528b4351f">


Screenshot after changes:
<img width="1438" alt="Screenshot after changes:" src="https://github.com/reactjs/react.dev/assets/78201744/d3c6f399-b61d-45d0-b45e-5bd5e53a4e3b">


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
