### PR TITLE
Improve "Learn React" Sections

### DIFF
--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1333,7 +1333,7 @@ export function useOnlineStatus() {
 
 In the above example, `useOnlineStatus` is implemented with a pair of [`useState`](/reference/react/useState) and [`useEffect`.](/reference/react/useEffect) However, this isn't the best possible solution. There is a number of edge cases it doesn't consider. For example, it assumes that when the component mounts, `isOnline` is already `true`, but this may be wrong if the network already went offline. You can use the browser [`navigator.onLine`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine) API to check for that, but using it directly would not work on the server for generating the initial HTML. In short, this code could be improved.
 
-Luckily, React 18 includes a dedicated API called [`useSyncExternalStore`](/reference/react/useSyncExternalStore) which takes care of all of these problems for you. Here is how your `useOnlineStatus` Hook, rewritten to take advantage of this new API:
+Luckily, React 18 includes a dedicated API called [`useSyncExternalStore`](/reference/react/useSyncExternalStore) which takes care of all of these problems for you. Here is your `useOnlineStatus` Hook, rewritten to take advantage of this new API:
 
 <Sandpack>
 

--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1525,7 +1525,7 @@ To make the component more readable, you might extract the logic into a `useFade
 <Sandpack>
 
 ```js
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useFadeIn } from './useFadeIn.js';
 
 function Welcome() {
@@ -1616,7 +1616,7 @@ You could keep the `useFadeIn` code as is, but you could also refactor it more. 
 <Sandpack>
 
 ```js
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useFadeIn } from './useFadeIn.js';
 
 function Welcome() {
@@ -1720,7 +1720,7 @@ However, you didn't *have to* do that. As with regular functions, ultimately you
 <Sandpack>
 
 ```js
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useFadeIn } from './useFadeIn.js';
 
 function Welcome() {
@@ -1750,7 +1750,7 @@ export default function App() {
 ```
 
 ```js src/useFadeIn.js active
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { FadeInAnimation } from './animation.js';
 
 export function useFadeIn(ref, duration) {
@@ -1820,7 +1820,7 @@ The examples above assume that the fade-in logic needs to be written in JavaScri
 <Sandpack>
 
 ```js
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import './welcome.css';
 
 function Welcome() {

--- a/src/content/learn/separating-events-from-effects.md
+++ b/src/content/learn/separating-events-from-effects.md
@@ -574,7 +574,7 @@ label { display: block; margin-top: 10px; }
 
 </Sandpack>
 
-You can think of Effect Events as being very similar to event handlers. The main difference is that event handlers run in response to a user interactions, whereas Effect Events are triggered by you from Effects. Effect Events let you "break the chain" between the reactivity of Effects and code that should not be reactive.
+You can think of Effect Events as being very similar to event handlers. The main difference is that event handlers run in response to user interactions, whereas Effect Events are triggered by you from Effects. Effect Events let you "break the chain" between the reactivity of Effects and code that should not be reactive.
 
 ### Reading latest props and state with Effect Events {/*reading-latest-props-and-state-with-effect-events*/}
 

--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -1133,7 +1133,7 @@ Calling the `setSquares` function lets React know the state of the component has
 
 <Note>
 
-JavaScript supports [closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures) which means an inner function (e.g. `handleClick`) has access to variables and functions defined in a outer function (e.g. `Board`). The `handleClick` function can read the `squares` state and call the `setSquares` method because they are both defined inside of the `Board` function.
+JavaScript supports [closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures) which means an inner function (e.g. `handleClick`) has access to variables and functions defined in an outer function (e.g. `Board`). The `handleClick` function can read the `squares` state and call the `setSquares` method because they are both defined inside of the `Board` function.
 
 </Note>
 


### PR DESCRIPTION
This fixes some minor typos and removes some unused imports from example code (all [demos](http://localhost:3000/learn/reusing-logic-with-custom-hooks) still work).
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
