### PR TITLE
fix typo

### DIFF
--- a/src/content/reference/react/useImperativeHandle.md
+++ b/src/content/reference/react/useImperativeHandle.md
@@ -46,7 +46,7 @@ function MyInput({ ref }) {
 
 <Note>
 
-Starting with React 19, [`ref` is available a prop.](/blog/2024/12/05/react-19#ref-as-a-prop) In React 18 and earlier, it was necessary to get the `ref` from [`forwardRef`.](/reference/react/forwardRef) 
+Starting with React 19, [`ref` is available as a prop.](/blog/2024/12/05/react-19#ref-as-a-prop) In React 18 and earlier, it was necessary to get the `ref` from [`forwardRef`.](/reference/react/forwardRef) 
 
 </Note>
 


### PR DESCRIPTION
This is just a typo in the first Note section for the useImperativeHandle hook.
Should be 'Starting with React 19, [`ref` is available AS a prop.]' and not 'Starting with React 19, [`ref` is available a prop.]'.

Thank you. No visual changes. 
