### PR TITLE
docs: update links @testing-library/react-native

### DIFF
--- a/src/content/warnings/react-test-renderer.md
+++ b/src/content/warnings/react-test-renderer.md
@@ -6,7 +6,7 @@ title: react-test-renderer Deprecation Warnings
 
 react-test-renderer is deprecated. A warning will fire whenever calling ReactTestRenderer.create() or ReactShallowRender.render(). The react-test-renderer package will remain available on NPM but will not be maintained and may break with new React features or changes to React's internals.
 
-The React Team recommends migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) for a modern and well supported testing experience.
+The React Team recommends migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/start/intro) for a modern and well supported testing experience.
 
 
 ## new ShallowRenderer() warning {/*new-shallowrenderer-warning*/}


### PR DESCRIPTION
# Issue
The link in the React Native library documentation is broken.
https://react.dev/warnings/react-test-renderer

# The old way
[@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started)

# The new way
[@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/start/intro)

# Fix
Text updated with new link