### PR TITLE
fix:#7158 `rss.js` issue

### DIFF
--- a/src/utils/rss.js
+++ b/src/utils/rss.js
@@ -40,7 +40,7 @@ exports.generateRssFeed = function () {
   const files = filesByOldest.reverse();
 
   for (const filePath of files) {
-    const id = filePath.split('/').slice(-1).join('');
+    const id = path.basename(filePath);
     if (id !== 'index.md') {
       const content = fs.readFileSync(filePath, 'utf-8');
       const {data} = matter(content);


### PR DESCRIPTION
The problem is getting the basename from the file path in the `rss.js` file.

Code before my changes
``` js
const id = filePath.split('/').slice(-1).join('');
```

Code after my changes
``` js
const id = path.basename(filePath);
```

issue: #7158 