### PR TITLE
[ci] Remove unused param

### DIFF
--- a/.github/workflows/discord_notify.yml
+++ b/.github/workflows/discord_notify.yml
@@ -14,7 +14,6 @@ jobs:
       contents: read
     with:
       actor: ${{ github.event.pull_request.user.login }}
-      is_remote: true
 
   notify:
     if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}

--- a/.github/workflows/label_core_team_prs.yml
+++ b/.github/workflows/label_core_team_prs.yml
@@ -18,7 +18,6 @@ jobs:
       contents: read
     with:
       actor: ${{ github.event.pull_request.user.login }}
-      is_remote: true
 
   label:
     if: ${{ needs.check_maintainer.outputs.is_core_team == 'true' }}


### PR DESCRIPTION

https://github.com/facebook/react/pull/32727 removes the `is_remote` param.
