### PR TITLE
Only show scrollbar when necessary in TerminalBlock component

### DIFF
--- a/src/components/MDX/TerminalBlock.tsx
+++ b/src/components/MDX/TerminalBlock.tsx
@@ -71,7 +71,7 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
         </div>
       </div>
       <div
-        className="px-8 pt-4 pb-6 text-primary-dark dark:text-primary-dark font-mono text-code whitespace-pre overflow-x-scroll"
+        className="px-8 pt-4 pb-6 text-primary-dark dark:text-primary-dark font-mono text-code whitespace-pre overflow-x-auto"
         translate="no"
         dir="ltr">
         <LevelText type={level} />


### PR DESCRIPTION
Adjust the overflow property from `overflow-x-scroll` to `overflow-x-auto` in the TerminalBlock component for improved layout handling.

before
![image](https://github.com/user-attachments/assets/d59630ff-7ab5-4b87-af15-dcaacd9c9eb8)

after
![image](https://github.com/user-attachments/assets/17e9c33c-d4b5-493d-ae2a-65e189a2c5c3)
