### PR TITLE
docs(input): convert `age` to string before setting to match initial type

### DIFF
--- a/src/content/reference/react-dom/components/input.md
+++ b/src/content/reference/react-dom/components/input.md
@@ -359,7 +359,7 @@ function Form() {
           onChange={e => setAge(e.target.value)}
           type="number"
         />
-        <button onClick={() => setAge(ageAsNumber + 10)}>
+        <button onClick={() => setAge(`${ageAsNumber + 10}`)}>
           Add 10 years
         </button>
 ```
@@ -391,7 +391,7 @@ export default function Form() {
           onChange={e => setAge(e.target.value)}
           type="number"
         />
-        <button onClick={() => setAge(ageAsNumber + 10)}>
+        <button onClick={() => setAge(`${ageAsNumber + 10}`)}>
           Add 10 years
         </button>
       </label>


### PR DESCRIPTION
Hi React team,

Thanks for the great doc!

I noticed in the following file that the initial state of the `age` is set as a string:

https://github.com/reactjs/react.dev/blob/4c91abc78b20be10e7d40cf57a80a6a6247e6e9a/src/content/reference/react-dom/components/input.md?plain=1#L351

https://github.com/reactjs/react.dev/blob/4c91abc78b20be10e7d40cf57a80a6a6247e6e9a/src/content/reference/react-dom/components/input.md?plain=1#L376

Given this, I believe converting the `age` back to a string would be more consistent before setting it with `setAge`. This would maintain type consistency throughout the component.

Thank you!