### PR TITLE
fix: correct path handling for file name extraction in `rss.js`

### DIFF
--- a/src/utils/rss.js
+++ b/src/utils/rss.js
@@ -40,7 +40,7 @@ exports.generateRssFeed = function () {
   const files = filesByOldest.reverse();
 
   for (const filePath of files) {
-    const id = filePath.split('/').slice(-1).join('');
+    const id = path.basename(filePath);
     if (id !== 'index.md') {
       const content = fs.readFileSync(filePath, 'utf-8');
       const {data} = matter(content);


### PR DESCRIPTION
# fix: correct path handling for file name extraction in `rss.js`

Hello😊 Thank you for your attention to this matter :)

## 1. Description
This PR addresses an issue with path handling in `rss.js`. This makes it impossible for ***Windows*** users to run dev server through `yarn dev`.

The problem was identified when the `generateRssFeed` method failed to exclude the `index.md` file correctly, causing errors due to missing metadata fields required for RSS feeds. 

![image](https://github.com/reactjs/react.dev/assets/119669540/b372c000-826c-46c5-93cc-82b60bf06d80)
![image](https://github.com/reactjs/react.dev/assets/119669540/0bdee005-d0d9-447f-819f-54b3a4b4df89)

## 2. Solution
The solution is to use the `path.basename` method, which correctly extracts the file name from a path regardless of the operating system's path separator(`/` or `\`). Here are the key changes made:

- Previous method
```javascript
const id = filePath.split('/').slice(-1).join('');
```
- Improved method
```javascript
const id = path.basename(filePath);
```

This ensures that the file name is accurately extracted, and the `index.md` file is correctly excluded from the RSS feed generation process.

## 3. Conclusion
This PR fixes the path handling issues, ensuring compatibility across different operating systems(***Windows*** or ***Linux***/***Mac***) by using the appropriate methods for file name extraction and path manipulation.