### PR TITLE
Fix typo in React.cache example

### DIFF
--- a/src/content/reference/react/cache.md
+++ b/src/content/reference/react/cache.md
@@ -226,7 +226,7 @@ By caching a long-running data fetch, you can kick off asynchronous work prior t
 ```jsx [[2, 6, "await getUser(id)"], [1, 17, "getUser(id)"]]
 const getUser = cache(async (id) => {
   return await db.user.query(id);
-}
+});
 
 async function Profile({id}) {
   const user = await getUser(id);


### PR DESCRIPTION
Add a pair of parentheses to the example code.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
