### PR TITLE
Rm dupe blog description

### DIFF
--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -22,7 +22,6 @@ function PageHeading({
   title,
   status,
   canary,
-  description,
   tags = [],
   breadcrumbs,
 }: PageHeadingProps) {
@@ -40,11 +39,6 @@ function PageHeading({
           )}
           {status ? <em>—{status}</em> : ''}
         </H1>
-        {description && (
-          <p className="mt-4 mb-6 dark:text-primary-dark text-xl text-primary leading-large">
-            {description}
-          </p>
-        )}
         {tags?.length > 0 && (
           <div className="mt-4">
             {tags.map((tag) => (


### PR DESCRIPTION
When we added the RSS feed, we added `description` to the .md header info, but there was already Page code to render the description metadata (probably from the old site) resulting in duplicated content. Since the `description` metadata is only used in the blog, this PR just deletes it from the Page component.