### PR TITLE
Refines the language around server component stability to emphasize it's stability for user facing purposes

### DIFF
--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -312,9 +312,9 @@ React 19 includes all of the React Server Components features included from the 
 
 #### How do I build support for Server Components? {/*how-do-i-build-support-for-server-components*/}
 
-Bundler and framework support for React Server Components can be built on React 19, but the underlying APIs will not follow semver and may break between minors in React 19.x. 
+While React Server Components in React 19 are stable and will not break between major versions, the underlying APIs used to implement a React Server Components bundler or framework do not follow semver and may break between minors in React 19.x. 
 
-To support React Server Components, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stabilize support for React Server Components in future versions.
+To support React Server Components as a bundler or framework, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stabilize the APIs used to implement React Server Components in the future.
 
 </Note>
 

--- a/src/content/reference/rsc/server-actions.md
+++ b/src/content/reference/rsc/server-actions.md
@@ -13,11 +13,11 @@ Server Actions allow Client Components to call async functions executed on the s
 
 <Note>
 
-#### How do I build support for Server Actions? {/*how-do-i-build-support-for-server-components*/}
+#### How do I build support for Server Actions? {/*how-do-i-build-support-for-server-actions*/}
 
-Bundler and framework support for Server Actins can be built on React 19, but the underlying APIs will not follow semver and may break between minors in React 19.x.
+While Server Actions in React 19 are stable and will not break between major versions, the underlying APIs used to implement Server Actions in a React Server Components bundler or framework do not follow semver and may break between minors in React 19.x. 
 
-To support Server Actions, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stablize support for React Server Components in future versions.
+To support Server Actions as a bundler or framework, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stabilize the APIs used to implement Server Actions in the future.
 
 </Note>
 

--- a/src/content/reference/rsc/server-components.md
+++ b/src/content/reference/rsc/server-components.md
@@ -17,9 +17,9 @@ This separate environment is the "server" in React Server Components. Server Com
 
 #### How do I build support for Server Components? {/*how-do-i-build-support-for-server-components*/}
 
-Bundler and framework support for React Server Components can be built on React 19, but the underlying APIs will not follow semver and may break between minors in React 19.x.
+While React Server Components in React 19 are stable and will not break between major versions, the underlying APIs used to implement a React Server Components bundler or framework do not follow semver and may break between minors in React 19.x. 
 
-To support React Server Components, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stablize support for React Server Components in future versions.
+To support React Server Components as a bundler or framework, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stabilize the APIs used to implement React Server Components in the future.
 
 </Note>
 


### PR DESCRIPTION
Some feedback about the original post is that the line explaining stabilizing Server Components might imply the feature itself is unstable to use when we intend to communicate that the APIs a framework needs to integrate with might change outside of semver updates. This change clarifies the messaging