### PR TITLE
[ci] Add workflow to label PRs from core team

### DIFF
--- a/.github/workflows/label_core_team_prs.yml
+++ b/.github/workflows/label_core_team_prs.yml
@@ -1,0 +1,31 @@
+name: Label Core Team PRs
+
+on:
+  pull_request_target:
+
+env:
+  TZ: /usr/share/zoneinfo/America/Los_Angeles
+  # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+jobs:
+  check_maintainer:
+    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    with:
+      actor: ${{ github.event.pull_request.user.login }}
+
+  label:
+    if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
+    runs-on: ubuntu-latest
+    needs: check_maintainer
+    steps:
+      - name: Label PR as React Core Team
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.number }},
+              labels: ['React Core Team']
+            });


### PR DESCRIPTION
Reuses the main repo's workflow to label if a PR is opened by a core team member.