### PR TITLE
Redirect legacy events page to commmon components overview

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,11 @@
       "permanent": false
     },
     {
+      "source": "/docs/events",
+      "destination": "/reference/react-dom/components/common",
+      "permanent": false
+    },
+    {
       "source": "/link/invalid-hook-call",
       "destination": "/warnings/invalid-hook-call-warning",
       "permanent": false


### PR DESCRIPTION
This pull request closes #6940 
It redirects the `docs/events` page from legacy to `Common components (e.g. <div>)` overview page where all events handlers are listed.