### PR TITLE
fix: set wrap-content to true for better code readability

### DIFF
--- a/src/components/MDX/Sandpack/CustomPreset.tsx
+++ b/src/components/MDX/Sandpack/CustomPreset.tsx
@@ -125,6 +125,7 @@ const Editor = memo(function Editor({
       showTabs={false}
       showRunButton={false}
       extensions={lintExtensions}
+      wrapContent={true}
     />
   );
 });

--- a/src/styles/sandpack.css
+++ b/src/styles/sandpack.css
@@ -216,7 +216,6 @@ html.dark .sp-wrapper {
 
 .sandpack--playground .sp-code-editor .cm-line {
   padding: 0 var(--sp-space-3);
-  width: max-content;
 }
 
 .sandpack--playground .sp-code-editor .cm-lineNumbers {


### PR DESCRIPTION
I have added wrap content to improve the code readability in the playgrounds

https://github.com/user-attachments/assets/eee1cdd1-99eb-48a5-8bf9-7873bc0696e3

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
