### PR TITLE
Add Changelog for cache

### DIFF
--- a/src/content/reference/react/cache.md
+++ b/src/content/reference/react/cache.md
@@ -1,13 +1,6 @@
 ---
 title: cache
-canary: true
 ---
-
-<Canary>
-* `cache` is only for use with [React Server Components](/blog/2023/03/22/react-labs-what-we-have-been-working-on-march-2023#react-server-components). See [frameworks](/learn/start-a-new-react-project#bleeding-edge-react-frameworks) that support React Server Components.
-
-* `cache` is only available in React’s [Canary](/community/versioning-policy#canary-channel) and [experimental](/community/versioning-policy#experimental-channel) channels. Please ensure you understand the limitations before using `cache` in production. Learn more about [React's release channels here](/community/versioning-policy#all-release-channels).
-</Canary>
 
 <Intro>
 
@@ -496,3 +489,6 @@ function App() {
 }
 ```
 
+## Changelog {/*changelog*/}
+
+- **19.0.0:** added `cache`

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -114,8 +114,7 @@
       "routes": [
         {
           "title": "cache",
-          "path": "/reference/react/cache",
-          "canary": true
+          "path": "/reference/react/cache"
         },
         {
           "title": "createContext",


### PR DESCRIPTION
An alternative proposal to add a changelog to the bottom of the page to show newly added APIs.

This is similar to

- php.net: https://www.php.net/manual/en/function.get-magic-quotes-runtime.php#refsect1-function.get-magic-quotes-runtime-changelog
- MDN: https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore#browser_compatibility

This approach in having 1 evergreen docs page reduces a lot of headache of having older versions that might still want occasional updates, especially with a very stable API like React.