### PR TITLE
Fix: replace broken Placekitten placeholder images with Loremflickr

### DIFF
--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -137,21 +137,21 @@ export default function CatFriends() {
         <ul>
           <li>
             <img
-              src="https://cataas.com/cat?width=200&height=200&tag=flower"
+              src="https://loremflickr.com/200/200/cat"
               alt="Tom"
               ref={firstCatRef}
             />
           </li>
           <li>
             <img
-              src="https://cataas.com/cat?width=300&height=200&tag=cute"
+              src="https://loremflickr.com/300/200/cat"
               alt="Maru"
               ref={secondCatRef}
             />
           </li>
           <li>
             <img
-              src="https://cataas.com/cat?width=300&height=200&tag=angel"
+              src="https://loremflickr.com/250/200/cat"
               alt="Jellylorum"
               ref={thirdCatRef}
             />
@@ -948,7 +948,7 @@ const catList = [];
 for (let i = 0; i < 10; i++) {
   catList.push({
     id: i,
-    imageUrl: `https://cataas.com/cat?width=${250 + i}&height=200`
+    imageUrl: "https://loremflickr.com/200/200/cat?lock=" + i
   });
 }
 
@@ -1065,7 +1065,7 @@ const catList = [];
 for (let i = 0; i < 10; i++) {
   catList.push({
     id: i,
-    imageUrl: `https://cataas.com/cat?width=${250 + i}&height=200`
+    imageUrl: "https://loremflickr.com/250/200/cat?lock=" + i,
   });
 }
 

--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -137,21 +137,21 @@ export default function CatFriends() {
         <ul>
           <li>
             <img
-              src="https://placekitten.com/g/200/200"
+              src="https://cataas.com/cat?width=200&height=200&tag=flower"
               alt="Tom"
               ref={firstCatRef}
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/300/200"
+              src="https://cataas.com/cat?width=300&height=200&tag=cute"
               alt="Maru"
               ref={secondCatRef}
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/250/200"
+              src="https://cataas.com/cat?width=300&height=200&tag=angel"
               alt="Jellylorum"
               ref={thirdCatRef}
             />
@@ -948,7 +948,7 @@ const catList = [];
 for (let i = 0; i < 10; i++) {
   catList.push({
     id: i,
-    imageUrl: 'https://placekitten.com/250/200?image=' + i
+    imageUrl: `https://cataas.com/cat?width=${250 + i}&height=200`
   });
 }
 
@@ -1065,7 +1065,7 @@ const catList = [];
 for (let i = 0; i < 10; i++) {
   catList.push({
     id: i,
-    imageUrl: 'https://placekitten.com/250/200?image=' + i
+    imageUrl: `https://cataas.com/cat?width=${250 + i}&height=200`
   });
 }
 

--- a/src/content/reference/react/useRef.md
+++ b/src/content/reference/react/useRef.md
@@ -340,19 +340,19 @@ export default function CatFriends() {
         <ul ref={listRef}>
           <li>
             <img
-              src="https://placekitten.com/g/200/200"
+              src="https://cataas.com/cat?width=200&height=200&tag=flower"
               alt="Tom"
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/300/200"
+              src="https://cataas.com/cat?width=300&height=200&tag=cute"
               alt="Maru"
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/250/200"
+              src="https://cataas.com/cat?width=250&height=200&tag=angel"
               alt="Jellylorum"
             />
           </li>

--- a/src/content/reference/react/useRef.md
+++ b/src/content/reference/react/useRef.md
@@ -340,19 +340,19 @@ export default function CatFriends() {
         <ul ref={listRef}>
           <li>
             <img
-              src="https://cataas.com/cat?width=200&height=200&tag=flower"
+              src="https://loremflickr.com/200/200/cat"
               alt="Tom"
             />
           </li>
           <li>
             <img
-              src="https://cataas.com/cat?width=300&height=200&tag=cute"
+              src="https://loremflickr.com/300/200/cat"
               alt="Maru"
             />
           </li>
           <li>
             <img
-              src="https://cataas.com/cat?width=250&height=200&tag=angel"
+              src="https://loremflickr.com/250/200/cat"
               alt="Jellylorum"
             />
           </li>


### PR DESCRIPTION
# Description
[Placekitten](https://placekitten.com/) (cat placeholder images) seems to be [down](https://downforeveryoneorjustme.com/placekitten.com).  

# Changes Made
I've replaced the placekitten urls with [loremflickr](https://loremflickr.com/) urls, another free placeholder image service that can supply cat images.  It's already being used elsewhere within the codebase for cat images, and allows width and height parameters to be passed (so that the image dimensions of the original placeholders could be matched).  This change could be used just temporarily if placekitten being down is also temporary.

# Code of Conduct
This pull request adheres to the project's [Code of Conduct](https://opensource.fb.com/code-of-conduct/).

# Screenshots

**[(React docs) Example: Scrolling to an element](https://react.dev/learn/manipulating-the-dom-with-refs#example-scrolling-to-an-element)**
- **Before change (placekitten):**
  - <img width="1119" alt="CleanShot 2024-06-01 at 20 06 57@2x" src="https://github.com/reactjs/react.dev/assets/78520107/45c88e27-b327-4902-897d-183cea4392f3">


- **After change (loremflickr)**:
  - ![CleanShot 2024-06-01 at 21 01 27](https://github.com/reactjs/react.dev/assets/78520107/993070d4-05c6-459f-a6fa-9c4c259bd8a5)


---
**[(React docs) Challenge: Scrolling an image carousel](https://react.dev/learn/manipulating-the-dom-with-refs#scrolling-an-image-carousel)**
- **Before change (placekitten)**:
  - <img width="1058" alt="CleanShot 2024-06-01 at 20 06 09@2x" src="https://github.com/reactjs/react.dev/assets/78520107/70d62295-3cf7-42ac-bcfc-72ede8726be9">

- **After change (loremflickr)**:
  - ![CleanShot 2024-06-01 at 21 01 07](https://github.com/reactjs/react.dev/assets/78520107/5f8f15e7-29af-47ef-ab94-48fc3e79823e)




