### PR TITLE
Nit: server actions can't be passed events

### DIFF
--- a/src/content/reference/rsc/server-actions.md
+++ b/src/content/reference/rsc/server-actions.md
@@ -53,7 +53,7 @@ When React renders the `EmptyNote` Server Component, it will create a reference 
 export default function Button({onClick}) { 
   console.log(onClick); 
   // {$$typeof: Symbol.for("react.server.reference"), $$id: 'createNoteAction'}
-  return <button onClick={onClick}>Create Empty Note</button>
+  return <button onClick={() => onClick()}>Create Empty Note</button>
 }
 ```
 


### PR DESCRIPTION
The current example would error with:


> Error: Only plain objects, and a few built-ins, can be passed to Server Actions. Classes or null prototypes are not supported

The issue is that the `onClick` passes an event handler to the server function. 

Thanks [`@bayes`](https://x.com/bayes/status/1835790101378421102) for reporting.