### PR TITLE
docs(act.md): correct ReactDOM to ReactDOMClient

### DIFF
--- a/src/content/reference/react/act.md
+++ b/src/content/reference/react/act.md
@@ -90,7 +90,7 @@ To test the render output of a component, wrap the render inside `act()`:
 
 ```js  {10,12}
 import {act} from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOMClient from 'react-dom/client';
 import Counter from './Counter';
 
 it('can render and update a counter', async () => {
@@ -99,7 +99,7 @@ it('can render and update a counter', async () => {
   
   // ✅ Render the component inside act().
   await act(() => {
-    ReactDOM.createRoot(container).render(<Counter />);
+    ReactDOMClient.createRoot(container).render(<Counter />);
   });
   
   const button = container.querySelector('button');
@@ -119,7 +119,7 @@ To test events, wrap the event dispatch inside `act()`:
 
 ```js {14,16}
 import {act} from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOMClient from 'react-dom/client';
 import Counter from './Counter';
 
 it.only('can render and update a counter', async () => {
@@ -127,7 +127,7 @@ it.only('can render and update a counter', async () => {
   document.body.appendChild(container);
   
   await act( async () => {
-    ReactDOM.createRoot(container).render(<Counter />);
+    ReactDOMClient.createRoot(container).render(<Counter />);
   });
   
   // ✅ Dispatch the event inside act().

--- a/src/content/reference/react/act.md
+++ b/src/content/reference/react/act.md
@@ -127,7 +127,7 @@ it.only('can render and update a counter', async () => {
   document.body.appendChild(container);
   
   await act( async () => {
-    ReactDOMClient.createRoot(container).render(<Counter />);
+    ReactDOM.createRoot(container).render(<Counter />);
   });
   
   // ✅ Dispatch the event inside act().


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Correct `ReactDOM` to `ReactDOMClient` in `act.md`.
