### PR TITLE
Add explanation link for DPI (Dots per inch)

### DIFF
--- a/src/content/learn/passing-props-to-a-component.md
+++ b/src/content/learn/passing-props-to-a-component.md
@@ -848,7 +848,7 @@ export function getImageUrl(person, size) {
 
 </Sandpack>
 
-You could also show a sharper image for high DPI screens by taking [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) into account:
+You could also show a sharper image for high [DPI](https://en.wikipedia.org/wiki/Dots_per_inch) screens by taking [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) into account:
 
 <Sandpack>
 


### PR DESCRIPTION
While translating [Passing Props to a Component](https://react.dev/learn/passing-props-to-a-component) page, I came across DPI term which is widely know I think. But, maybe there are some people who are not familiar with it so I've added wikipedia link to it.
