### PR TITLE
[ci] Run notify workflow on open or ready for review

### DIFF
--- a/.github/workflows/discord_notify.yml
+++ b/.github/workflows/discord_notify.yml
@@ -2,7 +2,7 @@ name: Discord Notify
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [opened, ready_for_review]
 
 jobs:
   check_maintainer:


### PR DESCRIPTION

Ports over the fix in the facebook/react repo for this workflow. We don't have to wait for it to be labeled first, now that we have the reusable maintainer check.
