### PR TITLE
fix: prevent layout breaking on mobile

### DIFF
--- a/src/components/Layout/TopNav/TopNav.tsx
+++ b/src/components/Layout/TopNav/TopNav.tsx
@@ -242,7 +242,7 @@ export default function TopNav({
         className={cn(
           isMenuOpen
             ? 'h-screen sticky top-0 lg:bottom-0 lg:h-screen flex flex-col shadow-nav dark:shadow-nav-dark z-20'
-            : 'z-40 sticky top-0'
+            : 'z-40 fixed top-0 left-0 right-0'
         )}>
         <nav
           className={cn(

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -393,6 +393,8 @@
   html {
     color-scheme: light;
 
+    overflow-x: hidden;
+
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-tap-highlight-color: transparent;
   }


### PR DESCRIPTION
Applied `overflow-x: hidden` to the html tag to resolve an issue
where the layout would compress on narrow screens.

### before
![image](https://github.com/user-attachments/assets/61be0f79-2357-4f7b-886c-e6e0113d78ca)

### after
![image](https://github.com/user-attachments/assets/0abda646-3ca7-4b0d-80d4-8f0c0650fe26)
