### PR TITLE
Fix: new meta tag add for quick start's indexing 

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -1,5 +1,5 @@
 ---
-title: Quick Start
+title: Quick Start - Getting Started
 ---
 
 <Intro>


### PR DESCRIPTION
I added `Getting Started` to title for better indexing from the old version of docs.

#6832