### PR TITLE
Fix double dot in Intro section

### DIFF
--- a/src/content/reference/react-dom/static/prerenderToNodeStream.md
+++ b/src/content/reference/react-dom/static/prerenderToNodeStream.md
@@ -4,7 +4,7 @@ title: prerenderToNodeStream
 
 <Intro>
 
-`prerender` renders a React tree to a static HTML string using a [Node.js Stream.](https://nodejs.org/api/stream.html).
+`prerender` renders a React tree to a static HTML string using a [Node.js Stream](https://nodejs.org/api/stream.html).
 
 ```js
 const {prelude} = await prerenderToNodeStream(reactNode, options?)


### PR DESCRIPTION
This PR fixes a small typo (double dot):
<img width="774" src="https://github.com/user-attachments/assets/13faba0e-44fa-4cf4-9d4b-c454f45512c3">
