### PR TITLE
Bring docs for cloneElement in line with `@react/types` types

### DIFF
--- a/src/content/reference/react/cloneElement.md
+++ b/src/content/reference/react/cloneElement.md
@@ -49,7 +49,7 @@ console.log(clonedElement); // <Row title="Cabbage" isHighlighted={true}>Goodbye
 
 * `element`: The `element` argument must be a valid React element. For example, it could be a JSX node like `<Something />`, the result of calling [`createElement`](/reference/react/createElement), or the result of another `cloneElement` call.
 
-* `props`: The `props` argument must either be an object or `null`. If you pass `null`, the cloned element will retain all of the original `element.props`. Otherwise, for every prop in the `props` object, the returned element will "prefer" the value from `props` over the value from `element.props`. The rest of the props will be filled from the original `element.props`. If you pass `props.key` or `props.ref`, they will replace the original ones.
+* `props`: The `props` argument must either be an object or `undefined`. If you pass `undefined`, the cloned element will retain all of the original `element.props`. Otherwise, for every prop in the `props` object, the returned element will "prefer" the value from `props` over the value from `element.props`. The rest of the props will be filled from the original `element.props`. If you pass `props.key` or `props.ref`, they will replace the original ones.
 
 * **optional** `...children`: Zero or more child nodes. They can be any React nodes, including React elements, strings, numbers, [portals](/reference/react-dom/createPortal), empty nodes (`null`, `undefined`, `true`, and `false`), and arrays of React nodes. If you don't pass any `...children` arguments, the original `element.props.children` will be preserved.
 
@@ -68,7 +68,7 @@ Usually, you'll return the element from your component or make it a child of ano
 
 * Cloning an element **does not modify the original element.**
 
-* You should only **pass children as multiple arguments to `cloneElement` if they are all statically known,** like `cloneElement(element, null, child1, child2, child3)`. If your children are dynamic, pass the entire array as the third argument: `cloneElement(element, null, listItems)`. This ensures that React will [warn you about missing `key`s](/learn/rendering-lists#keeping-list-items-in-order-with-key) for any dynamic lists. For static lists this is not necessary because they never reorder.
+* You should only **pass children as multiple arguments to `cloneElement` if they are all statically known,** like `cloneElement(element, undefined, child1, child2, child3)`. If your children are dynamic, pass the entire array as the third argument: `cloneElement(element, undefined, listItems)`. This ensures that React will [warn you about missing `key`s](/learn/rendering-lists#keeping-list-items-in-order-with-key) for any dynamic lists. For static lists this is not necessary because they never reorder.
 
 * `cloneElement` makes it harder to trace the data flow, so **try the [alternatives](#alternatives) instead.**
 


### PR DESCRIPTION
The docs for cloneElement give examples that are not legal as per the types in `@types/react`.

* [relevant types here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f1aeead9bdfd9af8af586a0ff86b2bf68eb95451/types/react/index.d.ts#L488)

Of the the overlaods here give the type for the props parameter as some variant of `props?: P` - in typescript `?:` will allow undefined but not null. However, the docs say to use `null`.

This means that currently, for someone creating the typical react app with common scaffolds that include typescript, using the examples from the docs will give type errors.
