### PR TITLE
[React19-blog]: Make use(context) example easier to understand

### DIFF
--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -287,7 +287,7 @@ function ThemedPage({theme, children}) {
     currentTheme = use(LightThemeContext);
   } 
   return (
-    <Page theme={themeValue}>
+    <Page theme={currentTheme}>
       {children}
     </Page>
   );

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -284,7 +284,7 @@ function ThemedPage({theme, children}) {
   if (theme === 'dark') {
     themeValue = use(DarkThemeContext);
   } else {
-    themeValue = use(LightThemeContext);
+    currentTheme = use(LightThemeContext);
   } 
   return (
     <Page theme={themeValue}>

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -280,14 +280,14 @@ import LightThemeContext from './LightThemeContext'
 import DarkThemeContext from './ThemeContext'
 
 function ThemedPage({theme, children}) {
-  let theme;
+  let themeValue;
   if (theme === 'dark') {
-    theme = use(DarkThemeContext);
+    themeValue = use(DarkThemeContext);
   } else {
-    theme = use(LightThemeContext);
+    themeValue = use(LightThemeContext);
   } 
   return (
-    <Page theme={theme}>
+    <Page theme={themeValue}>
       {children}
     </Page>
   );

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -280,7 +280,7 @@ import LightThemeContext from './LightThemeContext'
 import DarkThemeContext from './ThemeContext'
 
 function ThemedPage({theme, children}) {
-  let themeValue;
+  let currentTheme;
   if (theme === 'dark') {
     currentTheme = use(DarkThemeContext);
   } else {

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -282,7 +282,7 @@ import DarkThemeContext from './ThemeContext'
 function ThemedPage({theme, children}) {
   let themeValue;
   if (theme === 'dark') {
-    themeValue = use(DarkThemeContext);
+    currentTheme = use(DarkThemeContext);
   } else {
     currentTheme = use(LightThemeContext);
   } 


### PR DESCRIPTION
Current example was defining a local variable with the same name as the prop which was had to understand (also technically it's a runtime error) 
