### PR TITLE
Clarified 'one level deep' in hydration mismatch error documentation

### DIFF
--- a/src/content/reference/react-dom/hydrate.md
+++ b/src/content/reference/react-dom/hydrate.md
@@ -146,7 +146,25 @@ export default function App() {
 
 </Sandpack>
 
-This only works one level deep, and is intended to be an escape hatch. Don’t overuse it. Unless it’s text content, React still won’t attempt to patch it up, so it may remain inconsistent until future updates.
+/*This only works one level deep, and is intended to be an escape hatch. Don’t overuse it. Unless it’s text content, React still won’t attempt to patch it up, so it may remain inconsistent until future updates. */
+
+This suppression only works for the immediate children of the element with suppressHydrationWarning={true}, and is intended to be an escape hatch for specific scenarios where hydration mismatches are unavoidable. React won’t suppress mismatches in deeper nested elements. For example, if you apply suppressHydrationWarning to a parent element, the suppression only applies to its direct children, not to the grandchildren or deeper levels in the component tree.
+
+Example:
+
+If you have a component like this:
+
+```function ParentComponent() {
+  return (
+    <div suppressHydrationWarning={true}>
+      <ChildComponent />
+      <OtherChildComponent />
+    </div>
+  );
+}
+```
+
+React will suppress hydration mismatch warnings for ChildComponent and OtherChildComponent (the immediate children of the parent div), but not for any children within ChildComponent or OtherChildComponent.
 
 ---
 


### PR DESCRIPTION
This pull request aims to enhance the React documentation regarding suppressing hydration mismatch errors by providing a clear definition of the term "one level deep."

Changes Made:

Updated the documentation under the "Suppressing unavoidable hydration mismatch errors" section to clarify that:
The suppression of hydration mismatch warnings only applies to the immediate children of the element with the suppressHydrationWarning={true} attribute.
This means that any nested children beyond the immediate level will not benefit from this suppression.

Rationale:

The current documentation may cause confusion for developers regarding the scope of the suppressHydrationWarning attribute.
Providing this clarification will help users better understand how to use this feature effectively and avoid potential pitfalls in their applications.
By making this change, we hope to improve the user experience for developers working with React, allowing them to implement hydration warnings more confidently and accurately.

