### PR TITLE
Redirect `lists-and-keys` to `rendering-lists` describing key section

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,11 @@
       "permanent": false
     },
     {
+      "source": "/docs/lists-and-keys",
+      "destination": "/learn/rendering-lists#keeping-list-items-in-order-with-key",
+      "permanent": false
+    },
+    {
       "source": "/link/invalid-hook-call",
       "destination": "/warnings/invalid-hook-call-warning",
       "permanent": false


### PR DESCRIPTION
This pull request fixes #7080 
It redirects the `docs/lists-and-keys` to proper page in latest react.dev.

Initially the link was already redirecting from `fb.me/react-warning-keys` to the `docs/lists-and-keys` but was by default pointing to the react.dev, while that page is on legacy reactjs.org, so redirecting from that link to proper page will work for both sources.