### PR TITLE
fix issue #6734

### DIFF
--- a/src/pages/errors/[errorCode].tsx
+++ b/src/pages/errors/[errorCode].tsx
@@ -36,7 +36,7 @@ export default function ErrorDecoderPage({
         }}
         routeTree={sidebarLearn as RouteItem}
         section="unknown">
-        {parsedContent}
+        <div style={{whiteSpace: 'pre-line'}}>{parsedContent}</div>
         {/* <MaxWidth>
           <P>
             We highly recommend using the development build locally when debugging

--- a/src/pages/errors/[errorCode].tsx
+++ b/src/pages/errors/[errorCode].tsx
@@ -36,7 +36,7 @@ export default function ErrorDecoderPage({
         }}
         routeTree={sidebarLearn as RouteItem}
         section="unknown">
-        <div style={{whiteSpace: 'pre-line'}}>{parsedContent}</div>
+        <div className="whitespace-pre-line">{parsedContent}</div>
         {/* <MaxWidth>
           <P>
             We highly recommend using the development build locally when debugging


### PR DESCRIPTION
In [errorCode].tsx, wrapped parsedContent containing the errorMessage content in a div and applied styling of white-space: 'pre-wrap' to preserve whitespace and break on newline characters. 

![Screenshot from 2024-04-05 19-07-48](https://github.com/reactjs/react.dev/assets/101359829/72a18220-a377-43a0-95ba-bb0a5906dcd3)


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
