### PR TITLE
docs: Correct var reference in prerender example

### DIFF
--- a/src/content/reference/react-dom/static/prerender.md
+++ b/src/content/reference/react-dom/static/prerender.md
@@ -230,7 +230,7 @@ async function renderToString() {
     bootstrapScripts: ['/main.js']
   });
   
-  const reader = stream.getReader();
+  const reader = prelude.getReader();
   let content = '';
   while (true) {
     const {done, value} = await reader.read();


### PR DESCRIPTION
Simple typo, `stream` doesn't exist in the example.