### PR TITLE
Update docs: fix missing unused import in `escape-hatches.md` and `parating-events-from-effects.md`

### DIFF
--- a/src/content/learn/escape-hatches.md
+++ b/src/content/learn/escape-hatches.md
@@ -343,7 +343,7 @@ All code inside Effects is *reactive.* It will run again if some reactive value 
 
 ```js
 import { useState, useEffect } from 'react';
-import { createConnection, sendMessage } from './chat.js';
+import { createConnection } from './chat.js';
 import { showNotification } from './notifications.js';
 
 const serverUrl = 'https://localhost:1234';
@@ -472,7 +472,7 @@ This is not ideal. You want to re-connect to the chat only if the `roomId` has c
 ```js
 import { useState, useEffect } from 'react';
 import { experimental_useEffectEvent as useEffectEvent } from 'react';
-import { createConnection, sendMessage } from './chat.js';
+import { createConnection } from './chat.js';
 import { showNotification } from './notifications.js';
 
 const serverUrl = 'https://localhost:1234';

--- a/src/content/learn/separating-events-from-effects.md
+++ b/src/content/learn/separating-events-from-effects.md
@@ -281,7 +281,7 @@ Play with this example and see if you can spot the problem with this user experi
 
 ```js
 import { useState, useEffect } from 'react';
-import { createConnection, sendMessage } from './chat.js';
+import { createConnection } from './chat.js';
 import { showNotification } from './notifications.js';
 
 const serverUrl = 'https://localhost:1234';
@@ -465,7 +465,7 @@ Verify that the new behavior works as you would expect:
 ```js
 import { useState, useEffect } from 'react';
 import { experimental_useEffectEvent as useEffectEvent } from 'react';
-import { createConnection, sendMessage } from './chat.js';
+import { createConnection } from './chat.js';
 import { showNotification } from './notifications.js';
 
 const serverUrl = 'https://localhost:1234';
@@ -1442,7 +1442,7 @@ Your Effect knows which room it connected to. Is there any information that you 
 ```js
 import { useState, useEffect } from 'react';
 import { experimental_useEffectEvent as useEffectEvent } from 'react';
-import { createConnection, sendMessage } from './chat.js';
+import { createConnection } from './chat.js';
 import { showNotification } from './notifications.js';
 
 const serverUrl = 'https://localhost:1234';
@@ -1583,7 +1583,7 @@ To fix the issue, instead of reading the *latest* `roomId` inside the Effect Eve
 ```js
 import { useState, useEffect } from 'react';
 import { experimental_useEffectEvent as useEffectEvent } from 'react';
-import { createConnection, sendMessage } from './chat.js';
+import { createConnection } from './chat.js';
 import { showNotification } from './notifications.js';
 
 const serverUrl = 'https://localhost:1234';
@@ -1720,7 +1720,7 @@ To solve the additional challenge, save the notification timeout ID and clear it
 ```js
 import { useState, useEffect } from 'react';
 import { experimental_useEffectEvent as useEffectEvent } from 'react';
-import { createConnection, sendMessage } from './chat.js';
+import { createConnection } from './chat.js';
 import { showNotification } from './notifications.js';
 
 const serverUrl = 'https://localhost:1234';


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
