### PR TITLE
Improve useRef documentation to avoid re-creating ref contents and null checks

### DIFF
--- a/src/content/reference/react/useRef.md
+++ b/src/content/reference/react/useRef.md
@@ -534,6 +534,18 @@ function Video() {
 
 Here, the `playerRef` itself is nullable. However, you should be able to convince your type checker that there is no case in which `getPlayer()` returns `null`. Then use `getPlayer()` in your event handlers.
 
+A More Robust Solution Using useState:
+If you want a more robust solution that avoids all kinds of acrobatics like lying to a type checker or performing checks inside the render body, you can leverage useState:
+
+```js
+function Video() {
+  const [playerRef] = useState(() => ({ current: new VideoPlayer() }));
+
+  // playerRef is now a stable object containing the video player instance
+}
+```
+
+
 </DeepDive>
 
 ---


### PR DESCRIPTION
**Introduced a more robust solution using useState for stable reference initialization.**

### This approach has several advantages:

1. It avoids re-creating the video player instance on every render.
2. It provides a stable reference that does not change across renders.

#7041 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
