### PR TITLE
Add expand/collapse sidebar handler to the arrow icon

### DIFF
--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -21,6 +21,8 @@ interface SidebarLinkProps {
   isExpanded?: boolean;
   hideArrow?: boolean;
   isPending: boolean;
+  onExpand?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+  onToggle?: (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
 }
 
 export function SidebarLink({
@@ -32,6 +34,8 @@ export function SidebarLink({
   isExpanded,
   hideArrow,
   isPending,
+  onExpand,
+  onToggle,
 }: SidebarLinkProps) {
   const ref = useRef<HTMLAnchorElement>(null);
 
@@ -45,10 +49,29 @@ export function SidebarLink({
     }
   }, [ref, selected]);
 
+  const hasChildren = onExpand !== undefined;
+
   let target = '';
   if (href.startsWith('https://')) {
     target = '_blank';
   }
+
+  const handleLinkClick = (
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  ) => {
+    if (onExpand && hasChildren) {
+      onExpand(e);
+    }
+  };
+
+  const handleToggle = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (onToggle) {
+      onToggle(e);
+    }
+  };
+
   return (
     <Link
       href={href}
@@ -71,8 +94,8 @@ export function SidebarLink({
           'dark:bg-gray-70 bg-gray-3 dark:hover:bg-gray-70 hover:bg-gray-3':
             isPending,
         }
-      )}>
-      {/* This here needs to be refactored ofc */}
+      )}
+      onClick={handleLinkClick}>
       <div>
         {title}{' '}
         {canary && (
@@ -85,10 +108,11 @@ export function SidebarLink({
 
       {isExpanded != null && !hideArrow && (
         <span
-          className={cn('pe-1', {
+          className={cn('pe-1 p-1', {
             'text-link dark:text-link-dark': isExpanded,
             'text-tertiary dark:text-tertiary-dark': !isExpanded,
-          })}>
+          })}
+          onClick={handleToggle}>
           <IconNavArrow displayDirection={isExpanded ? 'down' : 'end'} />
         </span>
       )}

--- a/src/components/Layout/SidebarNav/SidebarNav.tsx
+++ b/src/components/Layout/SidebarNav/SidebarNav.tsx
@@ -8,6 +8,7 @@ import cn from 'classnames';
 import {Feedback} from '../Feedback';
 import {SidebarRouteTree} from '../Sidebar/SidebarRouteTree';
 import type {RouteItem} from '../getRouteMeta';
+import {useState} from 'react';
 
 declare global {
   interface Window {
@@ -23,6 +24,9 @@ export default function SidebarNav({
   routeTree: RouteItem;
   breadcrumbs: RouteItem[];
 }) {
+  const [expandedPath, setExpandedPath] = useState<string | null>(null);
+  const [collapsedPaths, setCollapsedPaths] = useState<Set<string>>(new Set());
+
   // HACK. Fix up the data structures instead.
   if ((routeTree as any).routes.length === 1) {
     routeTree = (routeTree as any).routes[0];
@@ -52,6 +56,10 @@ export default function SidebarNav({
                 routeTree={routeTree}
                 breadcrumbs={breadcrumbs}
                 isForceExpanded={false}
+                expandedPath={expandedPath}
+                setExpandedPath={setExpandedPath}
+                collapsedPaths={collapsedPaths}
+                setCollapsedPaths={setCollapsedPaths}
               />
             </Suspense>
             <div className="h-20" />

--- a/src/components/Layout/TopNav/TopNav.tsx
+++ b/src/components/Layout/TopNav/TopNav.tsx
@@ -435,6 +435,10 @@ export default function TopNav({
                     routeTree={routeTree}
                     breadcrumbs={breadcrumbs}
                     isForceExpanded={isMenuOpen}
+                    expandedPath={null}
+                    setExpandedPath={() => {}}
+                    collapsedPaths={new Set()}
+                    setCollapsedPaths={() => {}}
                   />
                 </Suspense>
                 <div className="h-16" />


### PR DESCRIPTION
### Overview

Added manual expand/collapse toggle handler for the arrow icon in the sidebar while keeping the original design, functionality and structure of the sidebar.

### Details

`SidebarRouteTree` component recursively renders routes which make up the sidebar using route tree and breadcrumbs, so I have added state to keep track of the expanded and collapsed routes, and toggle and expand handlers. 

The main functionality of the sidebar is kept intact:

- Always load the route path and expand children routes when clicking on the route
- Only 1 route group is expanded at a time for better navigation
- After refresh selected route is expanded

Red bg to illustrate the size of the manual toggle. Clicking the route elsewhere functions exactly like before.

![Screenshot from 2024-10-12 23-56-42](https://github.com/user-attachments/assets/514384a1-e173-4e67-80fd-bd2dbefc2860)






 ### Open Issues
There have been several issues opened in the past years of users intuitively wanting to manually collapse and expand routes for easier navigation, just recently #7203. Which shows the desire and need for better functionality and navigation with manual collapsing and expanding when searching instead of needing to always load the route in order to expand it.
But from what I have seen, all previous PR's messed up the original logic, which shouldn't be the case. My solution keeps the original functionality while adding the new functionality only to the arrow icon for those who want to use it.

### Testing
I have ran several profiler tests and compared memory usage, load times and cpu usage and couldn't find any noticeable differences with the new additional state. I have also tested memoized version of the of the sidebarroutree but there wasn't any significant difference since the tree of routes is pretty small.

### Conclusion
After playing around and using the new sidebar, it is hard to go back to the previous version. Test it yourself in the preview.



