### PR TITLE
fix: broken img tag in ui describe

### DIFF
--- a/src/content/learn/describing-the-ui.md
+++ b/src/content/learn/describing-the-ui.md
@@ -134,7 +134,7 @@ export default function TodoList() {
       src="https://i.imgur.com/yXOvdOSs.jpg"
       alt="Hedy Lamarr"
       class="photo"
-    >
+    />
     <ul>
       <li>Invent new traffic lights
       <li>Rehearse a movie scene


### PR DESCRIPTION
Hi! I reading react docs and see this error.
Just fix it :P
![image](https://github.com/user-attachments/assets/9495b801-d788-4782-98a1-b443771c7f44)
