### PR TITLE
[ci] Fix permissions and don't use pull_request_target

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -7,6 +7,8 @@ on:
       - main # change this if your default branch is named differently
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
@@ -23,7 +25,7 @@ jobs:
       - name: Restore cached node_modules
         uses: actions/cache@v4
         with:
-          path: "**/node_modules"
+          path: '**/node_modules'
           key: node_modules-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install deps

--- a/.github/workflows/analyze_comment.yml
+++ b/.github/workflows/analyze_comment.yml
@@ -2,9 +2,11 @@ name: Analyze Bundle (Comment)
 
 on:
   workflow_run:
-    workflows: ["Analyze Bundle"]
+    workflows: ['Analyze Bundle']
     types:
       - completed
+
+permissions: {}
 
 jobs:
   comment:

--- a/.github/workflows/discord_notify.yml
+++ b/.github/workflows/discord_notify.yml
@@ -1,12 +1,17 @@
 name: Discord Notify
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review]
+
+permissions: {}
 
 jobs:
   check_maintainer:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    permissions:
+      # Used by check_maintainer
+      contents: read
     with:
       actor: ${{ github.event.pull_request.user.login }}
       is_remote: true

--- a/.github/workflows/label_core_team_prs.yml
+++ b/.github/workflows/label_core_team_prs.yml
@@ -1,7 +1,9 @@
 name: Label Core Team PRs
 
 on:
-  pull_request_target:
+  pull_request:
+
+permissions: {}
 
 env:
   TZ: /usr/share/zoneinfo/America/Los_Angeles
@@ -11,6 +13,9 @@ env:
 jobs:
   check_maintainer:
     uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    permissions:
+      # Used by check_maintainer
+      contents: read
     with:
       actor: ${{ github.event.pull_request.user.login }}
       is_remote: true
@@ -19,6 +24,11 @@ jobs:
     if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}
     runs-on: ubuntu-latest
     needs: check_maintainer
+    permissions:
+      # Used to add labels on issues
+      issues: write
+      # Used to add labels on PRs
+      pull-requests: write
     steps:
       - name: Label PR as React Core Team
         uses: actions/github-script@v7

--- a/.github/workflows/site_lint.yml
+++ b/.github/workflows/site_lint.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -25,7 +27,7 @@ jobs:
       - name: Restore cached node_modules
         uses: actions/cache@v4
         with:
-          path: "**/node_modules"
+          path: '**/node_modules'
           key: node_modules-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install deps


### PR DESCRIPTION

Defaults permissions to none for all workflows, and only request extra permissions when needed.

Similar to https://github.com/facebook/react/pull/32708, prefer the less permissive `pull_request` trigger instead.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/reactjs/react.dev/pull/7689).
* #7690
* __->__ #7689