### PR TITLE
Add React Norway 2025 conference to community page

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -25,6 +25,12 @@ May 27 - 31, 2025. In-person in Athens, Greece
 
 [Website](https://athens.cityjsconf.org/) - [Twitter](https://x.com/cityjsconf) - [Bluesky](https://bsky.app/profile/cityjsconf.bsky.social)
 
+### React Norway 2025 {/*react-norway-2025*/}
+June 13, 2025. In-person in Oslo, Norway + remote (virtual event)
+
+[Website](https://reactnorway.com/) - [Twitter](https://x.com/ReactNorway)
+
+
 ### React Summit 2025 {/*react-summit-2025*/}
 June 13 - 17, 2025. In-person in Amsterdam, Netherlands + remote (hybrid event)
 

--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -30,7 +30,6 @@ June 13, 2025. In-person in Oslo, Norway + remote (virtual event)
 
 [Website](https://reactnorway.com/) - [Twitter](https://x.com/ReactNorway)
 
-
 ### React Summit 2025 {/*react-summit-2025*/}
 June 13 - 17, 2025. In-person in Amsterdam, Netherlands + remote (hybrid event)
 


### PR DESCRIPTION
- Included details about the event date, location, and links to the website and social media.

Image of the added conference
<img width="623" alt="image" src="https://github.com/user-attachments/assets/51dfe0f2-f0be-4006-adb5-ec573f2eac50" />
