### PR TITLE
【Docs】Add first log to useEffect synchronous flow description

### DIFF
--- a/src/content/learn/synchronizing-with-effects.md
+++ b/src/content/learn/synchronizing-with-effects.md
@@ -856,7 +856,7 @@ export default function App() {
 
 You will see three logs at first: `Schedule "a" log`, `Cancel "a" log`, and `Schedule "a" log` again. Three second later there will also be a log saying `a`. As you learned earlier, the extra schedule/cancel pair is because React remounts the component once in development to verify that you've implemented cleanup well.
 
-Now edit the input to say `abc`. If you do it fast enough, you'll see `Schedule "ab" log` immediately followed by `Cancel "ab" log` and `Schedule "abc" log`. **React always cleans up the previous render's Effect before the next render's Effect.** This is why even if you type into the input fast, there is at most one timeout scheduled at a time. Edit the input a few times and watch the console to get a feel for how Effects get cleaned up.
+Now edit the input to say `abc`. If you do it fast enough, you'll see `Cancel "a" log` immediately followed by `Schedule "ab" log`, `Cancel "ab" log` and `Schedule "abc" log`. **React always cleans up the previous render's Effect before the next render's Effect.** This is why even if you type into the input fast, there is at most one timeout scheduled at a time. Edit the input a few times and watch the console to get a feel for how Effects get cleaned up.
 
 Type something into the input and then immediately press "Unmount the component". Notice how unmounting cleans up the last render's Effect. Here, it clears the last timeout before it has a chance to fire.
 


### PR DESCRIPTION
# Overview
This PR corrects the log sequence in the example under [Synchronizing with Effects - Putting It All Together](https://react.dev/learn/synchronizing-with-effects#putting-it-all-together).

The current description states:

> Now edit the input to say `abc`. If you do it fast enough, you'll see `Schedule "ab" log` immediately followed by `Cancel "ab" log` and `Schedule "abc" log`.

However, in practice, `Cancel "a" log` appears before `Schedule "ab" log`.

⬇︎example in motion 
https://github.com/user-attachments/assets/e09c5c1a-0777-4e28-b1a9-609f32983f74

Updated the description to accurately reflect the log order:

> Now edit the input to say `abc`. If you do it fast enough, you'll see `Cancel "a" log` immediately followed by `Schedule "ab" log`, `Cancel "ab" log` and `Schedule "abc" log`.

This ensures the explanation aligns with the actual behavior of the effect cleanup process.

## Relevant section.
https://react.dev/learn/synchronizing-with-effects#putting-it-all-together
