### PR TITLE
fix: ErrorBoundary example code in use API Reference does not compile

### DIFF
--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -397,6 +397,18 @@ root.render(
 );
 ```
 
+```json package.json hidden
+{
+  "dependencies": {
+    "react": "19.0.0-rc-3edc000d-20240926",
+    "react-dom": "19.0.0-rc-3edc000d-20240926",
+    "react-scripts": "^5.0.0",
+    "react-error-boundary": "4.0.3"
+  },
+  "main": "/index.js"
+}
+```
+
 </Sandpack>
 
 #### Providing an alternative value with `Promise.catch` {/*providing-an-alternative-value-with-promise-catch*/}


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

fix https://github.com/reactjs/react.dev/issues/7220

After
![Screenshot 2024-12-10 at 15 30 44](https://github.com/user-attachments/assets/385b4892-3922-420a-9e7d-2df4e9253f3c)


Before
![image](https://github.com/user-attachments/assets/ccdd95f9-2831-47e4-bde7-3c27a094bab5)

