### PR TITLE
Remove console.log for uwuQueryParam 

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -87,7 +87,6 @@ const MyDocument = () => {
                     }
                   }
                   const uwuQueryParam = checkQueryParam();
-                  console.log('uwuQueryParam', uwuQueryParam);
                   if (uwuQueryParam != null) {
                     setUwu(uwuQueryParam);
                   } else if (checkLocalStorage()) {


### PR DESCRIPTION
`uwuQueryParam` and the currently value of `uwuQueryParam` is logged to the dev console in prod. This PR removes this `console.log` statement.

<img width="502" alt="Screenshot 2024-06-24 at 1 33 56 PM" src="https://github.com/reactjs/react.dev/assets/7158882/a6da49a0-b7c8-44a1-b6f2-653e363c86cf">
