### PR TITLE
Update Conferences Lists for 2025

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -26,7 +26,7 @@ June 13 - 17, 2025. In-person in Amsterdam, Netherlands + remote (hybrid event)
 [Website](https://reactsummit.com/) - [Twitter](https://x.com/reactsummit)
 
 ### React India 2025 {/*react-india-2025*/}
-October 31 - November 01, 2024. In-person in Goa, India (hybrid event) + Oct 15 2025 - remote day
+October 31 - November 01, 2025. In-person in Goa, India (hybrid event) + Oct 15 2025 - remote day
 
 [Website](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia) - [Youtube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w)
 

--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -10,10 +10,10 @@ Do you know of a local React.js conference? Add it here! (Please keep the list c
 
 ## Upcoming Conferences {/*upcoming-conferences*/}
 
-### React Day Berlin 2024 {/*react-day-berlin-2024*/}
-December 13 & 16, 2024. In-person in Berlin, Germany + remote (hybrid event)
+### React Paris 2025 {/*react-paris-2025*/}
+March 20 - 21, 2024. In-person in Paris, France (hybrid event)
 
-[Website](https://reactday.berlin/) - [Twitter](https://x.com/reactdayberlin)
+[Website](https://react.paris/) - [Twitter](https://x.com/BeJS_)
 
 ### App.js Conf 2025 {/*appjs-conf-2025*/}
 May 28 - 30, 2025. In-person in Kraków, Poland + remote
@@ -25,7 +25,17 @@ June 13 - 17, 2025. In-person in Amsterdam, Netherlands + remote (hybrid event)
 
 [Website](https://reactsummit.com/) - [Twitter](https://x.com/reactsummit)
 
+### React India 2025 {/*react-india-2025*/}
+October 31 - November 01, 2024. In-person in Goa, India (hybrid event) + Oct 15 2025 - remote day
+
+[Website](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia) - [Youtube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w)
+
 ## Past Conferences {/*past-conferences*/}
+
+### React Day Berlin 2024 {/*react-day-berlin-2024*/}
+December 13 & 16, 2024. In-person in Berlin, Germany + remote (hybrid event)
+
+[Website](https://reactday.berlin/) - [Twitter](https://x.com/reactdayberlin)
 
 ### React Africa 2024 {/*react-africa-2024*/}
 November 29, 2024. In-person in Casablanca, Morocco (hybrid event)
@@ -55,7 +65,7 @@ October 25, 2024. In-person in Verona, Italy + online (hybrid event)
 ### React Brussels 2024 {/*react-brussels-2024*/}
 October 18, 2024. In-person in Brussels, Belgium (hybrid event)
 
-[Website](https://www.react.brussels/) - [Twitter](https://x.com/BrusselsReact)
+[Website](https://www.react.brussels/) - [Twitter](https://x.com/BrusselsReact) - [YouTube](https://www.youtube.com/playlist?list=PL53Z0yyYnpWimQ0U75woee2zNUIFsiDC3)
 
 ### React India 2024 {/*react-india-2024*/}
 October 17 - 19, 2024. In-person in Goa, India (hybrid event) + Oct 15 2024 - remote day


### PR DESCRIPTION
Additions to the `Upcoming Conferences` section:

- Announced 2025 dates for `React India` 🇮🇳 & `React Paris` 🚀.

Reorganization of the Past Conferences

Moved all previously listed conferences from the Upcoming section to the Past section for better clarity and consistency.