### PR TITLE
Remove canary flag from useFormStatus

### DIFF
--- a/src/content/reference/react-dom/hooks/useFormStatus.md
+++ b/src/content/reference/react-dom/hooks/useFormStatus.md
@@ -1,6 +1,5 @@
 ---
 title: useFormStatus
-canary: true
 ---
 
 <Intro>


### PR DESCRIPTION
Removed the canary flag from the front matter because `useFormStatus` is now stable.