### PR TITLE
Add React Day Berlin 2024 to Conferences

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -65,6 +65,11 @@ November 29, 2024. In-person in Casablanca, Morocco (hybrid event)
 
 [Website](https://react-africa.com/) - [Twitter](https://x.com/BeJS_)
 
+### React Day Berlin 2024 {/*react-day-berlin-2024*/}
+December 13 & 16, 2024. In-person in Berlin, Germany + remote (hybrid event)
+
+[Website](https://reactday.berlin/) - [Twitter](https://x.com/reactdayberlin)
+
 ## Past Conferences {/*past-conferences*/}
 
 ### React Summit 2024 {/*react-summit-2024*/}


### PR DESCRIPTION
This pull request adds React Day Berlin 2024 to the list of upcoming conferences