### PR TITLE
Update /link/legacy-context to removal blog post

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -91,7 +91,7 @@
     },
     {
       "source": "/link/legacy-context",
-      "destination": "https://legacy.reactjs.org/docs/legacy-context.html",
+      "destination": "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-removing-legacy-context",
       "permanent": false
     },
     {


### PR DESCRIPTION
The link is used in the strict mode warning and I'm looking to use it more. This link doesn't go to the legacy website and has more context on the removal.

I think it stays true to the purpose for links from older versions so I can use the same link in other warnings.