### PR TITLE
Add redirects for moved rsc pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -158,6 +158,21 @@
       "source": "/link/new-jsx-transform",
       "destination": "https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html",
       "permanent": false
+    },
+    {
+      "source": "/reference/react/directives",
+      "destination": "/reference/rsc/directives",
+      "permanent": true
+    },
+    {
+      "source": "/reference/react/use-client",
+      "destination": "/reference/rsc/use-client",
+      "permanent": true
+    },
+    {
+      "source": "/reference/react/use-server",
+      "destination": "/reference/rsc/use-server",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
Closes https://github.com/reactjs/react.dev/issues/6799

Adds redirects for the pages that got moved during https://github.com/reactjs/react.dev/pull/6778.

We already updated internal links in https://github.com/reactjs/react.dev/pull/6797 but these pages were around for half a year so there's a high chance links to these pages still exist somewhere.