### PR TITLE
remove unnecessary import of React in template code

### DIFF
--- a/src/components/MDX/Sandpack/template.ts
+++ b/src/components/MDX/Sandpack/template.ts
@@ -1,7 +1,7 @@
 export const template = {
   '/src/index.js': {
     hidden: true,
-    code: `import React, { StrictMode } from "react";
+    code: `import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./styles.css";
 


### PR DESCRIPTION
Hello!!
In the document, the first line of code in `index.js `is` import { StrictMode } from 'react'`;, but,
In CodeSandbox, the first line of code was `import React, { StrictMode } from “react”`;, so I fixed it.
#7664