### PR TITLE
Explicitly redirect from legacy 'thinking-in-react' page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/thinking-in-react",
+      "destination": "/learn/thinking-in-react",
+      "permanent": false
+    },
+    {
       "source": "/learn/meet-the-team",
       "destination": "/community/team",
       "permanent": true


### PR DESCRIPTION
This pull request fixes #7142 

Although the `thinking-in-react` page redirect already works for https://reactjs.org/docs/thinking-in-react.html, making it explicit redirect also fixes the scenario where the link has the legacy path `/docs/` but the current website `react.dev`.