### PR TITLE
chore(a11y): improving a11y score to 100% for homepage in both light/dark mode for mobile/desktop

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -1304,7 +1304,7 @@ function BrowserChrome({children, hasPulse, hasRefresh, domain, path}) {
               />
             </svg>
 
-            <span className="text-gray-30">
+            <span>
               {domain}
               {path != null && '/'}
             </span>

--- a/src/components/Layout/TopNav/TopNav.tsx
+++ b/src/components/Layout/TopNav/TopNav.tsx
@@ -304,7 +304,7 @@ export default function TopNav({
               <button
                 type="button"
                 className={cn(
-                  'flex 3xl:w-[56rem] 3xl:mx-0 relative ps-4 pe-1 py-1 h-10 bg-gray-30/20 dark:bg-gray-40/20 outline-none focus:outline-link betterhover:hover:bg-opacity-80 pointer items-center text-start w-full text-gray-30 rounded-full align-middle text-base'
+                  'flex 3xl:w-[56rem] 3xl:mx-0 relative ps-4 pe-1 py-1 h-10 bg-gray-30/20 dark:bg-gray-40/20 outline-none focus:outline-link betterhover:hover:bg-opacity-80 pointer items-center text-start w-full rounded-full align-middle text-base'
                 )}
                 onClick={onOpenSearch}>
                 <IconSearch className="align-middle me-3 text-gray-30 shrink-0 group-betterhover:hover:text-gray-70" />


### PR DESCRIPTION
## Details
- Improves accessibility score to 100% for homepage in both light and dark mode across all devices
- Used AxeDevTool for accessibility check
- Closes issue [7233](https://github.com/reactjs/react.dev/issues/7233)

## Screenshots of Before/After fix

### Mobile: Light Mode
![mobile_light](https://github.com/user-attachments/assets/24e888f6-ae10-4a35-9b28-979bd5b1f08e)

### Mobile: Dark Mode
![mobile_dark](https://github.com/user-attachments/assets/fd41aff0-783c-4621-8422-7a92c9eaeee9)

### Desktop: Light Mode
![desktop_light](https://github.com/user-attachments/assets/5b5a6c51-3c84-44a5-937a-94895053a53b)

### Desktop: Dark Mode
![desktop_dark](https://github.com/user-attachments/assets/b27ba62b-2c59-4fbc-b077-98c27d755594)
