### PR TITLE
Fix missing comma in callback - react-compiler.md

### DIFF
--- a/src/content/learn/react-compiler.md
+++ b/src/content/learn/react-compiler.md
@@ -341,7 +341,7 @@ function reactCompilerLoader(sourceCode, sourceMap) {
 
   this.callback(
     null,
-    result.code
+    result.code,
     result.map === null ? undefined : result.map
   );
 }


### PR DESCRIPTION
The webpack loader snippet for React Compiler has a missing comma:

<img width="991" alt="image" src="https://github.com/reactjs/react.dev/assets/41679/b89f2f71-48dd-418b-933b-708c7e517fda">


