### PR TITLE
docs: include React 19 blog post in sidebarBlog.json

### DIFF
--- a/src/sidebarBlog.json
+++ b/src/sidebarBlog.json
@@ -12,6 +12,13 @@
       "skipBreadcrumb": true,
       "routes": [
         {
+          "title": "React 19",
+          "titleForHomepage": "React 19",
+          "icon": "blog",
+          "date": "December 05, 2024",
+          "path": "/blog/2024/12/05/react-19"
+        },
+        {
           "title": "React Compiler Beta Release and Roadmap",
           "titleForHomepage": "React Compiler Beta Release and Roadmap",
           "icon": "blog",


### PR DESCRIPTION
Make it appear on the home page, where it's currently missing

![CleanShot 2024-12-06 at 14 52 00](https://github.com/user-attachments/assets/74eb7547-e14a-49de-92f0-be2631f30646)
