### PR TITLE
Add missing react-error-boundary dependency to use.md Sandpack example

### DIFF
--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -397,6 +397,17 @@ root.render(
 );
 ```
 
+```json package.json hidden
+{
+  "dependencies": {
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-scripts": "^5.0.0",
+    "react-error-boundary": "4.0.3"
+  },
+  "main": "/index.js"
+}
+```
 </Sandpack>
 
 #### Providing an alternative value with `Promise.catch` {/*providing-an-alternative-value-with-promise-catch*/}


### PR DESCRIPTION
the [“Dealing with rejected Promises”](https://react.dev/reference/react/use#dealing-with-rejected-promises) codesandbox example depends on `react-error-boundary`, but doesn’t specify it as a dependency, so the code example is broken:

<img width="899" alt="image" src="https://github.com/user-attachments/assets/c8f589e3-4724-43a6-9613-7fdb3ff893c1">

i took the package.json file chunk from the `useTransition.md` doc that specifies `react-error-boundary`, updated the react/react-dom deps to 19.0.0, and used it for this example. i wasn’t sure if `react-scripts` was actually necessary, but i kept it just in case.