### PR TITLE
Add "Edit This Page" link to documentation

### DIFF
--- a/src/components/EditThis.tsx
+++ b/src/components/EditThis.tsx
@@ -1,17 +1,26 @@
 import {useRouter} from 'next/router';
 import {ExternalLink} from './ExternalLink';
 import {IconGitHub} from './Icon/IconGitHub';
+import {ReactElement} from 'react';
 
 const githubBranch = 'main';
 const baseGithubLink = `https://github.com/reactjs/react.dev/edit/${githubBranch}/`;
 
-export const EditThis = () => {
+type EditThisProps = {
+  path: string;
+  isIndexPage: boolean;
+};
+
+export const EditThis = ({path, isIndexPage}: EditThisProps): ReactElement => {
   const {asPath} = useRouter();
-  const cleanedPath = asPath.split(/[\?\#]/)[0];
+  const pathParts = asPath.split(/[\?\#]/)[0].split('/');
+  const pageToEdit = isIndexPage ? 'index' : pathParts[pathParts.length - 1];
+
   return (
     <div className="flex text-link dark:text-link-dark group justify-start align-middle">
       <IconGitHub />
-      <ExternalLink href={`${baseGithubLink}src/content/${cleanedPath}.md`}>
+      <ExternalLink
+        href={`${baseGithubLink}src/content${path}/${pageToEdit}.md`}>
         <span className="text-lg group-hover:underline">
           Edit this page on Github
         </span>

--- a/src/components/EditThis.tsx
+++ b/src/components/EditThis.tsx
@@ -1,0 +1,21 @@
+import {useRouter} from 'next/router';
+import {ExternalLink} from './ExternalLink';
+import {IconGitHub} from './Icon/IconGitHub';
+
+const githubBranch = 'main';
+const baseGithubLink = `https://github.com/reactjs/react.dev/edit/${githubBranch}/`;
+
+export const EditThis = () => {
+  const {asPath} = useRouter();
+  const cleanedPath = asPath.split(/[\?\#]/)[0];
+  return (
+    <div className="flex text-link dark:text-link-dark group justify-start align-middle">
+      <IconGitHub />
+      <ExternalLink href={`${baseGithubLink}src/content/${cleanedPath}.md`}>
+        <span className="text-lg group-hover:underline">
+          Edit this page on Github
+        </span>
+      </ExternalLink>
+    </div>
+  );
+};

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -90,7 +90,16 @@ export function Page({
               </LanguagesContext.Provider>
             </TocContext.Provider>
           </div>
-          {isReferencePage && <EditThis />}
+          {isReferencePage && route && (
+            <EditThis
+              isIndexPage={
+                routeTree.routes?.find((el: RouteItem): boolean | undefined =>
+                  el.path?.startsWith(route.path!)
+                )?.path === route.path
+              }
+              path={route?.path || routeTree.path || ''}
+            />
+          )}
           {!isBlogIndex && (
             <DocsPageFooter
               route={route}

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -21,6 +21,7 @@ import {HomeContent} from './HomeContent';
 import {TopNav} from './TopNav';
 import cn from 'classnames';
 import Head from 'next/head';
+import {EditThis} from 'components/EditThis';
 
 import(/* webpackPrefetch: true */ '../MDX/CodeBlock/CodeBlock');
 
@@ -88,6 +89,7 @@ export function Page({
               </LanguagesContext.Provider>
             </TocContext.Provider>
           </div>
+          {!isBlogIndex && <EditThis />}
           {!isBlogIndex && (
             <DocsPageFooter
               route={route}

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -58,6 +58,7 @@ export function Page({
   const description = meta.description || route?.description || '';
   const isHomePage = cleanedPath === '/';
   const isBlogIndex = cleanedPath === '/blog';
+  const isReferencePage = cleanedPath.startsWith('/reference');
 
   let content;
   if (isHomePage) {
@@ -89,7 +90,7 @@ export function Page({
               </LanguagesContext.Provider>
             </TocContext.Provider>
           </div>
-          {!isBlogIndex && <EditThis />}
+          {isReferencePage && <EditThis />}
           {!isBlogIndex && (
             <DocsPageFooter
               route={route}


### PR DESCRIPTION
This PR solves issue #7280 by adding a new "Edit this page" link to the markdown page in Github.

To note the requested additions:
- [x] Add an "Edit this page" button to the bottom of each documentation page
- [x] Ensure that the button links directly to the Markdown file in the GitHub repository
- [x] The link should open in edit mode if possible, so users can quickly make changes and propose pull requests
- [x] The ~button~ link should be styled consistently with the rest of the documentation site and be easy to find

Additionally:
The link is currently added to the "Reference" pages only. The logic is handled by the [Page.tsx](https://github.com/reactjs/react.dev/blob/84f29eb20af17e9c154b9ad71c21af4c9171e4a2/src/components/Layout/Page.tsx#L4) component