### PR TITLE
Update Next.js deployment notes

### DIFF
--- a/src/content/learn/creating-a-react-app.md
+++ b/src/content/learn/creating-a-react-app.md
@@ -32,7 +32,7 @@ This allows you to start with a client-only app, and if your needs change later,
 npx create-next-app@latest
 </TerminalBlock>
 
-Next.js is maintained by [Vercel](https://vercel.com/). You can [deploy a Next.js app](https://nextjs.org/docs/app/building-your-application/deploying) to any Node.js or serverless hosting, or to your own server. Next.js also supports [static export](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) which doesn't require a server. Vercel additionally provides opt-in paid cloud services.
+Next.js is maintained by [Vercel](https://vercel.com/). You can [deploy a Next.js app](https://nextjs.org/docs/app/building-your-application/deploying) to any hosting provider that supports Node.js or Docker containers, or to your own server. Next.js also supports [static export](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) which doesn't require a server.
 
 ### React Router (v7) {/*react-router-v7*/}
 


### PR DESCRIPTION
This PR updates the notes about deployment options on the [Next.js (App Router)](https://react.dev/learn/creating-a-react-app#nextjs-app-router) section with the following changes:

1. Replaces the mention of "serverless hosting" with "Docker containers" to reflect the three self-hosting options listed on https://nextjs.org/docs/app/guides/self-hosting. It is currently not true that you can deploy Next.js to any serverless hosting provider, as confirmed by the [Deployment Adapters API RFC](https://github.com/vercel/next.js/discussions/77740). This issue is described in more detail [here](https://eduardoboucas.com/posts/2025-03-25-you-should-know-this-before-choosing-nextjs/#fact-2-no-official-serverless-support).

2. Removes the reference to Vercel paid cloud services. There are other cloud providers also offering different paid services that apply to Next.js sites, so I don't think there's a reason to single out Vercel's in this case.