### PR TITLE
fix(reference): declare `subscribe` before passing it to the hook (issue #7707)

### DIFF
--- a/src/content/reference/react/useSyncExternalStore.md
+++ b/src/content/reference/react/useSyncExternalStore.md
@@ -405,14 +405,14 @@ If your store data is mutable, your `getSnapshot` function should return an immu
 
 This `subscribe` function is defined *inside* a component so it is different on every re-render:
 
-```js {4-7}
+```js {2-5}
 function ChatIndicator() {
-  const isOnline = useSyncExternalStore(subscribe, getSnapshot);
-  
   // 🚩 Always a different function, so React will resubscribe on every re-render
   function subscribe() {
     // ...
   }
+  
+  const isOnline = useSyncExternalStore(subscribe, getSnapshot);
 
   // ...
 }
@@ -420,28 +420,28 @@ function ChatIndicator() {
   
 React will resubscribe to your store if you pass a different `subscribe` function between re-renders. If this causes performance issues and you'd like to avoid resubscribing, move the `subscribe` function outside:
 
-```js {6-9}
-function ChatIndicator() {
-  const isOnline = useSyncExternalStore(subscribe, getSnapshot);
+```js {1-4}
+// ✅ Always the same function, so React won't need to resubscribe
+function subscribe() {
   // ...
 }
 
-// ✅ Always the same function, so React won't need to resubscribe
-function subscribe() {
+function ChatIndicator() {
+  const isOnline = useSyncExternalStore(subscribe, getSnapshot);
   // ...
 }
 ```
 
 Alternatively, wrap `subscribe` into [`useCallback`](/reference/react/useCallback) to only resubscribe when some argument changes:
 
-```js {4-8}
+```js {2-5}
 function ChatIndicator({ userId }) {
-  const isOnline = useSyncExternalStore(subscribe, getSnapshot);
-  
   // ✅ Same function as long as userId doesn't change
   const subscribe = useCallback(() => {
     // ...
   }, [userId]);
+  
+  const isOnline = useSyncExternalStore(subscribe, getSnapshot);
 
   // ...
 }


### PR DESCRIPTION
Fixes the typo in the docs, related issue: https://github.com/reactjs/react.dev/issues/7707

## Context from the issue

The following code will throw `Uncaught TypeError: subscribe is not a function`. 

https://github.com/reactjs/react.dev/blob/b5f5134b1f0359237894bbb814b6b1d75a730650/src/content/reference/react/useSyncExternalStore.md?plain=1#L438-L447

Documentation page: https://react.dev/reference/react/useSyncExternalStore#my-subscribe-function-gets-called-after-every-re-render

## Fix

Just declaring `subscribe` before passing it to the hook.

## Screenshot

In case you don't want to check out the auto-generated preview :)

![Screenshot of a section "My subscribe function gets called after every re-render" and related documentation of it](https://github.com/user-attachments/assets/5b05a8e2-3522-46e5-b866-5521eb380310)
