### PR TITLE
fix: correct broken WAI-ARIA modal dialog link in createPortal reference

### DIFF
--- a/src/content/reference/react-dom/createPortal.md
+++ b/src/content/reference/react-dom/createPortal.md
@@ -240,7 +240,7 @@ export default function ModalContent({ onClose }) {
 
 It's important to make sure that your app is accessible when using portals. For instance, you may need to manage keyboard focus so that the user can move the focus in and out of the portal in a natural way.
 
-Follow the [WAI-ARIA Modal Authoring Practices](https://www.w3.org/WAI/ARIA/apg/#dialog_modal) when creating modals. If you use a community package, ensure that it is accessible and follows these guidelines.
+Follow the [WAI-ARIA Modal Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal) when creating modals. If you use a community package, ensure that it is accessible and follows these guidelines.
 
 </Pitfall>
 


### PR DESCRIPTION
While translating the createPortal reference page to Russian, I tested the external WAI-ARIA link and noticed it led to the general APG homepage (#dialog_modal anchor is missing or invalid). I’ve replaced it with the correct and direct link to the Modal Dialog pattern page: `https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal`

This ensures users can access the specific modal accessibility guidelines without confusion.