### PR TITLE
fix: add missing blank lines in "Treat State as Read-Only" section

### DIFF
--- a/src/content/learn/updating-objects-in-state.md
+++ b/src/content/learn/updating-objects-in-state.md
@@ -57,6 +57,7 @@ This example holds an object in state to represent the current pointer position.
 
 ```js
 import { useState } from 'react';
+
 export default function MovingDot() {
   const [position, setPosition] = useState({
     x: 0,
@@ -127,6 +128,7 @@ Notice how the red dot now follows your pointer when you touch or hover over the
 
 ```js
 import { useState } from 'react';
+
 export default function MovingDot() {
   const [position, setPosition] = useState({
     x: 0,


### PR DESCRIPTION
Added blank lines between import statements and code blocks in the relevant sample codes within the "Treat State as Read-Only" section.
Ensured consistency across all sample codes in the section for better readability.

Closes #7125 