### PR TITLE
RFC: Move deprecated APIs in sidebar

### DIFF
--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -17,6 +17,7 @@ interface SidebarLinkProps {
   title: string;
   level: number;
   canary?: boolean;
+  deprecated?: boolean;
   icon?: React.ReactNode;
   isExpanded?: boolean;
   hideArrow?: boolean;
@@ -28,6 +29,7 @@ export function SidebarLink({
   selected = false,
   title,
   canary,
+  deprecated,
   level,
   isExpanded,
   hideArrow,
@@ -63,7 +65,9 @@ export function SidebarLink({
           'text-sm ps-6': level > 0,
           'ps-5': level < 2,
           'text-base font-bold': level === 0,
-          'text-primary dark:text-primary-dark': level === 0 && !selected,
+          'text-primary dark:text-primary-dark':
+            !deprecated && level === 0 && !selected,
+          'text-gray-30 dark:text-gray-60': deprecated && !selected,
           'text-base text-secondary dark:text-secondary-dark':
             level > 0 && !selected,
           'text-base text-link dark:text-link-dark bg-highlight dark:bg-highlight-dark border-blue-40 hover:bg-highlight hover:text-link dark:hover:bg-highlight-dark dark:hover:text-link-dark':

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -87,6 +87,7 @@ export function SidebarRouteTree({
             title,
             routes,
             canary,
+            deprecated,
             heading,
             hasSectionHeader,
             sectionHeader,
@@ -121,6 +122,7 @@ export function SidebarRouteTree({
                   level={level}
                   title={title}
                   canary={canary}
+                  deprecated={deprecated}
                   isExpanded={isExpanded}
                   hideArrow={isForceExpanded}
                 />
@@ -145,6 +147,7 @@ export function SidebarRouteTree({
                   level={level}
                   title={title}
                   canary={canary}
+                  deprecated={deprecated}
                 />
               </li>
             );

--- a/src/components/Layout/getRouteMeta.tsx
+++ b/src/components/Layout/getRouteMeta.tsx
@@ -21,6 +21,8 @@ export interface RouteItem {
   title: string;
   /** Optional canary flag for heading */
   canary?: boolean;
+  /** Optional deprecated flag */
+  deprecated?: boolean;
   /** Optional page description for heading */
   description?: string;
   /* Additional meta info for page tagging */

--- a/src/content/reference/react-dom/deprecated.md
+++ b/src/content/reference/react-dom/deprecated.md
@@ -1,0 +1,9 @@
+---
+title: Deprecated React DOM APIs
+---
+
+<Intro>
+
+The APIs documented under this page have been deprecated or removed from React. They are documented here for historical purposes or for users who are still using older versions of React.
+
+</Intro>

--- a/src/content/reference/react-dom/render.md
+++ b/src/content/reference/react-dom/render.md
@@ -4,7 +4,7 @@ title: render
 
 <Deprecated>
 
-This API will be removed in a future major version of React.
+In React 19, `unmountComponentAtNode` was removed.
 
 In React 18, `render` was replaced by [`createRoot`.](/reference/react-dom/client/createRoot) Using `render` in React 18 will warn that your app will behave as if it’s running React 17. Learn more [here.](/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis)
 

--- a/src/content/reference/react-dom/unmountComponentAtNode.md
+++ b/src/content/reference/react-dom/unmountComponentAtNode.md
@@ -4,7 +4,7 @@ title: unmountComponentAtNode
 
 <Deprecated>
 
-This API will be removed in a future major version of React.
+In React 19, `unmountComponentAtNode` was removed.
 
 In React 18, `unmountComponentAtNode` was replaced by [`root.unmount()`](/reference/react-dom/client/createRoot#root-unmount).
 

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -295,14 +295,6 @@
           "title": "preloadModule",
           "path": "/reference/react-dom/preloadModule",
           "canary": true
-        },
-        {
-          "title": "render",
-          "path": "/reference/react-dom/render"
-        },
-        {
-          "title": "unmountComponentAtNode",
-          "path": "/reference/react-dom/unmountComponentAtNode"
         }
       ]
     },
@@ -347,6 +339,21 @@
         {
           "title": "renderToString",
           "path": "/reference/react-dom/server/renderToString"
+        }
+      ]
+    },
+    {
+      "title": "Deprecated APIs",
+      "path": "/reference/react-dom/deprecated",
+      "deprecated": true,
+      "routes": [
+        {
+          "title": "render",
+          "path": "/reference/react-dom/render"
+        },
+        {
+          "title": "unmountComponentAtNode",
+          "path": "/reference/react-dom/unmountComponentAtNode"
         }
       ]
     },


### PR DESCRIPTION
This is a proposal how we can retain pages for deprecated APIs while maintaining an "evergreen" page that avoids creating versioned copies.

This adds a new navigation entry for the deprecated React DOM APIs where they can remain. I greyed out the text to de-emphasize the navigation entry.

The moved doc pages retain their original URL even when they're under a different entry now. We could also consider making the old URLs a redirect to a `/deprecated/` path.