### PR TITLE
Update "Deep Dive" in reusing-logic-with-custom-hooks.md with link and example of the use API

### DIFF
--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1419,10 +1419,31 @@ Similar to a [design system,](https://uxdesign.cc/everything-you-need-to-know-ab
 
 #### Will React provide any built-in solution for data fetching? {/*will-react-provide-any-built-in-solution-for-data-fetching*/}
 
+Today, with the [`use`](/reference/react/use#streaming-data-from-server-to-client) API, data can be streamed from the server to the client by passing a Promise as a prop from a [Server Component](/reference/rsc/server-components) and resolving it in a [Client Component](/reference/rsc/use-client):
+
+```js {3,6,13}
+"use client";
+
+import { use, Suspense } from "react";
+
+function Message({ messagePromise }) {
+  const messageContent = use(messagePromise);
+  return <p>Here is the message: {messageContent}</p>;
+}
+
+export function MessageContainer({ messagePromise }) {
+  return (
+    <Suspense fallback={<p>⌛Downloading message...</p>}>
+      <Message messagePromise={messagePromise} />
+    </Suspense>
+  );
+}
+```
+
 We're still working out the details, but we expect that in the future, you'll write data fetching like this:
 
 ```js {1,4,6}
-import { use } from 'react'; // Not available yet!
+import { use } from 'react';
 
 function ShippingForm({ country }) {
   const cities = use(fetch(`/api/cities?country=${country}`));

--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1419,7 +1419,7 @@ Similar to a [design system,](https://uxdesign.cc/everything-you-need-to-know-ab
 
 #### Will React provide any built-in solution for data fetching? {/*will-react-provide-any-built-in-solution-for-data-fetching*/}
 
-Today, with the [`use`](/reference/react/use#streaming-data-from-server-to-client) API, data can be streamed from the server to the client by passing a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) as a prop:
+Today, with the [`use`](/reference/react/use#streaming-data-from-server-to-client) API, data can be read in render by passing a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) to `use`:
 
 ```js {3,6,13}
 import { use, Suspense } from "react";

--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1421,7 +1421,7 @@ Similar to a [design system,](https://uxdesign.cc/everything-you-need-to-know-ab
 
 Today, with the [`use`](/reference/react/use#streaming-data-from-server-to-client) API, data can be read in render by passing a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) to `use`:
 
-```js {3,6,13}
+```js {1,4,11}
 import { use, Suspense } from "react";
 
 function Message({ messagePromise }) {

--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1419,11 +1419,9 @@ Similar to a [design system,](https://uxdesign.cc/everything-you-need-to-know-ab
 
 #### Will React provide any built-in solution for data fetching? {/*will-react-provide-any-built-in-solution-for-data-fetching*/}
 
-Today, with the [`use`](/reference/react/use#streaming-data-from-server-to-client) API, data can be streamed from the server to the client by passing a Promise as a prop from a [Server Component](/reference/rsc/server-components) and resolving it in a [Client Component](/reference/rsc/use-client):
+Today, with the [`use`](/reference/react/use#streaming-data-from-server-to-client) API, data can be streamed from the server to the client by passing a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) as a prop:
 
 ```js {3,6,13}
-"use client";
-
 import { use, Suspense } from "react";
 
 function Message({ messagePromise }) {


### PR DESCRIPTION
I noticed that the "Deep Dive" in `reusing-logic-with-custom-hooks.md` about whether React will provide a built-in data fetching solution in the future contained information about a non-existent `use` API, which now exists. I updated the "Deep Dive" with a link and example of `use` and removed the comment stating it's not yet available.
