### PR TITLE
Use stable React by default in Sandpacks

### DIFF
--- a/src/components/MDX/Sandpack/template.ts
+++ b/src/components/MDX/Sandpack/template.ts
@@ -28,8 +28,8 @@ root.render(
           eject: 'react-scripts eject',
         },
         dependencies: {
-          react: '19.0.0-rc-3edc000d-20240926',
-          'react-dom': '19.0.0-rc-3edc000d-20240926',
+          react: '^19.1.0',
+          'react-dom': '^19.1.0',
           'react-scripts': '^5.0.0',
         },
       },


### PR DESCRIPTION
Follow-up to https://github.com/reactjs/react.dev/pull/7322

Example: https://react-dev-git-sebbie-04-02-usestablereactby-f58b53-fbopensource.vercel.app/reference/react-dom/client/createRoot#rendering-an-app-fully-built-with-react