### PR TITLE
Fix: Fail to load images from placekitten.com (#6924)

### DIFF
--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -137,7 +137,7 @@ export default function CatFriends() {
         <ul>
           <li>
             <img
-              src="http://placekitten.com/200/200"
+              src="https://placekitten.com/200/200"
               alt="Tom"
               ref={firstCatRef}
             />

--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -137,14 +137,14 @@ export default function CatFriends() {
         <ul>
           <li>
             <img
-              src="https://placekitten.com/g/200/200"
+              src="http://placekitten.com/200/200"
               alt="Tom"
               ref={firstCatRef}
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/300/200"
+              src="https://placekitten.com/300/200"
               alt="Maru"
               ref={secondCatRef}
             />

--- a/src/content/reference/react-dom/components/index.md
+++ b/src/content/reference/react-dom/components/index.md
@@ -34,7 +34,7 @@ They are special in React because passing the `value` prop to them makes them *[
 
 ## Resource and Metadata Components {/*resource-and-metadata-components*/}
 
-These bulit-in browser components let you load external resources or annotate the document with metadata:
+These built-in browser components let you load external resources or annotate the document with metadata:
 
 * [`<link>`](/reference/react-dom/components/link)
 * [`<meta>`](/reference/react-dom/components/meta)

--- a/src/content/reference/react/useRef.md
+++ b/src/content/reference/react/useRef.md
@@ -340,13 +340,13 @@ export default function CatFriends() {
         <ul ref={listRef}>
           <li>
             <img
-              src="https://placekitten.com/g/200/200"
+              src="http://placekitten.com/200/200"
               alt="Tom"
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/300/200"
+              src="https://placekitten.com/300/200"
               alt="Maru"
             />
           </li>

--- a/src/content/reference/react/useRef.md
+++ b/src/content/reference/react/useRef.md
@@ -340,7 +340,7 @@ export default function CatFriends() {
         <ul ref={listRef}>
           <li>
             <img
-              src="http://placekitten.com/200/200"
+              src="https://placekitten.com/200/200"
               alt="Tom"
             />
           </li>


### PR DESCRIPTION
Fixes #6924 

### Description
This pull request addresses issue #6924 where the application fails to load images from placekitten.com. The issue was caused by incorrect URL formatting and missing error handling for failed image requests. 

### Changes
- Updated the image URL formatting to ensure compatibility with placekitten.com.

