### PR TITLE
Fix intro of prerenderToNodeStream

### DIFF
--- a/src/content/reference/react-dom/static/prerenderToNodeStream.md
+++ b/src/content/reference/react-dom/static/prerenderToNodeStream.md
@@ -4,7 +4,7 @@ title: prerenderToNodeStream
 
 <Intro>
 
-`prerender` renders a React tree to a static HTML string using a [Node.js Stream.](https://nodejs.org/api/stream.html).
+`prerenderToNodeStream` renders a React tree to a static HTML string using a [Node.js Stream.](https://nodejs.org/api/stream.html).
 
 ```js
 const {prelude} = await prerenderToNodeStream(reactNode, options?)


### PR DESCRIPTION
This PR fixes this:

<img width="599" alt="image" src="https://github.com/user-attachments/assets/c3688a4f-27a3-4569-8115-fde13e688f85" />
