### PR TITLE
Fix(ProductTable): Use continue for correct product filtering

### DIFF
--- a/src/content/learn/thinking-in-react.md
+++ b/src/content/learn/thinking-in-react.md
@@ -353,10 +353,10 @@ function ProductTable({ products, filterText, inStockOnly }) {
         filterText.toLowerCase()
       ) === -1
     ) {
-      return;
+      continue;
     }
     if (inStockOnly && !product.stocked) {
-      return;
+      continue;
     }
     if (product.category !== lastCategory) {
       rows.push(


### PR DESCRIPTION
Fix(ProductTable): Use continue for correct product filtering

Replaces `return` with `continue` within the `forEach` loop's filter conditions. Using `continue` correctly skips the current iteration for products that don't match the filters, preventing them from being added to the `rows` array. 
Closes #7698 