### PR TITLE
chore: fix typo

### DIFF
--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -627,7 +627,7 @@ This is also what you'd also have to do if you move the reducer outside of the `
 const reducer = (state: State, action: Action) => state;
 ```
 
-## Changlog {/*changelog*/}
+## Changelog {/*changelog*/}
 
 ### Other breaking changes {/*other-breaking-changes*/}
 


### PR DESCRIPTION
`Changlog` -> `Changelog`

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
