### PR TITLE
Update react-compiler.md

### DIFF
--- a/src/content/learn/react-compiler.md
+++ b/src/content/learn/react-compiler.md
@@ -151,7 +151,7 @@ Then, add it to your eslint config:
 ```js
 module.exports = {
   plugins: [
-    'eslint-plugin-react-compiler',
+    'react-compiler',
   ],
   rules: {
     'react-compiler/react-compiler': "error",


### PR DESCRIPTION
The docs at https://www.npmjs.com/package/eslint-plugin-react-compiler?activeTab=readme say 

> Add react-compiler to the plugins section of your .eslintrc configuration file. You can omit the eslint-plugin- prefix.

This change update this part of the docs whit what the docs at https://www.npmjs.com/package/eslint-plugin-react-compiler?activeTab=readme say an also it has now the same name used in the `plugin` section as in the `rules` section.