### PR TITLE
chore: add packageManager field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,5 +109,6 @@
   "lint-staged": {
     "*.{js,ts,jsx,tsx,css}": "yarn prettier",
     "src/**/*.md": "yarn fix-headings"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Include the packageManager field in package.json to specify the version of Yarn used for the project.