### PR TITLE
Recommend installing exact RC

### DIFF
--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -73,6 +73,12 @@ To install the latest version of React and React DOM:
 npm install --save-exact react@rc react-dom@rc
 ```
 
+Or, if you're using Yarn:
+
+```bash
+yarn add --exact react@rc react-dom@rc
+```
+
 If you're using TypeScript, you also need to update the types. Once React 19 is released as stable, you can install the types as usual from `@types/react` and `@types/react-dom`.  Until the stable release, the types are available in different packages which need to be enforced in your `package.json`:
 
 ```json

--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -70,7 +70,7 @@ We expect most apps will not be affected since the transform is enabled in most 
 To install the latest version of React and React DOM:
 
 ```bash
-npm install react@rc react-dom@rc
+npm install --save-exact react@rc react-dom@rc
 ```
 
 If you're using TypeScript, you also need to update the types. Once React 19 is released as stable, you can install the types as usual from `@types/react` and `@types/react-dom`.  Until the stable release, the types are available in different packages which need to be enforced in your `package.json`:


### PR DESCRIPTION
`npm install react@rc` would add the latest RC with a caret range to `package.json` which is generally unsafe since any prerelease may contain breaking changes. Especially in our case where commit hashes are encoded in the prerelease version. The caret range might match a version that was release earlier due to alphanumeric ordering.

`npm install --save-exact react@rc` will not use the caret range. This is the default behavior of for PNPM so I'm less concerned with documenting install instructions. You're on the save side if you just prepend a `p` to the NPM command.