### PR TITLE
Remove `forwardRef` reference from API listing

### DIFF
--- a/src/content/reference/react/apis.md
+++ b/src/content/reference/react/apis.md
@@ -11,7 +11,6 @@ In addition to [Hooks](/reference/react) and [Components](/reference/react/compo
 ---
 
 * [`createContext`](/reference/react/createContext) lets you define and provide context to the child components. Used with [`useContext`.](/reference/react/useContext)
-* [`forwardRef`](/reference/react/forwardRef) lets your component expose a DOM node as a ref to the parent. Used with [`useRef`.](/reference/react/useRef)
 * [`lazy`](/reference/react/lazy) lets you defer loading a component's code until it's rendered for the first time.
 * [`memo`](/reference/react/memo) lets your component skip re-renders with same props. Used with [`useMemo`](/reference/react/useMemo) and [`useCallback`.](/reference/react/useCallback)
 * [`startTransition`](/reference/react/startTransition) lets you mark a state update as non-urgent. Similar to [`useTransition`.](/reference/react/useTransition)


### PR DESCRIPTION
This API is now under "Legacy APIs" and should probably no longer be listed as a "modern API".
