### PR TITLE
Add key and improve clarity in people.map() example

### DIFF
--- a/src/content/learn/rendering-lists.md
+++ b/src/content/learn/rendering-lists.md
@@ -72,8 +72,8 @@ const people = [
 ];
 
 export default function List() {
-  const listItems = people.map(person =>
-    <li>{person}</li>
+  const listItems = people.map((person, index) =>
+    <li key={index}>{person}</li>
   );
   return <ul>{listItems}</ul>;
 }


### PR DESCRIPTION
This PR improves the beginner-facing example in the "Rendering data from arrays" section.

Changes:
- Adds a `key` prop to each `<li>` element when mapping over the `people` array (to resolve console warning)

This change aligns the code with React best practices and helps new learners avoid common pitfalls when rendering lists.

