### PR TITLE
Better use(Promise) example in 19 blog

### DIFF
--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -243,7 +243,7 @@ In React 19 we're introducing a new API to read resources in render: `use`.
 
 For example, you can read a promise with `use`, and React will Suspend until the promise resolves:
 
-```js {1,6}
+```js {1,5}
 import {use} from 'react';
 
 function Comments({commentsPromise}) {

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -247,10 +247,19 @@ For example, you can read a promise with `use`, and React will Suspend until the
 import {use} from 'react';
 
 function Comments({commentsPromise}) {
-  // NOTE: this will resume the promise from the server.
-  // It will suspend until the data is available.
+  // `use` will suspend until the promise resolves.
   const comments = use(commentsPromise);
-  return comments.map(comment => <p>{comment}</p>);
+  return comments.map(comment => <p key={comment.id}>{comment}</p>);
+}
+
+function Page({commentsPromise}) {
+  // When `use` suspends in Comments,
+  // this Suspense boundary will be shown.
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Comments commentsPromise={commentsPromise} />
+    </Suspense>
+  )
 }
 ```
 


### PR DESCRIPTION
Adds a `key` and a parent with a `<Suspense>` bondary.