### PR TITLE
Update queueing-a-series-of-state-updates.md

### DIFF
--- a/src/content/learn/queueing-a-series-of-state-updates.md
+++ b/src/content/learn/queueing-a-series-of-state-updates.md
@@ -264,7 +264,7 @@ If you prefer more verbose code, another common convention is to repeat the full
 
 * Setting state does not change the variable in the existing render, but it requests a new render.
 * React processes state updates after event handlers have finished running. This is called batching.
-* To update some state multiple times in one event, you can use `setNumber(n => n + 1)` updater function.
+* To update some state multiple times in one event, you can use an updater function like `setNumber(n => n + 1)`.
 
 </Recap>
 


### PR DESCRIPTION
## Update React Docs: State Updater Function Example

### Summary
This PR improves the clarity of the documentation regarding the use of state updater functions in React. The previous wording was slightly ambiguous, and this revision makes the explanation more precise.

### Changes
- Updated the sentence: **Before:** "To update some state multiple times in one event, you can use `setNumber(n => n + 1)` updater function."   **After:** "To update some state multiple times in one event, you can use an updater function like `setNumber(n => n + 1)`."

### Rationale
- Introduces **"an updater function"** before the example for better readability.
- Ensures consistency with React documentation standards.
- Improves comprehension for new developers.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
