### PR TITLE
Compiler: Update link to Expo documentation

### DIFF
--- a/src/content/learn/react-compiler.md
+++ b/src/content/learn/react-compiler.md
@@ -315,7 +315,7 @@ A community Webpack loader is [now available here](https://github.com/SukkaW/rea
 
 ### Expo {/*usage-with-expo*/}
 
-Please refer to [Expo's docs](https://docs.expo.dev/preview/react-compiler/) to enable and use the React Compiler in Expo apps.
+Please refer to [Expo's docs](https://docs.expo.dev/guides/react-compiler/) to enable and use the React Compiler in Expo apps.
 
 ### Metro (React Native) {/*usage-with-react-native-metro*/}
 


### PR DESCRIPTION
# Why

We are moving the guide for using React Compiler out of preview:
* https://github.com/expo/expo/pull/32804

# How

Let's correct the link to Expo docs on the React Compiler page to avoid unnecessary redirects.
