### PR TITLE
Use resolved Canary version in `captureOwnerStack` docs

### DIFF
--- a/src/content/reference/react/captureOwnerStack.md
+++ b/src/content/reference/react/captureOwnerStack.md
@@ -129,8 +129,8 @@ createRoot(document.createElement('div'), {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.1.0-canary-ebc22ef7-20250225",
+    "react-dom": "19.1.0-canary-ebc22ef7-20250225",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -360,8 +360,8 @@ createRoot(container).render(<App />);
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.1.0-canary-ebc22ef7-20250225",
+    "react-dom": "19.1.0-canary-ebc22ef7-20250225",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -420,8 +420,8 @@ export default function App() {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.1.0-canary-ebc22ef7-20250225",
+    "react-dom": "19.1.0-canary-ebc22ef7-20250225",
     "react-scripts": "latest"
   },
   "scripts": {


### PR DESCRIPTION
Preview: https://react-dev-git-fork-eps1lon-sandbox-fix-fbopensource.vercel.app/reference/react/captureOwnerStack

For unknown reasons, the inlined sandboxes will not resolve to the same version if use an NPM dist-tag. But when I use a hardcoded version, it can't find the module? The forks always work though.

supposed to fix
```
Error
Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
  - react:      19.1.0-canary-ebc22ef7-20250225
  - react-dom:  19.1.0-canary-22e39ea7-20250225
Learn more: https://react.dev/warnings/version-mismatch
```