### PR TITLE
fix: align counter example code with Effect dependencies documentation

### DIFF
--- a/src/content/learn/removing-effect-dependencies.md
+++ b/src/content/learn/removing-effect-dependencies.md
@@ -311,7 +311,7 @@ export default function Timer() {
   const [increment, setIncrement] = useState(1);
 
   function onTick() {
-	setCount(count + increment);
+	setCount(count => count + increment);
   }
 
   useEffect(() => {


### PR DESCRIPTION
The original code didn't work properly - the counter only incremented once and then stopped. It failed to demonstrate the tutorial's point about dependency warnings.
After changes, the counter now increments every second, but remains unresponsive to button clicks, which suppressing the dependency linter so dangerous.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
