### PR TITLE
docs: fix name of `MUI` and reference link

### DIFF
--- a/src/content/learn/your-first-component.md
+++ b/src/content/learn/your-first-component.md
@@ -51,7 +51,7 @@ Just like with HTML tags, you can compose, order and nest components to design w
 </PageLayout>
 ```
 
-As your project grows, you will notice that many of your designs can be composed by reusing components you already wrote, speeding up your development. Our table of contents above could be added to any screen with `<TableOfContents />`! You can even jumpstart your project with the thousands of components shared by the React open source community like [Chakra UI](https://chakra-ui.com/) and [Material UI.](https://material-ui.com/)
+As your project grows, you will notice that many of your designs can be composed by reusing components you already wrote, speeding up your development. Our table of contents above could be added to any screen with `<TableOfContents />`! You can even jumpstart your project with the thousands of components shared by the React open source community like [Chakra UI](https://chakra-ui.com/) and [MUI](https://mui.com/material-ui/).
 
 ## Defining a component {/*defining-a-component*/}
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Hi, At first, thank you for maintenance this site.
Corrected the name and reference list of `MUI` since `MUI` was rebranded from `material-ui` to `MUI`. Check it out.
