### PR TITLE
[conditional-rendering] Make object data easier for translation

### DIFF
--- a/src/content/learn/conditional-rendering.md
+++ b/src/content/learn/conditional-rendering.md
@@ -719,24 +719,16 @@ Another solution would be to remove the condition altogether by moving the infor
 <Sandpack>
 
 ```js
-const drinks = {
-  tea: {
-    part: 'leaf',
-    caffeine: '15–70 mg/cup',
-    age: '4,000+ years'
-  },
-  coffee: {
-    part: 'bean',
-    caffeine: '80–185 mg/cup',
-    age: '1,000+ years'
-  }
-};
+const drinks = [
+  {name: 'tea', part: 'leaf', caffeine: '15–70 mg/cup', age: '4,000+ years'},
+  {name: 'coffee', part: 'bean', caffeine: '80–185 mg/cup', age: '1,000+ years'}
+];
 
 function Drink({ name }) {
-  const info = drinks[name];
+  const info = drinks.find(d => d.name === name);
   return (
     <section>
-      <h1>{name}</h1>
+      <h1>{info.name}</h1>
       <dl>
         <dt>Part of plant</dt>
         <dd>{info.part}</dd>


### PR DESCRIPTION
While translating [conditional-rendering](https://react.dev/learn/conditional-rendering) page I encountered one small issue. Namely, last (3rd) [challenge solution](https://react.dev/learn/conditional-rendering#refactor-a-series-of---to-if-and-variables) has list of objects in the code which are referenced by its names. Name of the object is not the property of the object, so I needed to make workaround. Since I'm trying to translate all the text, including object property values, I needed to introduce `name` field to the object, similar to the example at the end of [thinking-in-react](http://localhost:3000/learn/thinking-in-react#step-5-add-inverse-data-flow) page:
```
const PRODUCTS = [
  {category: "Fruits", price: "$1", stocked: true, name: "Apple"},
  {category: "Fruits", price: "$1", stocked: true, name: "Dragonfruit"},
  {category: "Fruits", price: "$2", stocked: false, name: "Passionfruit"},
  {category: "Vegetables", price: "$2", stocked: true, name: "Spinach"},
  {category: "Vegetables", price: "$4", stocked: false, name: "Pumpkin"},
  {category: "Vegetables", price: "$1", stocked: true, name: "Peas"}
];
```

I saw that some other languages also have similar workaround:
[French](https://fr.react.dev/learn/conditional-rendering#refactor-a-series-of---to-if-and-variables):
![French](https://github.com/user-attachments/assets/6301ce33-aaa1-4b8f-aa3e-16863e90db61)

[Spanish](https://es.react.dev/learn/conditional-rendering#refactor-a-series-of---to-if-and-variables):
![Spanish](https://github.com/user-attachments/assets/d61d188c-895c-47a8-a253-c17f5c46a57c)

I didn't want to to use either english names as in the french solution nor non-english names of variables as in the spanish solution. My idea was to have all functions/variables/etc. in english and all object values on my mother tongue, Serbian.
