### PR TITLE
fix: appropriately set prevRoute and nextRoute in getRouteMeta.tsx

### DIFF
--- a/src/components/Layout/getRouteMeta.tsx
+++ b/src/components/Layout/getRouteMeta.tsx
@@ -85,8 +85,8 @@ function buildRouteMeta(
 
   const {routes} = currentRoute;
 
-  if (ctx.route && !ctx.nextRoute) {
-    ctx.nextRoute = currentRoute;
+  if (!ctx.route) {
+    ctx.prevRoute = currentRoute;
   }
 
   if (currentRoute.path === searchPath) {
@@ -98,8 +98,8 @@ function buildRouteMeta(
     ctx.nextRoute = undefined;
   }
 
-  if (!ctx.route) {
-    ctx.prevRoute = currentRoute;
+  if (ctx.route && !ctx.nextRoute) {
+    ctx.nextRoute = currentRoute;
   }
 
   if (!routes) {


### PR DESCRIPTION
at the moment, on the blog, the link to the previous route is actually the next route and that of the next route, is the article before the current one (the open page).

that default comes from this file and to fix it, i set `prevRoute` to `ctx.route` initially and when the current route is found, `prevRoute` is assigned the last breadcrumb if the current index is greater than 1.

for example, in this screenshot below, the next article was published in March 2023, while the previous was in February 2024. Meanwhile, it should be the other way round

![Screenshot 2024-04-23 at 10 42 44](https://github.com/reactjs/react.dev/assets/44336070/66d76bac-fc10-4326-ad4b-cb022509873a)


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
