### PR TITLE
Remove captureOwnerStack canary banner

### DIFF
--- a/src/content/reference/react/captureOwnerStack.md
+++ b/src/content/reference/react/captureOwnerStack.md
@@ -2,12 +2,6 @@
 title: captureOwnerStack
 ---
 
-<Canary>
-
-The `captureOwnerStack` API is currently only available in React's Canary and experimental channels. Learn more about [React's release channels here](/community/versioning-policy#all-release-channels).
-
-</Canary>
-
 <Intro>
 
 `captureOwnerStack` reads the current Owner Stack in development and returns it as a string if available.

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -117,6 +117,9 @@
         {
           "title": "cache",
           "path": "/reference/react/cache"
+        },        {
+          "title": "captureOwnerStack",
+          "path": "/reference/react/captureOwnerStack"
         },
         {
           "title": "createContext",
@@ -146,11 +149,6 @@
         {
           "title": "experimental_taintUniqueValue",
           "path": "/reference/react/experimental_taintUniqueValue",
-          "version": "canary"
-        },
-        {
-          "title": "captureOwnerStack",
-          "path": "/reference/react/captureOwnerStack",
           "version": "canary"
         }
       ]

--- a/src/siteConfig.js
+++ b/src/siteConfig.js
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 exports.siteConfig = {
-  version: '19',
+  version: '19.1',
   // --------------------------------------
   // Translations should replace these lines:
   languageCode: 'en',


### PR DESCRIPTION
This is now stable with the release of 19.1