### PR TITLE
Update meetups page by adding `React Summit US` and replacing the link for `React Advanced London`

### DIFF
--- a/src/content/community/meetups.md
+++ b/src/content/community/meetups.md
@@ -72,7 +72,7 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 ## England (UK) {/*england-uk*/}
 * [Manchester](https://www.meetup.com/Manchester-React-User-Group/)
 * [React.JS Girls London](https://www.meetup.com/ReactJS-Girls-London/)
-* [React Advanced London](https://guild.host/react-advanced-london)
+* [React Advanced London](https://reactadvanced.com/)
 * [React Native London](https://guild.host/RNLDN)
 
 ## France {/*france*/}

--- a/src/content/community/meetups.md
+++ b/src/content/community/meetups.md
@@ -72,7 +72,7 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 ## England (UK) {/*england-uk*/}
 * [Manchester](https://www.meetup.com/Manchester-React-User-Group/)
 * [React.JS Girls London](https://www.meetup.com/ReactJS-Girls-London/)
-* [React Advanced London](https://reactadvanced.com/)
+* [React Advanced London](https://guild.host/react-advanced-london)
 * [React Native London](https://guild.host/RNLDN)
 
 ## France {/*france*/}

--- a/src/content/community/meetups.md
+++ b/src/content/community/meetups.md
@@ -201,6 +201,7 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 * [New York, NY - ReactJS](https://www.meetup.com/NYC-Javascript-React-Group/)
 * [New York, NY - React Ladies](https://www.meetup.com/React-Ladies/)
 * [New York, NY - React Native](https://www.meetup.com/React-Native-NYC/)
+* [New York, NY - React Summit US](https://reactsummit.us/)
 * [New York, NY - useReactNYC](https://www.meetup.com/useReactNYC/)
 * [New York, NY - React.NYC](https://guild.host/react-nyc)
 * [Omaha, NE - ReactJS/React Native](https://www.meetup.com/omaha-react-meetup-group/)


### PR DESCRIPTION
This pull request
* adds `React Summit US` to the meetups page
* replaces the guild.host based link with the direct one for the `React Advanced London`

(If the usage of `guild.host` is intentional, let me know, so that the commit can be reverted 👍)