### PR TITLE
[Typo] Correct reference to sandboxed file App.js in challenge

### DIFF
--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1899,7 +1899,7 @@ export default function Counter() {
 }
 ```
 
-You'll need to write your custom Hook in `useCounter.js` and import it into the `Counter.js` file.
+You'll need to write your custom Hook in `useCounter.js` and import it into the `App.js` file.
 
 <Sandpack>
 


### PR DESCRIPTION
The default name for sandboxed files seems to be `App.js`, but is wrongly referenced as `Counter.js` in one of the challenges. I decided to fix the reference in the text rather renaming the sandbox file due to (a) consistency with all other sandbox examples and (b) consistency with the corresponding solution that already mentions `App.js`. 