### PR TITLE
doc: Add missing return statement

### DIFF
--- a/src/content/reference/rsc/server-actions.md
+++ b/src/content/reference/rsc/server-actions.md
@@ -82,7 +82,7 @@ import {createNoteAction} from './actions';
 function EmptyNote() {
   console.log(createNoteAction);
   // {$$typeof: Symbol.for("react.server.reference"), $$id: 'createNoteAction'}
-  <button onClick={createNoteAction} />
+  return <button onClick={createNoteAction} />
 }
 ```
 


### PR DESCRIPTION
Added a missing return statement in the EmptyNote component under ["Importing Server Actions from Client Components"](https://react.dev/reference/rsc/server-actions#importing-server-actions-from-client-components).
