### PR TITLE
chore: update .gitignore to include Yarn files and preserve specific directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,12 @@ public/fonts/**/Optimistic_*.woff2
 
 # rss
 public/rss.xml
+
+# https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
Include Yarn-related files in .gitignore while preserving specific directories for patches, plugins, releases, sdks, and versions.