### PR TITLE
Add Rsbuild as a build tool for React projects

### DIFF
--- a/src/content/blog/2025/02/14/sunsetting-create-react-app.md
+++ b/src/content/blog/2025/02/14/sunsetting-create-react-app.md
@@ -56,9 +56,9 @@ For existing apps, these guides will help you migrate to a client-only SPA:
 
 Create React App will continue working in maintenance mode, and we've published a new version of Create React App to work with React 19.
 
-If your app has unusual constraints, or you prefer to solve these problems by building your own framework, or you just want to learn how react works from scratch, you can roll your own custom setup with React using Vite or Parcel.
+If your app has unusual constraints, or you prefer to solve these problems by building your own framework, or you just want to learn how react works from scratch, you can roll your own custom setup with React using Vite, Parcel or Rsbuild.
 
-To help users get started with Vite or Parcel, we've published new docs for [Building a Framework](/learn/building-a-react-framework). Continue reading to learn more about the [limitations of Create React App](#limitations-of-create-react-app) and [why we recommend frameworks](#why-we-recommend-frameworks).
+To help users get started with Vite, Parcel or Rsbuild, we've published new docs for [Building a Framework](/learn/building-a-react-framework). Continue reading to learn more about the [limitations of Create React App](#limitations-of-create-react-app) and [why we recommend frameworks](#why-we-recommend-frameworks).
 
 <Note>
 

--- a/src/content/learn/building-a-react-framework.md
+++ b/src/content/learn/building-a-react-framework.md
@@ -26,7 +26,7 @@ If you are building your own framework to learn, using popular tools like Vite a
 
 ## Step 1: Install a build tool {/*step-1-install-a-build-tool*/}
 
-The first step is to install a build tool like `vite` or `parcel`. These build tools provide features to package and run source code, provide a development server for local development and a build command to deploy your app to a production server.
+The first step is to install a build tool like `vite`, `parcel`, or `rsbuild`. These build tools provide features to package and run source code, provide a development server for local development and a build command to deploy your app to a production server.
 
 ### Vite {/*vite*/}
 
@@ -49,6 +49,16 @@ npm install --save-dev parcel
 </TerminalBlock>
 
 Parcel supports fast refresh, JSX, TypeScript, Flow, and styling out of the box. See [Parcel's React recipe](https://parceljs.org/recipes/react/#getting-started) to get started.
+
+### Rsbuild {/*rsbuild*/}
+
+[Rsbuild](https://rsbuild.dev/) is an Rspack-powered build tool that provides a seamless development experience for React applications. It comes with carefully tuned defaults and performance optimizations ready to use.
+
+<TerminalBlock>
+npx create-rsbuild --template react
+</TerminalBlock>
+
+Rsbuild includes built-in support for React features like fast refresh, JSX, TypeScript, and styling. See [Rsbuild's React guide](https://rsbuild.dev/guide/framework/react) to get started.
 
 <Note>
 


### PR DESCRIPTION
This PR adds [Rsbuild](https://rsbuild.dev/)  to the list of build tools on the "Building a React Framework" page. 

Rsbuild is a modern CRA alternative and provides a step-by-step [migration guide](https://rsbuild.dev/guide/migration/cra) for CRA. It's already mentioned in the React Compiler documentation: https://react.dev/learn/react-compiler#usage-with-rsbuild

This should help more CRA users to migrate, and allow users to build their own framework based on Rsbuild.

There are many proposals on X to add Rsbuild to the documentation, such as:

- https://x.com/ScriptedAlchemy/status/1890486115959709752
- https://x.com/mwarger/status/1890604932862030160
- https://x.com/jait_chen/status/1890521940613345531
- https://x.com/rspack_dev/status/1890519360160043338