### PR TITLE
Update Node.js version in engines into package.json file (^21.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "webpack-bundle-analyzer": "^4.5.0"
   },
   "engines": {
-    "node": "^16.8.0 || ^18.0.0 || ^19.0.0 || ^20.0.0"
+    "node": "^16.8.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
   },
   "nextBundleAnalysis": {
     "budget": null,


### PR DESCRIPTION
## Summary

This pull request updates the `package.json` file to extend the supported Node.js versions to include version 21.0.0. The `engines` field is now modified to:

`
"engines": {
"node": "^16.8.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
},
`

## Problem I found
My current node version 21.6.1 so when I try to install dependencies and I get an incompatible error.
![node](https://github.com/reactjs/react.dev/assets/19346496/8b06d74e-a445-457a-9783-498f9260f176)
### Error
![error](https://github.com/reactjs/react.dev/assets/19346496/f2cd7a00-985a-482c-be1b-c6ef58953bf5)


## Changes

- The `engines.node` field in `package.json` has been updated to include `^21.0.0` alongside the previously supported versions. This change clarifies to developers and deployment environments which versions of Node.js are officially supported by our project.

