### PR TITLE
fix(sandpack): resolve UI desync after reset by removing call to reset()

### DIFF
--- a/src/components/MDX/Sandpack/NavigationBar.tsx
+++ b/src/components/MDX/Sandpack/NavigationBar.tsx
@@ -11,11 +11,7 @@ import {
   Fragment,
 } from 'react';
 import cn from 'classnames';
-import {
-  FileTabs,
-  useSandpack,
-  useSandpackNavigation,
-} from '@codesandbox/sandpack-react/unstyled';
+import {FileTabs, useSandpack} from '@codesandbox/sandpack-react/unstyled';
 import {OpenInCodeSandboxButton} from './OpenInCodeSandboxButton';
 import {ResetButton} from './ResetButton';
 import {DownloadButton} from './DownloadButton';
@@ -47,9 +43,7 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
   // By default, show the dropdown because all tabs may not fit.
   // We don't know whether they'll fit or not until after hydration:
   const [showDropdown, setShowDropdown] = useState(true);
-  const {activeFile, setActiveFile, visibleFiles, clients} = sandpack;
-  const clientId = Object.keys(clients)[0];
-  const {refresh} = useSandpackNavigation(clientId);
+  const {activeFile, setActiveFile, visibleFiles} = sandpack;
   const isMultiFile = visibleFiles.length > 1;
   const hasJustToggledDropdown = useRef(false);
 
@@ -109,8 +103,6 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
     ) {
       sandpack.resetAllFiles();
     }
-
-    refresh();
   };
 
   return (


### PR DESCRIPTION


https://github.com/user-attachments/assets/d12f54d9-1412-42ba-add4-62d10f53d3d5

Remove call to refresh() in the handleReset function and dependencies related to refresh() from NavigationBar.tsx file to fix a UI desynchronization issue in the Sandpack embedded editor. Currently, clicking the reset button resets the code but does not update the UI until the editor is interacted with.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
