### PR TITLE
Fix wrong documentation for effect events

### DIFF
--- a/src/content/learn/separating-events-from-effects.md
+++ b/src/content/learn/separating-events-from-effects.md
@@ -439,7 +439,7 @@ function ChatRoom({ roomId, theme }) {
   // ...
 ```
 
-This solves the problem. Note that you had to *remove* `onConnected` from the list of your Effect's dependencies. **Effect Events are not reactive and must be omitted from dependencies.**
+This solves the problem. Note that you had to *remove* `theme` from the list of your Effect's dependencies, and you also don't need to *add* `onConnected` to it . **Effect Events are not reactive and must be omitted from dependencies.**
 
 Verify that the new behavior works as you would expect:
 


### PR DESCRIPTION
`onConnected` was never listed as a dependency in the instrcutive code before this line, but this line mentions that we had to *remove* it. So it does not make full sense. The only dependency that was added was `theme` and we did remove that.

So I changed the documenation text to correct it. 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
