### PR TITLE
Change the word 'Function' to 'Component'

### DIFF
--- a/src/content/reference/rsc/server-functions.md
+++ b/src/content/reference/rsc/server-functions.md
@@ -54,7 +54,7 @@ function EmptyNote () {
 }
 ```
 
-When React renders the `EmptyNote` Server Function, it will create a reference to the `createNoteAction` function, and pass that reference to the `Button` Client Component. When the button is clicked, React will send a request to the server to execute the `createNoteAction` function with the reference provided:
+When React renders the `EmptyNote` Server Component, it will create a reference to the `createNoteAction` function, and pass that reference to the `Button` Client Component. When the button is clicked, React will send a request to the server to execute the `createNoteAction` function with the reference provided:
 
 ```js {5}
 "use client";


### PR DESCRIPTION
Change the word `Function` to `Component` in the following sentence
```
When React renders the EmptyNote Server Function, it will create a reference to the createNoteAction
```
since `EmptyNote` is a React component.
