### PR TITLE
Add React Summit US 2025 and React Advanced London 2025

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -50,6 +50,16 @@ October 31 - November 01, 2025. In-person in Goa, India (hybrid event) + Oct 15 
 
 [Website](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia) - [Youtube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w)
 
+### React Summit US 2025 {/*react-summit-us-2025*/}
+November 18 - 21, 2025. In-person in New York, USA + remote (hybrid event)
+
+[Website](https://reactsummit.us/) - [Twitter](https://x.com/reactsummit)
+
+### React Advanced London 2025 {/*react-advanced-london-2025*/}
+November 28 & December 1, 2025. In-person in London, UK + online (hybrid event)
+
+[Website](https://reactadvanced.com/) - [Twitter](https://x.com/reactadvanced)
+
 
 ## Past Conferences {/*past-conferences*/}
 


### PR DESCRIPTION
Add `React Summit US 2025` and `React Advanced London 2025` to the list of upcoming conferences (`conferences.md`).

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
