### PR TITLE
Fix missing Sunsetting CRA entry in sidebar

### DIFF
--- a/src/content/blog/index.md
+++ b/src/content/blog/index.md
@@ -4,7 +4,7 @@ title: React Blog
 
 <Intro>
 
-This blog is the official source for the updates from the React team. Anything important, including release notes or deprecation notices, will be posted here first. 
+This blog is the official source for the updates from the React team. Anything important, including release notes or deprecation notices, will be posted here first.
 
 You can also follow the [@react.dev](https://bsky.app/profile/react.dev) account on Bluesky, or [@reactjs](https://twitter.com/reactjs) account on Twitter, but you won’t miss anything essential if you only read this blog.
 
@@ -12,7 +12,7 @@ You can also follow the [@react.dev](https://bsky.app/profile/react.dev) account
 
 <div className="sm:-mx-5 flex flex-col gap-5 mt-12">
 
-<BlogCard title="Sunsetting Create React App" date="February 13, 2025" url="/blog/2025/02/14/sunsetting-create-react-app">
+<BlogCard title="Sunsetting Create React App" date="February 14, 2025" url="/blog/2025/02/14/sunsetting-create-react-app">
 
 Today, we’re deprecating Create React App for new apps, and encouraging existing apps to migrate to a framework, or to migrate to a build tool like Vite, Parcel, or RSBuild. We’re also providing docs for when a framework isn’t a good fit for your project, you want to build your own framework, or you just want to learn how React works by building a React app from scratch ...
 

--- a/src/sidebarBlog.json
+++ b/src/sidebarBlog.json
@@ -12,6 +12,13 @@
       "skipBreadcrumb": true,
       "routes": [
         {
+          "title": "Sunsetting Create React App",
+          "titleForHomepage": "Sunsetting Create React App",
+          "icon": "blog",
+          "date": "February 14, 2025",
+          "path": "/blog/2025/02/14/sunsetting-create-react-app"
+        },
+        {
           "title": "React 19",
           "titleForHomepage": "React 19",
           "icon": "blog",


### PR DESCRIPTION

This was missed in the last blog post. Also fixed the incorrect date.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/reactjs/react.dev/pull/7755).
* #7756
* __->__ #7755