### PR TITLE
Add note about `useId` being allowed in non-async Server Components

### DIFF
--- a/src/content/reference/react/useId.md
+++ b/src/content/reference/react/useId.md
@@ -2,12 +2,6 @@
 title: useId
 ---
 
-<RSC>
-
-`useId` is allowed in non-async [Server Components](/reference/rsc/server-components).
-
-</RSC>
-
 <Intro>
 
 `useId` is a React Hook for generating unique IDs that can be passed to accessibility attributes.
@@ -51,6 +45,8 @@ function PasswordField() {
 * `useId` is a Hook, so you can only call it **at the top level of your component** or your own Hooks. You can't call it inside loops or conditions. If you need that, extract a new component and move the state into it.
 
 * `useId` **should not be used to generate keys** in a list. [Keys should be generated from your data.](/learn/rendering-lists#where-to-get-your-key)
+
+* `useId` currently cannot be used in [async Server Components](/reference/rsc/server-components#async-components-with-server-components).
 
 ---
 

--- a/src/content/reference/react/useId.md
+++ b/src/content/reference/react/useId.md
@@ -2,6 +2,12 @@
 title: useId
 ---
 
+<RSC>
+
+`useId` is allowed in non-async [Server Components](/reference/rsc/server-components).
+
+</RSC>
+
 <Intro>
 
 `useId` is a React Hook for generating unique IDs that can be passed to accessibility attributes.


### PR DESCRIPTION
I remember seeing this [PR](https://github.com/facebook/react/pull/31208) that mentions that `useId` is allowed in non-async Server Components. However, nowhere in the documentation mentions this fact. 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
