### PR TITLE
Fix stylesheet precedence example

### DIFF
--- a/src/content/reference/react-dom/components/link.md
+++ b/src/content/reference/react-dom/components/link.md
@@ -158,9 +158,7 @@ export default function SiteMapPage() {
 
 ### Controlling stylesheet precedence {/*controlling-stylesheet-precedence*/}
 
-Stylesheets can conflict with each other, and when they do, the browser goes with the one that comes later in the document. React lets you control the order of stylesheets with the `precedence` prop. In this example, two components render stylesheets, and the one with the higher precedence goes later in the document even though the component that renders it comes earlier.
-
-{/*FIXME: this doesn't appear to actually work -- I guess precedence isn't implemented yet?*/}
+Stylesheets can conflict with each other, and when they do, the browser goes with the one that comes later in the document. React lets you control the order of stylesheets with the `precedence` prop. In this example, three components render stylesheets, and the ones with the same precedence are grouped together in the `<head>`. 
 
 <SandpackWithHTMLOutput>
 
@@ -172,17 +170,22 @@ export default function HomePage() {
     <ShowRenderedHTML>
       <FirstComponent />
       <SecondComponent />
+      <ThirdComponent/>
       ...
     </ShowRenderedHTML>
   );
 }
 
 function FirstComponent() {
-  return <link rel="stylesheet" href="first.css" precedence="high" />;
+  return <link rel="stylesheet" href="first.css" precedence="first" />;
 }
 
 function SecondComponent() {
-  return <link rel="stylesheet" href="second.css" precedence="low" />;
+  return <link rel="stylesheet" href="second.css" precedence="second" />;
+}
+
+function ThirdComponent() {
+  return <link rel="stylesheet" href="third.css" precedence="first" />;
 }
 
 ```


### PR DESCRIPTION
The `precedence` prop documentation for `<style>` and `<link>` was fixed last May in this pull request:
https://github.com/reactjs/react.dev/pull/6908
(Precedence is now using any name, instead of "high", "medium" or "low")

But the code example accompanying the `<link>` documentation was not fixed.  

There was even a comment in the doc about the fact that precedence didn't seem to work.  -- It did work, it's just that it's more of a grouping behavior than an ordering behavior. So you need at least 3 `<link>` to visibly show that grouping behavior.  
