### PR TITLE
fix(docs): wrong vite command on the "Building a React Framework" page

### DIFF
--- a/src/content/learn/building-a-react-framework.md
+++ b/src/content/learn/building-a-react-framework.md
@@ -33,7 +33,7 @@ The first step is to install a build tool like `vite` or `parcel`. These build t
 [Vite](https://vite.dev/) is a build tool that aims to provide a faster and leaner development experience for modern web projects.
 
 <TerminalBlock>
-npx vite@latest --template react
+npm create vite@latest my-app -- --template react
 </TerminalBlock>
 
 Vite is opinionated and comes with sensible defaults out of the box. Vite has a rich ecosystem of plugins to support fast refresh, JSX,  Babel/SWC, and other common features. See Vite's [React plugin](https://vite.dev/plugins/#vitejs-plugin-react) or [React SWC plugin](https://vite.dev/plugins/#vitejs-plugin-react-swc) and [React SSR example project](https://vite.dev/guide/ssr.html#example-projects) to get started.


### PR DESCRIPTION
# Overview

- fixing wrong vite command in the docs (#7614) 

Fixes #7614 