### PR TITLE
Remove number type from createPortal key param reference

### DIFF
--- a/src/content/reference/react-dom/createPortal.md
+++ b/src/content/reference/react-dom/createPortal.md
@@ -50,7 +50,7 @@ A portal only changes the physical placement of the DOM node. In every other way
 
 * `domNode`: Some DOM node, such as those returned by `document.getElementById()`. The node must already exist. Passing a different DOM node during an update will cause the portal content to be recreated.
 
-* **optional** `key`: A unique string or number to be used as the portal's [key.](/learn/rendering-lists/#keeping-list-items-in-order-with-key)
+* **optional** `key`: A unique string to be used as the portal's [key.](/learn/rendering-lists/#keeping-list-items-in-order-with-key)
 
 #### Returns {/*returns*/}
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The signature of the createPortal() function is `createPortal(children: React.ReactNode, container: Element | DocumentFragment, key?: string | null | undefined): React.ReactPortal`. The `key` param doesn't accept `number` type.