### PR TITLE
Fixed useEffectEvent import path under escape hatch section

### DIFF
--- a/src/content/learn/removing-effect-dependencies.md
+++ b/src/content/learn/removing-effect-dependencies.md
@@ -660,7 +660,8 @@ The problem is that every time `isMuted` changes (for example, when the user pre
 To solve this problem, you need to extract the logic that shouldn't be reactive out of the Effect. You don't want this Effect to "react" to the changes in `isMuted`. [Move this non-reactive piece of logic into an Effect Event:](/learn/separating-events-from-effects#declaring-an-effect-event)
 
 ```js {1,7-12,18,21}
-import { useState, useEffect, useEffectEvent } from 'react';
+import { useState, useEffect} from 'react';
+import { experimental_useEffectEvent as useEffectEvent } from 'react';
 
 function ChatRoom({ roomId }) {
   const [messages, setMessages] = useState([]);

--- a/src/content/learn/removing-effect-dependencies.md
+++ b/src/content/learn/removing-effect-dependencies.md
@@ -659,9 +659,9 @@ The problem is that every time `isMuted` changes (for example, when the user pre
 
 To solve this problem, you need to extract the logic that shouldn't be reactive out of the Effect. You don't want this Effect to "react" to the changes in `isMuted`. [Move this non-reactive piece of logic into an Effect Event:](/learn/separating-events-from-effects#declaring-an-effect-event)
 
-```js {1,7-12,18,21}
-import { experimental_useEffectEvent as useEffectEvent } from 'react';
+```js {2,7-12,18,21}
 import { useState, useEffect} from 'react';
+import { experimental_useEffectEvent as useEffectEvent } from 'react';
 
 function ChatRoom({ roomId }) {
   const [messages, setMessages] = useState([]);

--- a/src/content/learn/removing-effect-dependencies.md
+++ b/src/content/learn/removing-effect-dependencies.md
@@ -660,8 +660,8 @@ The problem is that every time `isMuted` changes (for example, when the user pre
 To solve this problem, you need to extract the logic that shouldn't be reactive out of the Effect. You don't want this Effect to "react" to the changes in `isMuted`. [Move this non-reactive piece of logic into an Effect Event:](/learn/separating-events-from-effects#declaring-an-effect-event)
 
 ```js {1,7-12,18,21}
-import { useState, useEffect} from 'react';
 import { experimental_useEffectEvent as useEffectEvent } from 'react';
+import { useState, useEffect} from 'react';
 
 function ChatRoom({ roomId }) {
   const [messages, setMessages] = useState([]);

--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -901,8 +901,10 @@ This will work, but there's one more improvement you can do when your custom Hoo
 
 Adding a dependency on `onReceiveMessage` is not ideal because it will cause the chat to re-connect every time the component re-renders. [Wrap this event handler into an Effect Event to remove it from the dependencies:](/learn/removing-effect-dependencies#wrapping-an-event-handler-from-the-props)
 
-```js {1,4,5,15,18}
-import { useEffect, useEffectEvent } from 'react';
+```js {2,4,5,15,18}
+import { useEffect } from 'react';
+import { experimental_useEffectEvent as useEffectEvent } from 'react';
+
 // ...
 
 export function useChatRoom({ serverUrl, roomId, onReceiveMessage }) {

--- a/src/content/learn/separating-events-from-effects.md
+++ b/src/content/learn/separating-events-from-effects.md
@@ -408,8 +408,9 @@ This section describes an **experimental API that has not yet been released** in
 
 Use a special Hook called [`useEffectEvent`](/reference/react/experimental_useEffectEvent) to extract this non-reactive logic out of your Effect:
 
-```js {1,4-6}
-import { useEffect, useEffectEvent } from 'react';
+```js {2,4-6}
+import { useEffect } from 'react';
+import { experimental_useEffectEvent as useEffectEvent } from 'react';
 
 function ChatRoom({ roomId, theme }) {
   const onConnected = useEffectEvent(() => {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Ignore this PR If the intention is to have the docs have final import for useEffectEvent api (which is not valid as api is in experimental stage and thus has different import path than the currently specified in docs)

If the above case is true, then I think it would be better to specify the current experimental import statement (for copying or learning) in the "under construction" banner or a comment or as a note as the real import is specified very down below in challenges section.

tl;dr - Updated the useEffectEvent import path to reflect the current experimental stage. 
