### PR TITLE
docs: rename unstableViewTransition to unstable_ViewTransition

### DIFF
--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -23,7 +23,7 @@ Experimental versions of React may contain bugs. Don't use them in production.
 
 
 ```js
-import {unstableViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition as ViewTransition} from 'react';
 
 <ViewTransition>
   <div>...</div>


### PR DESCRIPTION
Renaming `unstableViewTransition` to `unstable_ViewTransition` on the `<ViewTransition>` [page](https://react.dev/reference/react/ViewTransition) to match the correct name exported in [react experimental code](https://github.com/facebook/react/blob/693803a9bb3073b2ff5c99f8ae804f855db9aae2/packages/react/index.experimental.js#L35).