### PR TITLE
/errors: Empty args are not missing arguments

### DIFF
--- a/src/components/MDX/ErrorDecoder.tsx
+++ b/src/components/MDX/ErrorDecoder.tsx
@@ -11,7 +11,7 @@ function replaceArgs(
   return msg.replace(/%s/g, function () {
     const arg = argList[argIdx++];
     // arg can be an empty string: ?args[0]=&args[1]=count
-    return arg === undefined || arg === '' ? replacer : arg;
+    return arg === undefined ? replacer : arg;
   });
 }
 


### PR DESCRIPTION
e.g. the hydration diff will always produce `/errors/418?args[]=` in prod because prod doesn't have diffs. This displayed a `[missing-argument]` which isn't accurate.

Includes drive-by fix for https://github.com/reactjs/react.dev/issues/6734


Preview: 
- https://react-dev-git-fork-eps1lon-empty-error-decoder-fbopensource.vercel.app/errors/418?args[]=
- Still shows missing if args[] is absent: https://react-dev-git-fork-eps1lon-empty-error-decoder-fbopensource.vercel.app/errors/418