### PR TITLE
Replace '/' path separator with platform-specific path separator.

### DIFF
--- a/src/utils/rss.js
+++ b/src/utils/rss.js
@@ -6,16 +6,20 @@ const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
 
+const { platform } = process;
+const locale = path[platform === `posix` ? `posix` : `win32`];
+
 const getAllFiles = function (dirPath, arrayOfFiles) {
   const files = fs.readdirSync(dirPath);
 
   arrayOfFiles = arrayOfFiles || [];
 
   files.forEach(function (file) {
-    if (fs.statSync(dirPath + '/' + file).isDirectory()) {
-      arrayOfFiles = getAllFiles(dirPath + '/' + file, arrayOfFiles);
+    if (fs.statSync(dirPath + locale.sep + file).isDirectory()) {
+      arrayOfFiles = getAllFiles(dirPath + locale.sep + file, arrayOfFiles);
     } else {
-      arrayOfFiles.push(path.join(dirPath, '/', file));
+      arrayOfFiles.push(path.join(dirPath, locale.sep, file));
+      const pushedFile = path.join(dirPath, locale.sep, file);
     }
   });
 
@@ -35,16 +39,17 @@ exports.generateRssFeed = function () {
     generator: 'react.dev rss module',
   });
 
-  const dirPath = path.join(process.cwd(), 'src/content/blog');
+  const blogPath = `src${locale.sep}content${locale.sep}blog`;
+  const dirPath = path.join(process.cwd(), blogPath);
   const filesByOldest = getAllFiles(dirPath);
   const files = filesByOldest.reverse();
 
   for (const filePath of files) {
-    const id = filePath.split('/').slice(-1).join('');
+    const id = filePath.split(locale.sep).slice(-1).join('');
     if (id !== 'index.md') {
       const content = fs.readFileSync(filePath, 'utf-8');
       const {data} = matter(content);
-      const slug = filePath.split('/').slice(-4).join('/').replace('.md', '');
+      const slug = filePath.split(locale.sep).slice(-4).join(locale.sep).replace('.md', '');
 
       if (data.title == null || data.title.trim() === '') {
         throw new Error(

--- a/src/utils/rss.js
+++ b/src/utils/rss.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
 
-const { platform } = process;
+const {platform} = process;
 const locale = path[platform === `posix` ? `posix` : `win32`];
 
 const getAllFiles = function (dirPath, arrayOfFiles) {
@@ -19,7 +19,6 @@ const getAllFiles = function (dirPath, arrayOfFiles) {
       arrayOfFiles = getAllFiles(dirPath + locale.sep + file, arrayOfFiles);
     } else {
       arrayOfFiles.push(path.join(dirPath, locale.sep, file));
-      const pushedFile = path.join(dirPath, locale.sep, file);
     }
   });
 
@@ -49,7 +48,11 @@ exports.generateRssFeed = function () {
     if (id !== 'index.md') {
       const content = fs.readFileSync(filePath, 'utf-8');
       const {data} = matter(content);
-      const slug = filePath.split(locale.sep).slice(-4).join(locale.sep).replace('.md', '');
+      const slug = filePath
+        .split(locale.sep)
+        .slice(-4)
+        .join(locale.sep)
+        .replace('.md', '');
 
       if (data.title == null || data.title.trim() === '') {
         throw new Error(


### PR DESCRIPTION
This pull request updates the rss.js to use the platform-specific path separator (path.sep) instead of the hard-coded '/' separator.This change ensures compatibility across different operating systems.
