### PR TITLE
Add React Paris 2025 conference + React Brussels videos link

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -10,10 +10,10 @@ Do you know of a local React.js conference? Add it here! (Please keep the list c
 
 ## Upcoming Conferences {/*upcoming-conferences*/}
 
-### React Day Berlin 2024 {/*react-day-berlin-2024*/}
-December 13 & 16, 2024. In-person in Berlin, Germany + remote (hybrid event)
+### React Paris 2025 {/*react-paris-2025*/}
+March 20 - 21, 2024. In-person in Paris, France (hybrid event)
 
-[Website](https://reactday.berlin/) - [Twitter](https://x.com/reactdayberlin)
+[Website](https://react.paris/) - [Twitter](https://x.com/BeJS_)
 
 ### App.js Conf 2025 {/*appjs-conf-2025*/}
 May 28 - 30, 2025. In-person in Kraków, Poland + remote
@@ -26,6 +26,11 @@ June 13 - 17, 2025. In-person in Amsterdam, Netherlands + remote (hybrid event)
 [Website](https://reactsummit.com/) - [Twitter](https://x.com/reactsummit)
 
 ## Past Conferences {/*past-conferences*/}
+
+### React Day Berlin 2024 {/*react-day-berlin-2024*/}
+December 13 & 16, 2024. In-person in Berlin, Germany + remote (hybrid event)
+
+[Website](https://reactday.berlin/) - [Twitter](https://x.com/reactdayberlin)
 
 ### React Africa 2024 {/*react-africa-2024*/}
 November 29, 2024. In-person in Casablanca, Morocco (hybrid event)
@@ -55,7 +60,7 @@ October 25, 2024. In-person in Verona, Italy + online (hybrid event)
 ### React Brussels 2024 {/*react-brussels-2024*/}
 October 18, 2024. In-person in Brussels, Belgium (hybrid event)
 
-[Website](https://www.react.brussels/) - [Twitter](https://x.com/BrusselsReact)
+[Website](https://www.react.brussels/) - [Twitter](https://x.com/BrusselsReact) - [YouTube](https://www.youtube.com/playlist?list=PL53Z0yyYnpWimQ0U75woee2zNUIFsiDC3)
 
 ### React India 2024 {/*react-india-2024*/}
 October 17 - 19, 2024. In-person in Goa, India (hybrid event) + Oct 15 2024 - remote day


### PR DESCRIPTION
This is to add React Paris conference and add the videos link to React Brussels.