### PR TITLE
Document behaviour of setting state inside `useLayoutEffect`

### DIFF
--- a/src/content/reference/react/useLayoutEffect.md
+++ b/src/content/reference/react/useLayoutEffect.md
@@ -67,7 +67,7 @@ function Tooltip() {
 
 * The code inside `useLayoutEffect` and all state updates scheduled from it **block the browser from repainting the screen.** When used excessively, this makes your app slow. When possible, prefer [`useEffect`.](/reference/react/useEffect)
 
-* If you trigger a render inside `useLayoutEffect`, React will flush all remaining effects including `useEffect`.
+* If you trigger a state update inside `useLayoutEffect`, React will execute all remaining Effects immediately including `useEffect`.
 
 ---
 

--- a/src/content/reference/react/useLayoutEffect.md
+++ b/src/content/reference/react/useLayoutEffect.md
@@ -67,6 +67,8 @@ function Tooltip() {
 
 * The code inside `useLayoutEffect` and all state updates scheduled from it **block the browser from repainting the screen.** When used excessively, this makes your app slow. When possible, prefer [`useEffect`.](/reference/react/useEffect)
 
+* If you trigger a render inside `useLayoutEffect`, React will flush all remaining effects including `useEffect`.
+
 ---
 
 ## Usage {/*usage*/}


### PR DESCRIPTION
As discussed: https://github.com/facebook/react/issues/17334#issuecomment-2272162502

@eps1lon You will probably have a better idea of how to word this. I was also wondering if we should add a note under "[Measuring layout before the browser repaints the screen](https://react.dev/reference/react/useLayoutEffect#measuring-layout-before-the-browser-repaints-the-screen)". This is exactly what I was trying to achieve before realising the behaviour with regards to `useEffect`.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
