### PR TITLE
Update test warning content

### DIFF
--- a/src/content/warnings/react-test-renderer.md
+++ b/src/content/warnings/react-test-renderer.md
@@ -4,11 +4,20 @@ title: react-test-renderer Deprecation Warnings
 
 ## ReactTestRenderer.create() warning {/*reacttestrenderercreate-warning*/}
 
-react-test-renderer is deprecated. A warning will fire whenever calling ReactTestRenderer.create() or ReactShallowRender.render(). The react-test-renderer package will remain available on NPM but will not be maintained and may break with new React features or changes to React's internals.
+`react-test-renderer` is deprecated. An error will log whenever calling ReactTestRenderer.create(). The package will remain available on NPM but will not be maintained and will break with new React features or changes to React's internals.
 
+<Note>
 The React Team recommends migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) for a modern and well supported testing experience.
 
+If your application has extensive `react-test-renderer` usage, consider pinning the package to an alias such as `react-test-renderer-DO_NOT_USE` and incrementally migrating to `testing-library`. When your tests have been migrated, you can upgrade to React 19 with more confidence.
+</Note>
 
 ## new ShallowRenderer() warning {/*new-shallowrenderer-warning*/}
 
-The react-test-renderer package no longer exports a shallow renderer at `react-test-renderer/shallow`. This was simply a repackaging of a previously extracted separate package: `react-shallow-renderer`. Therefore you can continue using the shallow renderer in the same way by installing it directly. See [Github](https://github.com/enzymejs/react-shallow-renderer) / [NPM](https://www.npmjs.com/package/react-shallow-renderer).
+Shallow rendering is no longer supported. As of React 19, the `react-test-renderer` package no longer exports a renderer at `react-test-renderer/shallow` and you will get an error when creating a `ShallowRenderer` instance.
+
+<Note>
+The React Team recommends migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) for a modern and well supported testing experience.
+
+If your application has extensive `react-test-renderer/shallow` usage, consider installing the external package, [`react-shallow-renderer`](https://www.npmjs.com/package/react-shallow-renderer), pinning it to an alias such as `react-shallow-renderer-DO_NOT_USE`, and incrementally migrating to `testing-library`. When your tests have been migrated, you can upgrade to React 19 with more confidence.
+</Note>


### PR DESCRIPTION
- Make it more clear that shallow rendering is not supported
- Provide recommendations for incrementally migrating tests before major version upgrade