### PR TITLE
Improve clarity of sentence in choosing-the-state-structure.md

### DIFF
--- a/src/content/learn/choosing-the-state-structure.md
+++ b/src/content/learn/choosing-the-state-structure.md
@@ -2504,7 +2504,7 @@ li { border-radius: 5px; }
 
 In this example, each `Letter` has an `isSelected` prop and an `onToggle` handler that marks it as selected. This works, but the state is stored as a `selectedId` (either `null` or an ID), so only one letter can get selected at any given time.
 
-Change the state structure to support multiple selection. (How would you structure it? Think about this before writing the code.) Each checkbox should become independent from the others. Clicking a selected letter should uncheck it. Finally, the footer should show the correct number of the selected items.
+Change the state structure to support multiple selections. (How would you structure it? Think about this before writing the code.) Each checkbox should become independent from the others. Clicking a selected letter should uncheck it. Finally, the footer should show the correct number of the selected items.
 
 <Hint>
 


### PR DESCRIPTION
Changed "Change the state structure to support multiple selection" to "Change the state structure to support multiple selection`s`" for improved clarity.

If the original singular is preferred, (i.e. "selection"), then re-writing the sentence to something such as:
"Change the state structure to `allow for multiple item selection`" would still be clearer.