### PR TITLE
chore(docs): add mention that React will drop all extraneous props when using `precedence` with `<style>`

### DIFF
--- a/src/content/reference/react-dom/components/style.md
+++ b/src/content/reference/react-dom/components/style.md
@@ -52,6 +52,7 @@ To opt into this behavior, provide the `href` and `precedence` props. React will
 This special treatment comes with two caveats:
 
 * React will ignore changes to props after the style has been rendered. (React will issue a warning in development if this happens.)
+* React will drop all extraneous props when using the `precedence` prop (beyond `href` and `precedence`).
 * React may leave the style in the DOM even after the component that rendered it has been unmounted.
 
 ---


### PR DESCRIPTION
## Why?

> When React hoists style rules using <style precedence="..." href="...">{...rules}</style> it does not accept arbitrary props.

- x-ref: https://github.com/facebook/react/issues/32449

This behavior should be additionally mentioned in https://react.dev/reference/react-dom/components/style#special-rendering-behavior.