### PR TITLE
Remove canary label from cache

### DIFF
--- a/src/components/MDX/ExpandableCallout.tsx
+++ b/src/components/MDX/ExpandableCallout.tsx
@@ -10,7 +10,13 @@ import {IconWarning} from '../Icon/IconWarning';
 import {IconPitfall} from '../Icon/IconPitfall';
 import {IconCanary} from '../Icon/IconCanary';
 
-type CalloutVariants = 'deprecated' | 'pitfall' | 'note' | 'wip' | 'canary';
+type CalloutVariants =
+  | 'changelog'
+  | 'deprecated'
+  | 'pitfall'
+  | 'note'
+  | 'wip'
+  | 'canary';
 
 interface ExpandableCalloutProps {
   children: React.ReactNode;
@@ -28,6 +34,15 @@ const variantMap = {
   },
   note: {
     title: 'Note',
+    Icon: IconNote,
+    containerClasses:
+      'bg-green-5 dark:bg-green-60 dark:bg-opacity-20 text-primary dark:text-primary-dark text-lg',
+    textColor: 'text-green-60 dark:text-green-40',
+    overlayGradient:
+      'linear-gradient(rgba(245, 249, 248, 0), rgba(245, 249, 248, 1)',
+  },
+  changelog: {
+    title: 'Changelog',
     Icon: IconNote,
     containerClasses:
       'bg-green-5 dark:bg-green-60 dark:bg-opacity-20 text-primary dark:text-primary-dark text-lg',

--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -94,6 +94,9 @@ const Note = ({children}: {children: React.ReactNode}) => (
 const Canary = ({children}: {children: React.ReactNode}) => (
   <ExpandableCallout type="canary">{children}</ExpandableCallout>
 );
+const Changelog = ({children}: {children: React.ReactNode}) => (
+  <ExpandableCallout type="changelog">{children}</ExpandableCallout>
+);
 
 const CanaryBadge = ({title}: {title: string}) => (
   <span
@@ -292,7 +295,7 @@ function IllustrationBlock({
   );
   const images = imageInfos.map((info, index) => (
     <figure key={index}>
-      <div className="bg-white rounded-lg p-4 flex-1 flex xl:p-6 justify-center items-center my-4">
+      <div className="flex items-center justify-center flex-1 p-4 my-4 bg-white rounded-lg xl:p-6">
         <img
           className="text-primary"
           src={info.src}
@@ -445,6 +448,7 @@ export const MDXComponents = {
   MathI,
   Note,
   Canary,
+  Changelog,
   CanaryBadge,
   PackageImport,
   ReadBlogPost,

--- a/src/content/reference/react/cache.md
+++ b/src/content/reference/react/cache.md
@@ -1,13 +1,10 @@
 ---
 title: cache
-canary: true
 ---
 
-<Canary>
-* `cache` is only for use with [React Server Components](/blog/2023/03/22/react-labs-what-we-have-been-working-on-march-2023#react-server-components). See [frameworks](/learn/start-a-new-react-project#bleeding-edge-react-frameworks) that support React Server Components.
-
-* `cache` is only available in React’s [Canary](/community/versioning-policy#canary-channel) and [experimental](/community/versioning-policy#experimental-channel) channels. Please ensure you understand the limitations before using `cache` in production. Learn more about [React's release channels here](/community/versioning-policy#all-release-channels).
-</Canary>
+<Changelog>
+* `cache` was added in React 19.0.0
+</Changelog>
 
 <Intro>
 
@@ -495,4 +492,3 @@ function App() {
   );
 }
 ```
-

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -114,8 +114,7 @@
       "routes": [
         {
           "title": "cache",
-          "path": "/reference/react/cache",
-          "canary": true
+          "path": "/reference/react/cache"
         },
         {
           "title": "createContext",


### PR DESCRIPTION
An idea how to signal the version support of `cache`.