### PR TITLE
fix: use path.basename to ensure cross-platform compatibility

### DIFF
--- a/src/utils/rss.js
+++ b/src/utils/rss.js
@@ -40,10 +40,11 @@ exports.generateRssFeed = function () {
   const files = filesByOldest.reverse();
 
   for (const filePath of files) {
-    const id = filePath.split('/').slice(-1).join('');
+    const id = path.basename(filePath);
     if (id !== 'index.md') {
       const content = fs.readFileSync(filePath, 'utf-8');
       const {data} = matter(content);
+
       const slug = filePath.split('/').slice(-4).join('/').replace('.md', '');
 
       if (data.title == null || data.title.trim() === '') {


### PR DESCRIPTION
Replaced filePath.split('/').slice(-1).join('') with path.basename(filePath)
to correctly extract the file name from the file path. This ensures the code
works correctly on all operating systems, including Windows, macOS, and Unix-like
systems, which use different path separators."