### PR TITLE
Clearer rule severity for React Compiler eslint plugin

### DIFF
--- a/src/content/learn/react-compiler.md
+++ b/src/content/learn/react-compiler.md
@@ -121,7 +121,7 @@ module.exports = {
     'eslint-plugin-react-compiler',
   ],
   rules: {
-    'react-compiler/react-compiler': 2,
+    'react-compiler/react-compiler': "error",
   },
 }
 ```


### PR DESCRIPTION
## What is this PR?
Updates the eslint-plugin-react-compiler docs to use severity of `"error"` rather than severity of `2`

## Why is this PR?
Using `"off"`, `"warn"`, `"error"` for eslint rule severity has been supported for many years now - I think this helps improve the readability :) 

I completely forgot what rule: 2 meant - had to look it up!
https://eslint.org/docs/latest/use/configure/rules

