### PR TITLE
Fix order of .on() and .connect() in chat example

### DIFF
--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -997,10 +997,10 @@ export function useChatRoom({ serverUrl, roomId, onReceiveMessage }) {
       roomId: roomId
     };
     const connection = createConnection(options);
-    connection.connect();
     connection.on('message', (msg) => {
       onMessage(msg);
     });
+    connection.connect();
     return () => connection.disconnect();
   }, [roomId, serverUrl]);
 }


### PR DESCRIPTION
### Summary

This PR fixes the order of method calls in the `useChatRoom` example. Previously, `connection.connect()` was called before `connection.on('message', ...)`, which caused a subtle issue: the message handler (`messageCallback`) might be `null` when the first message interval ticks.

### What Changed

- Moved `connection.on('message', ...)` before `connection.connect()` in the example code.
