### PR TITLE
Revert inappropriate capitalization of "Transition"

### DIFF
--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -1741,7 +1741,7 @@ function Router() {
   // ...
 ```
 
-This tells React that the state Transition is not urgent, and it's better to keep showing the previous page instead of hiding any already revealed content. Now clicking the button "waits" for the `Biography` to load:
+This tells React that the state transition is not urgent, and it's better to keep showing the previous page instead of hiding any already revealed content. Now clicking the button "waits" for the `Biography` to load:
 
 <Sandpack>
 


### PR DESCRIPTION
PR #6712 capitalized instances of "transition" to "Transition". I found one instance that shouldn't have been capitalized.

https://github.com/reactjs/react.dev/blob/a7103d8cc2ee8b10e314aea096538b5057e0ba10/src/content/reference/react/Suspense.md?plain=1#L1744

Here, "transition" in "state transition" does not refer to the React mechanism itself, so it should remain lowercase.

@rickhanlonii