### PR TITLE
fix: implement `.editorconfig` to enforce LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = lf


### PR DESCRIPTION
Hello 😊

For general Windows users, when cloning the react.dev repository, `LF` often automatically changes to `CRLF` if no special settings are made in the editor. Typically, this changes back to `LF` during commits.

However,

1. In some cases, due to bugs or conflicts, the conversion back to `LF` does not occur properly.
1. To prevent `CRLF` automatic conversion on Windows, users must use commands like `git config --global core.autocrlf false`, which is a drawback as it relies on personal settings of the user.
1. Due to the execution of pre-commit hooks, `CRLF` is changed back to `LF` during commits. However, since all file line endings are changed to `CRLF` after cloning the repository on Windows, there is a major drawback where all files are marked as modified.

Example of an error situation:

On windows, After adding a comment `// add test` to the `404.js` file and entering `git commit -m "test"`, all files with `CRLF` are changed to `LF`, resulting in over 100 files showing changes.

![스크린샷 2024-06-30 225655](https://github.com/reactjs/react.dev/assets/119669540/4b5077d8-050d-44f4-8b83-d6e8c492bc63)

![스크린샷 2024-06-30 225754](https://github.com/reactjs/react.dev/assets/119669540/65a6216a-565b-41ce-84c1-715820bdaf1d)

Therefore, to ensure smooth compatibility between Windows and Linux/Mac users, I propose the adoption of `.editorconfig`, which is used in various repositories like '[react](https://github.com/facebook/react)', '[eslint](https://github.com/eslint/eslint)' and '[prettier](https://github.com/prettier/prettier)'. By enforcing the use of `LF`, it is expected that Windows users will experience less confusion due to `CRLF`/`LF` issues during development.

Furthermore, I would like to tell you that after adopting `.editorconfig`, all the above-mentioned errors have been resolved. Thank you for your attention to this matter :)