### PR TITLE
Removed misleading code in Sharing State Between Components page

### DIFF
--- a/src/content/learn/sharing-state-between-components.md
+++ b/src/content/learn/sharing-state-between-components.md
@@ -153,9 +153,7 @@ function Panel({ title, children, isActive }) {
       {isActive ? (
         <p>{children}</p>
       ) : (
-        <button onClick={() => setIsActive(true)}>
-          Show
-        </button>
+        <button>Show</button>
       )}
     </section>
   );


### PR DESCRIPTION
This pull request introduces the fix where I removed misleading code in the `Sharing State Between Components` page. With this fix, when the learners reach the `Step 2: Pass hardcoded data from the common parent` section, they will no longer see the piece of code that is not supposed to be there.

### Key Changes:
Removed the `setIsActive` function and its onClick handler in the `Panel` component.

### Rationale:
The `Panel` component doesn't know about the `setIsActive` function, so it shouldn't be there.

### Testing and Validation:
Conducted tests with `yarn check-all`. and made sure the functionality and UI behave as expected.
Verified that the component maintains its performance and responsiveness across different devices and browsers.
