### PR TITLE
docs: remove outdated caveat about useId in async Server Components

### DIFF
--- a/src/content/reference/react/useId.md
+++ b/src/content/reference/react/useId.md
@@ -46,8 +46,6 @@ function PasswordField() {
 
 * `useId` **should not be used to generate keys** in a list. [Keys should be generated from your data.](/learn/rendering-lists#where-to-get-your-key)
 
-* `useId` currently cannot be used in [async Server Components](/reference/rsc/server-components#async-components-with-server-components).
-
 ---
 
 ## Usage {/*usage*/}


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The previous documentation stated that useId cannot be used in Server Components that are async functions.

However, as of React 19.1.0, useId now works correctly in async Server Components as well.

I have tested this behavior and confirmed that the caveat is no longer necessary.

This PR removes the outdated note to reflect the current behavior.

> Tested with:
> - next: 15.3.5
> - react: 19.1.0
> - react-dom: 19.1.0
>
> ```jsx
> // app/page.jsx
> import { useId } from "react";
>
> export default async function Page() {
> const id = useId();
> return (
> <div>
> <label htmlFor={id}>Name:</label>
> <input id={id} type="text" />
> <p>Generated id: <code>{id}</code></p>
> </div>
> );
> }
> ```
>
> This async Server Component renders without any error and the generated id works as expected.
