### PR TITLE
fix: update SidebarNav component style

### DIFF
--- a/src/components/Layout/SidebarNav/SidebarNav.tsx
+++ b/src/components/Layout/SidebarNav/SidebarNav.tsx
@@ -34,7 +34,7 @@ export default function SidebarNav({
         'sticky top-0 lg:bottom-0 lg:h-[calc(100vh-4rem)] flex flex-col'
       )}>
       <div
-        className="overflow-y-scroll no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark"
+        className="overflow-y-scroll no-bg-scrollbar grow bg-wash dark:bg-wash-dark"
         style={{
           overscrollBehavior: 'contain',
         }}>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -154,8 +154,8 @@ module.exports = {
       colors,
       gridTemplateColumns: {
         'only-content': 'auto',
-        'sidebar-content': '20rem auto',
-        'sidebar-content-toc': '20rem auto 20rem',
+        'sidebar-content': '342px auto',
+        'sidebar-content-toc': '342px auto 20rem',
       },
     },
   },


### PR DESCRIPTION
considering that the grid-template for the “lg” breakpoint is “grid-cols-sidebar-content”.

https://github.com/reactjs/react.dev/blob/b12743c31af7f5cda2c25534f64281ff030b7205/src/components/Layout/Page.tsx#L146-L150

https://github.com/reactjs/react.dev/blob/b12743c31af7f5cda2c25534f64281ff030b7205/tailwind.config.js#L155-L159

and the fixed width of the SidebarNav in:

https://github.com/reactjs/react.dev/blob/b12743c31af7f5cda2c25534f64281ff030b7205/src/components/Layout/SidebarNav/SidebarNav.tsx#L37-L37

<hr>

I think the “20rem” width might not be enough, considering the fixed width of the SidebarNav.

I think we could consider that the width should be defined in the grid-template.