### PR TITLE
fix: server action params when using useFormState

### DIFF
--- a/src/content/reference/react/use-server.md
+++ b/src/content/reference/react/use-server.md
@@ -139,7 +139,7 @@ To update the UI based on the result of a Server Action while supporting progres
 // requestUsername.js
 'use server';
 
-export default async function requestUsername(formData) {
+export default async function requestUsername(prevState, formData) {
   const username = formData.get('username');
   if (canRequest(username)) {
     // ...


### PR DESCRIPTION
When used with useFormState, the server action requires 2 params: (prevState, formData) => newState

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
