### PR TITLE
A new section has been added to start a new project with vite.js

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -57,6 +57,7 @@ If you're new to React, check out the [learn React course.](https://react.dev/le
 
 Vite is a **frontend project builder** optimized for rapid development in **React** and other modern frameworks. It focuses on providing an agile and efficient experience.
 
+
 ### Remix {/*remix*/}
 
 **[Remix](https://remix.run/) is a full-stack React framework with nested routing.** It lets you break your app into nested parts that can load data in parallel and refresh in response to the user actions. To create a new Remix project, run:

--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -47,6 +47,16 @@ If you're new to Next.js, check out the [learn Next.js course.](https://nextjs.o
 
 Next.js is maintained by [Vercel](https://vercel.com/). You can [deploy a Next.js app](https://nextjs.org/docs/app/building-your-application/deploying) to any Node.js or serverless hosting, or to your own server. Next.js also supports a [static export](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports) which doesn't require a server.
 
+### Vite {/*vite*/}
+
+<TerminalBlock>
+npm create vite@latest
+</TerminalBlock>
+
+If you're new to React, check out the [learn React course.](https://react.dev/learn)
+
+Vite is a **frontend project builder** optimized for rapid development in **React** and other modern frameworks. It focuses on providing an agile and efficient experience.
+
 ### Remix {/*remix*/}
 
 **[Remix](https://remix.run/) is a full-stack React framework with nested routing.** It lets you break your app into nested parts that can load data in parallel and refresh in response to the user actions. To create a new Remix project, run:


### PR DESCRIPTION
Vite has been added to the official React documentation (React.dev) as an option in the "Start a new project" section. This means that developers can now use [Vite](https://vite.dev/guide/) the recommended tool to quickly set up a new React project.

![image](https://github.com/user-attachments/assets/6f99e913-f6de-4eb0-88c1-9061d459569a)

