### PR TITLE
fix(docs): wrong redirect link to /learn/creating-a-react-app

### DIFF
--- a/src/content/learn/installation.md
+++ b/src/content/learn/installation.md
@@ -48,7 +48,7 @@ If want to try using React in your existing app or a website, you can [add React
 
 ### Create React App (Deprecated) {/*create-react-app-deprecated*/}
 
-Create React App is a deprecated tool, previously recommended for creating new React apps. If you want to start a new React app, you can [create a React app](/learn/creat-a-react-app) using a recommended framework. 
+Create React App is a deprecated tool, previously recommended for creating new React apps. If you want to start a new React app, you can [create a React app](/learn/creating-a-react-app) using a recommended framework. 
 
 For more information, see [Sunsetting Create React App](/blog/2025/02/14/sunsetting-create-react-app).
 


### PR DESCRIPTION
Added a fix to wrong redirect link on https://react.dev/learn/installation#create-react-app-deprecated page section.

Right now it redirects to non-existing link: 
<img width="1552" alt="Screenshot 2025-02-16 at 17 16 21" src="https://github.com/user-attachments/assets/086ad9b2-9bd9-4ba1-8250-6d389723d2d1" />

