### PR TITLE
docs(api-act): api act parts word error

### DIFF
--- a/src/content/reference/react/act.md
+++ b/src/content/reference/react/act.md
@@ -109,7 +109,7 @@ it('can render and update a counter', async () => {
 });
 ```
 
-Here, wwe create a container, append it to the document, and render the `Counter` component inside `act()`. This ensures that the component is rendered and its effects are applied before making assertions.
+Here, we create a container, append it to the document, and render the `Counter` component inside `act()`. This ensures that the component is rendered and its effects are applied before making assertions.
 
 Using `act` ensures that all updates have been applied before we make assertions.
 


### PR DESCRIPTION
- Question Description:
	-  	There is a misspelling in [api-act](https://react.dev/reference/react/act#rendering-components-in-tests) parts of the document. If it is intentional, please ignore this PR.
	- 	As shown below:
	![image](https://github.com/reactjs/react.dev/assets/88535417/9e06d398-2156-4908-9cd8-e3ede010d68e)

-	Amend as follows:
	-	Replace `wwe` with `we` , The modification code is as follows.
	![image](https://github.com/reactjs/react.dev/assets/88535417/391d64bd-c1d5-421d-be5b-ea659d2a7ec7)
