### PR TITLE
Fix broken link to Next.js base path configuration

### DIFF
--- a/src/content/learn/add-react-to-an-existing-project.md
+++ b/src/content/learn/add-react-to-an-existing-project.md
@@ -21,7 +21,7 @@ Let's say you have an existing web app at `example.com` built with another serve
 Here's how we recommend to set it up:
 
 1. **Build the React part of your app** using one of the [React-based frameworks](/learn/start-a-new-react-project).
-2. **Specify `/some-app` as the *base path*** in your framework's configuration (here's how: [Next.js](https://nextjs.org/docs/api-reference/next.config.js/basepath), [Gatsby](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)).
+2. **Specify `/some-app` as the *base path*** in your framework's configuration (here's how: [Next.js](https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath), [Gatsby](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)).
 3. **Configure your server or a proxy** so that all requests under `/some-app/` are handled by your React app.
 
 This ensures the React part of your app can [benefit from the best practices](/learn/start-a-new-react-project#can-i-use-react-without-a-framework) baked into those frameworks.


### PR DESCRIPTION
This pull request updates the React documentation in the "Add React to an Existing Project" section. Specifically, it fixes the broken link to the Next.js documentation on configuring a base path. The original link pointed to an outdated or incorrect URL, which could cause confusion for readers trying to implement a React application for a specific subroute, such as /some-app, using Next.js.

The updated link now directs users to the correct Next.js documentation page that explains how to configure a base path in a Next.js application.