### PR TITLE
Add warning page for ReactDOMTestUtils deprecation

### DIFF
--- a/src/content/warnings/react-dom-test-utils.md
+++ b/src/content/warnings/react-dom-test-utils.md
@@ -4,11 +4,18 @@ title: react-dom/test-utils Deprecation Warnings
 
 ## ReactDOMTestUtils.act() warning {/*reactdomtestutilsact-warning*/}
 
-`act` from `react-dom/test-utils` has been deprecated in favor of `act` from `react`:
+`act` from `react-dom/test-utils` has been deprecated in favor of `act` from `react`.
 
-```diff
--import {act} from 'react-dom/test-utils';
-+import {act} from 'react';
+Before:
+
+```js
+import {act} from 'react-dom/test-utils';
+```
+
+After:
+
+```js
+import {act} from 'react';
 ```
 
 ## Rest of ReactDOMTestUtils APIS {/*rest-of-reactdomtestutils-apis*/}
@@ -19,27 +26,44 @@ The React Team recommends migrating your tests to [@testing-library/react](https
 
 ### ReactDOMTestUtils.renderIntoDocument {/*reactdomtestutilsrenderintodocument*/}
 
-`renderIntoDocument` can be replaced with `render` from `@testing-library/react`:
+`renderIntoDocument` can be replaced with `render` from `@testing-library/react`.
 
-```diff
--import {renderIntoDocument} from 'react-dom/test-utils';
-+import {render} from '@testing-library/react';
+Before:
 
--renderIntoDocument(<Component />);
-+render(<Component />);
+```js
+import {renderIntoDocument} from 'react-dom/test-utils';
+
+renderIntoDocument(<Component />);
+```
+
+After:
+
+```js
+import {render} from '@testing-library/react';
+
+render(<Component />);
 ```
 
 ### ReactDOMTestUtils.Simulate {/*reactdomtestutilssimulate*/}
 
 `Simulate` can be replaced with `fireEvent` from `@testing-library/react`.
 
-```diff
--import {Simulate} from 'react-dom/test-utils';
-+import {fireEvent} from '@testing-library/react';
+Before:
+
+```js
+import {Simulate} from 'react-dom/test-utils';
 
 const element = document.querySelector('button');
--Simulate.click(element);
-+fireEvent.click(element);
+Simulate.click(element);
+```
+
+After:
+
+```js
+import {fireEvent} from '@testing-library/react';
+
+const element = document.querySelector('button');
+fireEvent.click(element);
 ```
 
 Be aware, that `fireEvent` dispatches an actual event on the element and doesn't just synthetically call the event handler.

--- a/src/content/warnings/react-dom-test-utils.md
+++ b/src/content/warnings/react-dom-test-utils.md
@@ -66,7 +66,7 @@ const element = document.querySelector('button');
 fireEvent.click(element);
 ```
 
-Be aware, that `fireEvent` dispatches an actual event on the element and doesn't just synthetically call the event handler.
+Be aware that `fireEvent` dispatches an actual event on the element and doesn't just synthetically call the event handler.
 
 ### List of all removed APIs {/*list-of-all-removed-apis-list-of-all-removed-apis*/}
 

--- a/src/content/warnings/react-dom-test-utils.md
+++ b/src/content/warnings/react-dom-test-utils.md
@@ -1,0 +1,63 @@
+---
+title: react-dom/test-utils Deprecation Warnings
+---
+
+## ReactDOMTestUtils.act() warning {/*reactdomtestutilsact-warning*/}
+
+`act` from `react-dom/test-utils` has been deprecated in favor of `act` from `react`:
+
+```diff
+-import {act} from 'react-dom/test-utils';
++import {act} from 'react';
+```
+
+## Rest of ReactDOMTestUtils APIS {/*rest-of-reactdomtestutils-apis*/}
+
+All APIs except `act` have been removed.
+
+The React Team recommends migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) for a modern and well supported testing experience.
+
+### ReactDOMTestUtils.renderIntoDocument {/*reactdomtestutilsrenderintodocument*/}
+
+`renderIntoDocument` can be replaced with `render` from `@testing-library/react`:
+
+```diff
+-import {renderIntoDocument} from 'react-dom/test-utils';
++import {render} from '@testing-library/react';
+
+-renderIntoDocument(<Component />);
++render(<Component />);
+```
+
+### ReactDOMTestUtils.Simulate {/*reactdomtestutilssimulate*/}
+
+`Simulate` can be replaced with `fireEvent` from `@testing-library/react`.
+
+```diff
+-import {Simulate} from 'react-dom/test-utils';
++import {fireEvent} from '@testing-library/react';
+
+const element = document.querySelector('button');
+-Simulate.click(element);
++fireEvent.click(element);
+```
+
+Be aware, that `fireEvent` dispatches an actual event on the element and doesn't just synthetically call the event handler.
+
+### List of all removed APIs {/*list-of-all-removed-apis-list-of-all-removed-apis*/}
+
+- `mockComponent()`
+- `isElement()`
+- `isElementOfType()`
+- `isDOMComponent()`
+- `isCompositeComponent()`
+- `isCompositeComponentWithType()`
+- `findAllInRenderedTree()`
+- `scryRenderedDOMComponentsWithClass()`
+- `findRenderedDOMComponentWithClass()`
+- `scryRenderedDOMComponentsWithTag()`
+- `findRenderedDOMComponentWithTag()`
+- `scryRenderedComponentsWithType()`
+- `findRenderedComponentWithType()`
+- `renderIntoDocument`
+- `Simulate`


### PR DESCRIPTION
Similar to https://github.com/reactjs/react.dev/pull/6632 but for `react-dom/test-utils` (https://github.com/facebook/react/pull/28541 + https://github.com/facebook/react/pull/28597)

Preview: https://react-dev-git-fork-eps1lon-rdtu-warnings-fbopensource.vercel.app/warnings/react-dom-test-utils

The wording isn't final with regards to deprecation vs warning vs error.