### PR TITLE
Use correct link for translations.react.dev

### DIFF
--- a/src/content/community/acknowledgements.md
+++ b/src/content/community/acknowledgements.md
@@ -59,7 +59,7 @@ We'd like to recognize a few people who have made significant contributions to R
 
 This list is not exhaustive.
 
-We'd like to give special thanks to [Tom Occhino](https://github.com/tomocchino) and [Adam Wolff](https://github.com/wolffiex) for their guidance and support over the years. We are also thankful to all the volunteers who [translated React into other languages.](https://translations.reactjs.org/)
+We'd like to give special thanks to [Tom Occhino](https://github.com/tomocchino) and [Adam Wolff](https://github.com/wolffiex) for their guidance and support over the years. We are also thankful to all the volunteers who [translated React into other languages.](https://translations.react.dev/)
 
 ## Additional Thanks {/*additional-thanks*/}
 


### PR DESCRIPTION
Hello, I've noticed that acknowledgements page is using an [old](https://translations.reactjs.org/) URL for [translations.react.dev](https://translations.react.dev/). Even though there is redirection from old to new domain, new URL should be used everywhere.
