### PR TITLE
fix: correct overlay highlighting in code examples

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -859,7 +859,8 @@ function ExampleLayout({
           </div>
           <div
             ref={contentRef}
-            className="relative mt-0 lg:-my-20 w-full p-2.5 xs:p-5 lg:p-10 flex grow justify-center">
+            className="relative mt-0 lg:-my-20 w-full p-2.5 xs:p-5 lg:p-10 flex grow justify-center"
+            dir="ltr">
             {right}
             <div
               className={cn(


### PR DESCRIPTION
Description

This PR fixes the code overlay highlight issue in RTL mode on [fa.react.dev](https://fa.react.dev/) and [ar.react.dev](https://ar.react.dev/). Previously, hovering over the code section did not properly highlight the preview area due to incorrect overlay positioning in RTL layouts.

Fix
	•	Added dir="ltr" to ensure consistent overlay behavior across RTL and LTR layouts.

Before & After Video

📌 Before Fix (Bug in RTL Mode):

https://github.com/user-attachments/assets/9bf2d311-1503-4b7e-99b8-5c1b4cf59281


✅ After Fix (Corrected Overlay in RTL Mode):

https://github.com/user-attachments/assets/b312fdd1-9eff-4166-81a1-a2e7237dd5fe




Related Issue

Closes #7668