### PR TITLE
Better UX in SidebarNav

### DIFF
--- a/src/components/Layout/SidebarNav/SidebarNav.tsx
+++ b/src/components/Layout/SidebarNav/SidebarNav.tsx
@@ -34,9 +34,10 @@ export default function SidebarNav({
         'sticky top-0 lg:bottom-0 lg:h-[calc(100vh-4rem)] flex flex-col'
       )}>
       <div
-        className="overflow-y-scroll no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark"
+        className="overflow-y-auto no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark"
         style={{
           overscrollBehavior: 'contain',
+          scrollbarGutter: 'stable',
         }}>
         <aside
           className={cn(


### PR DESCRIPTION
When SidebarNav has all elements collapsed it shows always the scroll-y (due to overflow-y-scroll class). If change it with overflow-y-auto it disappears when it is no needed and to avoid changing width, also is added a style: scrollbar-gutter: stable;

Before:
![before](https://github.com/reactjs/react.dev/assets/2633254/6b72fbc9-3b16-4dac-8e20-39af5e253c52)

After:
![after](https://github.com/reactjs/react.dev/assets/2633254/681c06c9-99a9-4ddd-9d97-922a3efce915)
