### PR TITLE
[errors] special case for 418

### DIFF
--- a/src/pages/errors/[errorCode].tsx
+++ b/src/pages/errors/[errorCode].tsx
@@ -36,7 +36,7 @@ export default function ErrorDecoderPage({
         }}
         routeTree={sidebarLearn as RouteItem}
         section="unknown">
-        <div className="whitespace-pre-line">{parsedContent}</div>
+        <div>{parsedContent}</div>
         {/* <MaxWidth>
           <P>
             We highly recommend using the development build locally when debugging


### PR DESCRIPTION
Currently, 418 has an issue where the diff is included in the message with `%s` at the end, but we don't supply the hydration diff for security and size constraints. We're also updating the error to include `text` or `HTML` depending on the mismatch, but old errors won't have args.

This PR adds special handling to fix both, and also fixes the padding on error pages.