### PR TITLE
Mention in the recap that the AND operator will still render `cond`

### DIFF
--- a/src/content/learn/conditional-rendering.md
+++ b/src/content/learn/conditional-rendering.md
@@ -444,8 +444,10 @@ If you're not familiar with JavaScript, this variety of styles might seem overwh
 * In React, you control branching logic with JavaScript.
 * You can return a JSX expression conditionally with an `if` statement.
 * You can conditionally save some JSX to a variable and then include it inside other JSX by using the curly braces.
-* In JSX, `{cond ? <A /> : <B />}` means *"if `cond`, render `<A />`, otherwise `<B />`"*.
-* In JSX, `{cond && <A />}` means *"if `cond`, render `<A />`, otherwise `cond` or nothing if `cond` is either `null`, `undefined` or an empty string"*.
+* In JSX, `{cond ? <A /> : <B />}` means:
+<br/>*"if `cond`, render `<A />`, otherwise `<B />`"*.
+* In JSX, `{cond && <A />}` means:
+<br/>*"if `cond`, render `<A />`, otherwise `cond` or nothing if `cond` is either `null`, `undefined` or an empty string"*.
 * The shortcuts are common, but you don't have to use them if you prefer plain `if`.
 
 </Recap>

--- a/src/content/learn/conditional-rendering.md
+++ b/src/content/learn/conditional-rendering.md
@@ -445,7 +445,7 @@ If you're not familiar with JavaScript, this variety of styles might seem overwh
 * You can return a JSX expression conditionally with an `if` statement.
 * You can conditionally save some JSX to a variable and then include it inside other JSX by using the curly braces.
 * In JSX, `{cond ? <A /> : <B />}` means *"if `cond`, render `<A />`, otherwise `<B />`"*.
-* In JSX, `{cond && <A />}` means *"if `cond`, render `<A />`, otherwise nothing"*.
+* In JSX, `{cond && <A />}` means *"if `cond`, render `<A />`, otherwise `cond` or nothing if `cond` is either `null`, `undefined` or an empty string"*.
 * The shortcuts are common, but you don't have to use them if you prefer plain `if`.
 
 </Recap>


### PR DESCRIPTION
This pull request modifies the [recap section](https://react.dev/learn/conditional-rendering#recap) in "Conditional Rendering" page.

---

**Reasoning for this PR:**
In the page the recap of conditional rendering with AND operator says:
> In JSX, {cond && <A />} means “if cond, render <A />, otherwise nothing”.

while it is not always true. As we know, it will render nothing **only if** `cond` is one of `null`, `undefined` or `""` (empty string).

I'm aware that previously the pitfall of putting numbers in AND conditional render is described very well, but I believe the recap should not be forgetting about it.
I fear that simplified thought in the recap is what will stay in one's mind leaving a conclusion that it's always fine to, almost with the muscle memory, use the AND to conditionally render.

---

I also allowed myself to edit the formatting, as I found the updated sentence being quite long, so having it in new line (I believe) improves the readability. Let me know what is your opinion.