### PR TITLE
Docs for partial-prerendering APIs

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/content/reference/react-dom/server/index.md
+++ b/src/content/reference/react-dom/server/index.md
@@ -10,19 +10,20 @@ The `react-dom/server` APIs let you server-side render React components to HTML.
 
 ---
 
-## Server APIs for Node.js Streams {/*server-apis-for-nodejs-streams*/}
-
-These methods are only available in the environments with [Node.js Streams:](https://nodejs.org/api/stream.html)
-
-* [`renderToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) renders a React tree to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
-
----
-
 ## Server APIs for Web Streams {/*server-apis-for-web-streams*/}
 
 These methods are only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), which includes browsers, Deno, and some modern edge runtimes:
 
 * [`renderToReadableStream`](/reference/react-dom/server/renderToReadableStream) renders a React tree to a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+* [`resume`](/reference/react-dom/server/renderToPipeableStream) resumes [`prerender`](/reference/react-dom/static/prerender) to a [Readable Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+---
+
+## Server APIs for Node.js Streams {/*server-apis-for-nodejs-streams*/}
+
+These methods are only available in the environments with [Node.js Streams:](https://nodejs.org/api/stream.html)
+
+* [`renderToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) renders a React tree to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
+* [`resumeToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) resumes [`prerenderToNodeStream`](/reference/react-dom/static/prerenderToNodeStream) to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
 
 ---
 

--- a/src/content/reference/react-dom/server/index.md
+++ b/src/content/reference/react-dom/server/index.md
@@ -16,6 +16,8 @@ These methods are only available in the environments with [Web Streams](https://
 
 * [`renderToReadableStream`](/reference/react-dom/server/renderToReadableStream) renders a React tree to a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
 * [`resume`](/reference/react-dom/server/renderToPipeableStream) resumes [`prerender`](/reference/react-dom/static/prerender) to a [Readable Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+
+Node.js also includes these methods for compatibility, but they are not recommended due to worse performance. Use the [dedicated Node.js APIs](#server-apis-for-nodejs-streams) instead.
 ---
 
 ## Server APIs for Node.js Streams {/*server-apis-for-nodejs-streams*/}

--- a/src/content/reference/react-dom/server/index.md
+++ b/src/content/reference/react-dom/server/index.md
@@ -17,7 +17,12 @@ These methods are only available in the environments with [Web Streams](https://
 * [`renderToReadableStream`](/reference/react-dom/server/renderToReadableStream) renders a React tree to a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
 * [`resume`](/reference/react-dom/server/renderToPipeableStream) resumes [`prerender`](/reference/react-dom/static/prerender) to a [Readable Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
+
+<Note>
+
 Node.js also includes these methods for compatibility, but they are not recommended due to worse performance. Use the [dedicated Node.js APIs](#server-apis-for-nodejs-streams) instead.
+
+</Note>
 ---
 
 ## Server APIs for Node.js Streams {/*server-apis-for-nodejs-streams*/}

--- a/src/content/reference/react-dom/server/resume.md
+++ b/src/content/reference/react-dom/server/resume.md
@@ -1,0 +1,240 @@
+---
+title: resume
+canary: true
+---
+
+<Intro>
+
+`resume` streams a pre-rendered React tree to a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+
+```js
+const stream = await resume(reactNode, postponedState, options?)
+```
+
+</Intro>
+
+<InlineToc />
+
+<Note>
+
+This API depends on [Web Streams.](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) For Node.js, use [`resumeToNodeStream`](/reference/react-dom/server/renderToPipeableStream) instead.
+
+</Note>
+
+---
+
+## Reference {/*reference*/}
+
+### `resume(node, postponed, options?)` {/*resume*/}
+
+Call `resume` to resume rendering a pre-rendered React tree as HTML into a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+
+```js
+import { resume } from 'react-dom/server';
+import {getPostponedState} from 'storage';
+
+async function handler(request) {
+  const postponed = await getPostponedState(request);
+  const stream = await resume(<App />, postponed, {
+    bootstrapScripts: ['/main.js']
+  });
+  return new Response(stream, {
+    headers: { 'content-type': 'text/html' },
+  });
+}
+```
+
+TODO: when do you call hydrateRoot? In the shell or when you resume?
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+* `reactNode`: The React node you called `prerender` with. For example, a JSX element like `<App />`. It is expected to represent the entire document, so the `App` component should render the `<html>` tag.
+* `postponedState`: The opaque `postpone` object returned from `prerender`, loaded from wherever you stored it (e.g. redis, a file, or S3).
+* **optional** `options`: An object with streaming options.
+  * **optional** `nonce`: A [`nonce`](http://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nonce) string to allow scripts for [`script-src` Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
+  * **optional** `signal`: An [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that lets you [abort server rendering](#aborting-server-rendering) and render the rest on the client.
+  * **optional** `onError`: A callback that fires whenever there is a server error, whether [recoverable](#recovering-from-errors-outside-the-shell) or [not.](#recovering-from-errors-inside-the-shell) By default, this only calls `console.error`. If you override it to [log crash reports,](#logging-crashes-on-the-server) make sure that you still call `console.error`.
+
+
+#### Returns {/*returns*/}
+
+`resume` returns a Promise:
+
+- If `prerender` successfully produced a [shell](#specifying-what-goes-into-the-shell) is successful, that Promise will resolve to a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) whether replaying the shell errors or not.
+- If `prerender` failed to produce a [shell](#specifying-what-goes-into-the-shell), and `resume` errors, the Promise will be rejected. TODO: Example?
+
+The returned stream has an additional property:
+
+* `allReady`: A Promise that resolves when all rendering is complete. You can `await stream.allReady` before returning a response [for crawlers and static generation.](#waiting-for-all-content-to-load-for-crawlers-and-static-generation) If you do that, you won't get any progressive loading. The stream will contain the final HTML.
+
+#### Caveats {/*caveats*/}
+- `resume` does not accept options for `bootstrapScripts`, `bootstrapScriptContent`, or `bootstrapModules`. Instead, you need to pass these options to the `prerender` call that generates the `postponedState`. These may be injected either during pre-render or resume.
+- `resume` does not accept `identifierPrefix` since the prefix needs to be the same in both `prerender` and `resume`.
+- Since `nonce` cannot be provided to prerender, you should only provide `nonce` to `resume` if you're not providing scripts to prerender.
+- `resume` re-renders from the root until it finds a component that was not fully pre-rendered, and skips fully pre-rendered components.
+---
+
+## Usage {/*usage*/}
+
+### Resuming a prerender to a Readable Web Stream {/*resuming-a-prerender-to-a-readable-web-stream*/}
+
+TODO
+
+---
+
+### Logging crashes on the server {/*logging-crashes-on-the-server*/}
+
+By default, all errors on the server are logged to console. You can override this behavior to log crash reports:
+
+```js {9-10}
+import { resume } from 'react-dom/server';
+import { getPostponedState } from 'storage';
+import { logServerCrashReport } from 'logging';
+
+async function handler(request) {
+  const postponed = await getPostponedState(request);
+  const stream = await resume(<App />, postponed, {
+    onError(error) {
+      console.error(error);
+      logServerCrashReport(error);
+    }
+  });
+  return new Response(stream, {
+    headers: { 'content-type': 'text/html' },
+  });
+}
+```
+
+If you provide a custom `onError` implementation, don't forget to also log errors to the console like above.
+
+---
+
+### Recovering from errors replaying the shell {/*recovering-from-errors-inside-the-shell*/}
+
+TODO: this is for when the shell completed.
+
+In this example, prerender successfully rendered a shell containing `ProfileLayout`, `ProfileCover`, and `PostsGlimmer`:
+
+```js {3-5,7-8}
+function ProfilePage() {
+  return (
+    <ProfileLayout>
+      <ProfileCover />
+      <Suspense fallback={<PostsGlimmer />}>
+        <Posts />
+      </Suspense>
+    </ProfileLayout>
+  );
+}
+```
+
+If an error occurs while replaying those components, React won't have any meaningful HTML to send to the client. TODO: how to recover from this, since the promise is resolved. I think it will just encode an error in the stream and trigger an error boundary?
+
+```js {2,13-18}
+// TODO
+```
+
+If there is an error while replaying the shell, it will be logged to `onError`.
+
+### Recovering from errors re-creating the shell {/*recovering-from-errors-re-creating-the-shell*/}
+
+TODO: this is for when the shell errors, and re-creating the shell fails.
+
+---
+
+### Recovering from errors outside the shell {/*recovering-from-errors-outside-the-shell*/}
+
+TODO: confirm this section is correct.
+
+In this example, the `<Posts />` component is wrapped in `<Suspense>` so it is *not* a part of the shell:
+
+```js {6}
+function ProfilePage() {
+  return (
+    <ProfileLayout>
+      <ProfileCover />
+      <Suspense fallback={<PostsGlimmer />}>
+        <Posts />
+      </Suspense>
+    </ProfileLayout>
+  );
+}
+```
+
+If an error happens in the `Posts` component or somewhere inside it, React will [try to recover from it:](/reference/react/Suspense#providing-a-fallback-for-server-errors-and-client-only-content)
+
+1. It will emit the loading fallback for the closest `<Suspense>` boundary (`PostsGlimmer`) into the HTML.
+2. It will "give up" on trying to render the `Posts` content on the server anymore.
+3. When the JavaScript code loads on the client, React will *retry* rendering `Posts` on the client.
+
+If retrying rendering `Posts` on the client *also* fails, React will throw the error on the client. As with all the errors thrown during rendering, the [closest parent error boundary](/reference/react/Component#static-getderivedstatefromerror) determines how to present the error to the user. In practice, this means that the user will see a loading indicator until it is certain that the error is not recoverable.
+
+If retrying rendering `Posts` on the client succeeds, the loading fallback from the server will be replaced with the client rendering output. The user will not know that there was a server error. However, the server `onError` callback and the client [`onRecoverableError`](/reference/react-dom/client/hydrateRoot#hydrateroot) callbacks will fire so that you can get notified about the error.
+
+---
+
+### Setting the status code {/*setting-the-status-code*/}
+
+TODO: you can't set the status code in resume, unless you're calling prerender in the same request. If so, set the status code between `prerender` and `resume`.
+
+---
+
+### Handling different errors in different ways {/*handling-different-errors-in-different-ways*/}
+
+TODO: update this example.
+
+You can [create your own `Error` subclasses](https://javascript.info/custom-errors) and use the [`instanceof`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) operator to check which error is thrown. For example, you can define a custom `NotFoundError` and throw it from your component. Then you can save the error in `onError` and do something different before returning the response depending on the error type:
+
+```js {2-3,5-15,22,28,33}
+async function handler(request) {
+  let didError = false;
+  let caughtError = null;
+
+  function getStatusCode() {
+    if (didError) {
+      if (caughtError instanceof NotFoundError) {
+        return 404;
+      } else {
+        return 500;
+      }
+    } else {
+      return 200;
+    }
+  }
+
+  try {
+    const stream = await renderToReadableStream(<App />, {
+      bootstrapScripts: ['/main.js'],
+      onError(error) {
+        didError = true;
+        caughtError = error;
+        console.error(error);
+        logServerCrashReport(error);
+      }
+    });
+    return new Response(stream, {
+      status: getStatusCode(),
+      headers: { 'content-type': 'text/html' },
+    });
+  } catch (error) {
+    return new Response('<h1>Something went wrong</h1>', {
+      status: getStatusCode(),
+      headers: { 'content-type': 'text/html' },
+    });
+  }
+}
+```
+
+---
+
+### Waiting for all content to load for crawlers and static generation {/*waiting-for-all-content-to-load-for-crawlers-and-static-generation*/}
+
+TODO: this doesn't make sense for `resume` right?
+
+---
+
+### Aborting server rendering {/*aborting-server-rendering*/}
+
+TODO

--- a/src/content/reference/react-dom/server/resumeToPipeableStream.md
+++ b/src/content/reference/react-dom/server/resumeToPipeableStream.md
@@ -1,0 +1,245 @@
+---
+title: resumeToPipeableStream
+canary: true
+---
+
+<Intro>
+
+`resume` streams a pre-rendered React tree  to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
+
+```js
+const {pipe, abort} = await resumeToPipeableStream(reactNode, postponedState, options?)
+```
+
+</Intro>
+
+<InlineToc />
+
+<Note>
+
+This API is specific to Node.js. Environments with [Web Streams,](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) like Deno and modern edge runtimes, should use [`resume`](/reference/react-dom/server/renderToReadableStream) instead.
+
+</Note>
+
+---
+
+## Reference {/*reference*/}
+
+### `resumeToPipeableStream(node, postponed, options?)` {/*resume-to-pipeable-stream*/}
+
+Call `resume` to resume rendering a pre-rendered React tree as HTML into a [Node.js Stream.](https://nodejs.org/api/stream.html#writable-streams)
+
+```js
+import { resume } from 'react-dom/server';
+import {getPostponedState} from 'storage';
+
+async function handler(request) {
+  const postponed = await getPostponedState(request);
+  const {pipe} = await resumeToPipeableStream(<App />, postponed, {
+    onShellReady: () => {
+      pipe(response);
+    }
+  });
+}
+```
+
+TODO: when do you call hydrateRoot? In the shell or when you resume?
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+* `reactNode`: The React node you called `prerender` with. For example, a JSX element like `<App />`. It is expected to represent the entire document, so the `App` component should render the `<html>` tag.
+* `postponedState`: The opaque `postpone` object returned from `prerender`, loaded from wherever you stored it (e.g. redis, a file, or S3).
+* **optional** `options`: An object with streaming options.
+  * **optional** `nonce`: A [`nonce`](http://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nonce) string to allow scripts for [`script-src` Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
+  * **optional** `onAllReady`: A callback that fires when all rendering is complete. You can use this instead of `onShellReady` [for crawlers and static generation.](#waiting-for-all-content-to-load-for-crawlers-and-static-generation) If you start streaming here, you won't get any progressive loading. The stream will contain the final HTML.
+  * **optional** `onError`: A callback that fires whenever there is a server error, whether [recoverable](#recovering-from-errors-outside-the-shell) or [not.](#recovering-from-errors-inside-the-shell) By default, this only calls `console.error`. If you override it to [log crash reports,](#logging-crashes-on-the-server) make sure that you still call `console.error`.
+  * **optional** `onShellReady`: A callback that fires right after the [initial shell](#specifying-what-goes-into-the-shell) has been replayed. You can call `pipe` here to start streaming. React will [stream the additional content](#streaming-more-content-as-it-loads) after the shell along with the inline `<script>` tags that replace the HTML loading fallbacks with the content.
+  * **optional** `onShellError`: A callback that fires if there was an error rendering the initial shell.  It receives the error as an argument. No bytes were emitted from the stream yet, and neither `onShellReady` nor `onAllReady` will get called, so you can [output a fallback HTML shell.](#recovering-from-errors-inside-the-shell)
+
+TODO: what's the behavior of `onShellError`? Is this only for when the shell replay errors?
+
+
+#### Returns {/*returns*/}
+
+`resume` returns a Promise:
+
+returns an object with two methods:
+
+* `pipe` outputs the HTML into the provided [Writable Node.js Stream.](https://nodejs.org/api/stream.html#writable-streams) Call `pipe` in `onShellReady` if you want to enable streaming, or in `onAllReady` for crawlers and static generation.
+* `abort` lets you [abort server rendering](#aborting-server-rendering) and render the rest on the client.
+
+
+#### Caveats {/*caveats*/}
+- `resume` does not accept options for `bootstrapScripts`, `bootstrapScriptContent`, or `bootstrapModules`. Instead, you need to pass these options to the `prerender` call that generates the `postponedState`. These may be injected either during pre-render or resume.
+- `resume` does not accept `identifierPrefix`, `namespaceURI`, or `progressiveChunkSize` since these need to be the same in both `prerender` and `resume`.
+- Since `nonce` cannot be provided to prerender, you should only provide `nonce` to `resume` if you're not providing scripts to prerender.
+- `resume` re-renders from the root until it finds a component that was not fully pre-rendered, and skips fully pre-rendered components.
+- TODO: no `namespaceURI`
+- TODO: can't set status codes.
+
+---
+
+## Usage {/*usage*/}
+
+### Resuming a prerender to a Node.js Stream {/*resuming-a-prerender-to-a-node-js-stream*/}
+
+TODO
+
+---
+
+### Logging crashes on the server {/*logging-crashes-on-the-server*/}
+
+By default, all errors on the server are logged to console. You can override this behavior to log crash reports:
+
+```js {9-10}
+import { resume } from 'react-dom/server';
+import { getPostponedState } from 'storage';
+import { logServerCrashReport } from 'logging';
+
+async function handler(request, response) {
+  const postponed = await getPostponedState(request);
+  const {pipe} = await resumeToPipeableStream(<App />, postponed, {
+    onShellReady: () => {
+      pipe(response);
+    },
+    onError(error) {
+      console.error(error);
+      logServerCrashReport(error);
+    }
+  });
+}
+```
+
+If you provide a custom `onError` implementation, don't forget to also log errors to the console like above.
+
+---
+
+### Recovering from errors replaying the shell {/*recovering-from-errors-inside-the-shell*/}
+
+TODO: this is for when the shell completed.
+
+In this example, prerender successfully rendered a shell containing `ProfileLayout`, `ProfileCover`, and `PostsGlimmer`:
+
+```js {3-5,7-8}
+function ProfilePage() {
+  return (
+    <ProfileLayout>
+      <ProfileCover />
+      <Suspense fallback={<PostsGlimmer />}>
+        <Posts />
+      </Suspense>
+    </ProfileLayout>
+  );
+}
+```
+
+If an error occurs while replaying those components, React won't have any meaningful HTML to send to the client. TODO: how to recover from this, since the promise is resolved. I think it will just encode an error in the stream and trigger an error boundary?
+
+```js {2,13-18}
+// TODO
+```
+
+If there is an error while replaying the shell, it will be logged to `onError`.
+
+### Recovering from errors re-creating the shell {/*recovering-from-errors-re-creating-the-shell*/}
+
+TODO: this is for when the shell errors, and re-creating the shell fails.
+
+---
+
+### Recovering from errors outside the shell {/*recovering-from-errors-outside-the-shell*/}
+
+TODO: confirm this section is correct.
+
+In this example, the `<Posts />` component is wrapped in `<Suspense>` so it is *not* a part of the shell:
+
+```js {6}
+function ProfilePage() {
+  return (
+    <ProfileLayout>
+      <ProfileCover />
+      <Suspense fallback={<PostsGlimmer />}>
+        <Posts />
+      </Suspense>
+    </ProfileLayout>
+  );
+}
+```
+
+If an error happens in the `Posts` component or somewhere inside it, React will [try to recover from it:](/reference/react/Suspense#providing-a-fallback-for-server-errors-and-client-only-content)
+
+1. It will emit the loading fallback for the closest `<Suspense>` boundary (`PostsGlimmer`) into the HTML.
+2. It will "give up" on trying to render the `Posts` content on the server anymore.
+3. When the JavaScript code loads on the client, React will *retry* rendering `Posts` on the client.
+
+If retrying rendering `Posts` on the client *also* fails, React will throw the error on the client. As with all the errors thrown during rendering, the [closest parent error boundary](/reference/react/Component#static-getderivedstatefromerror) determines how to present the error to the user. In practice, this means that the user will see a loading indicator until it is certain that the error is not recoverable.
+
+If retrying rendering `Posts` on the client succeeds, the loading fallback from the server will be replaced with the client rendering output. The user will not know that there was a server error. However, the server `onError` callback and the client [`onRecoverableError`](/reference/react-dom/client/hydrateRoot#hydrateroot) callbacks will fire so that you can get notified about the error.
+
+---
+
+### Setting the status code {/*setting-the-status-code*/}
+
+TODO: you can't set the status code in resume, unless you're calling prerender in the same request. If so, set the status code between `prerender` and `resume`.
+
+---
+
+### Handling different errors in different ways {/*handling-different-errors-in-different-ways*/}
+
+TODO: update this example.
+
+You can [create your own `Error` subclasses](https://javascript.info/custom-errors) and use the [`instanceof`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) operator to check which error is thrown. For example, you can define a custom `NotFoundError` and throw it from your component. Then you can save the error in `onError` and do something different before returning the response depending on the error type:
+
+```js {2-3,5-15,22,28,33}
+async function handler(request) {
+  let didError = false;
+  let caughtError = null;
+
+  function getStatusCode() {
+    if (didError) {
+      if (caughtError instanceof NotFoundError) {
+        return 404;
+      } else {
+        return 500;
+      }
+    } else {
+      return 200;
+    }
+  }
+
+  try {
+    const stream = await renderToReadableStream(<App />, {
+      bootstrapScripts: ['/main.js'],
+      onError(error) {
+        didError = true;
+        caughtError = error;
+        console.error(error);
+        logServerCrashReport(error);
+      }
+    });
+    return new Response(stream, {
+      status: getStatusCode(),
+      headers: { 'content-type': 'text/html' },
+    });
+  } catch (error) {
+    return new Response('<h1>Something went wrong</h1>', {
+      status: getStatusCode(),
+      headers: { 'content-type': 'text/html' },
+    });
+  }
+}
+```
+
+---
+
+### Waiting for all content to load for crawlers and static generation {/*waiting-for-all-content-to-load-for-crawlers-and-static-generation*/}
+
+TODO: this doesn't make sense for `resume` right?
+
+---
+
+### Aborting server rendering {/*aborting-server-rendering*/}
+
+TODO

--- a/src/content/reference/react-dom/server/resumeToPipeableStream.md
+++ b/src/content/reference/react-dom/server/resumeToPipeableStream.md
@@ -3,9 +3,17 @@ title: resumeToPipeableStream
 canary: true
 ---
 
+<Canary>
+
+**The `resumeToPipeableStream` API is currently only available in React’s Canary and Experimental channels.** 
+
+[Learn more about React’s release channels here.](/community/versioning-policy#all-release-channels)
+
+</Canary>
+
 <Intro>
 
-`resume` streams a pre-rendered React tree  to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
+`resumeToPipeableStream` streams a pre-rendered React tree  to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
 
 ```js
 const {pipe, abort} = await resumeToPipeableStream(reactNode, postponedState, options?)
@@ -31,215 +39,49 @@ Call `resume` to resume rendering a pre-rendered React tree as HTML into a [Node
 
 ```js
 import { resume } from 'react-dom/server';
-import {getPostponedState} from 'storage';
+import {getPostponedState} from './storage';
 
-async function handler(request) {
+async function handler(request, response) {
   const postponed = await getPostponedState(request);
-  const {pipe} = await resumeToPipeableStream(<App />, postponed, {
+  const {pipe} = resumeToPipeableStream(<App />, postponed, {
     onShellReady: () => {
       pipe(response);
     }
   });
 }
 ```
-
-TODO: when do you call hydrateRoot? In the shell or when you resume?
 
 [See more examples below.](#usage)
 
 #### Parameters {/*parameters*/}
 
 * `reactNode`: The React node you called `prerender` with. For example, a JSX element like `<App />`. It is expected to represent the entire document, so the `App` component should render the `<html>` tag.
-* `postponedState`: The opaque `postpone` object returned from `prerender`, loaded from wherever you stored it (e.g. redis, a file, or S3).
+* `postponedState`: The opaque `postpone` object returned from a [prerender API](/reference/react-dom/static/index), loaded from wherever you stored it (e.g. redis, a file, or S3).
 * **optional** `options`: An object with streaming options.
   * **optional** `nonce`: A [`nonce`](http://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nonce) string to allow scripts for [`script-src` Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
-  * **optional** `onAllReady`: A callback that fires when all rendering is complete. You can use this instead of `onShellReady` [for crawlers and static generation.](#waiting-for-all-content-to-load-for-crawlers-and-static-generation) If you start streaming here, you won't get any progressive loading. The stream will contain the final HTML.
-  * **optional** `onError`: A callback that fires whenever there is a server error, whether [recoverable](#recovering-from-errors-outside-the-shell) or [not.](#recovering-from-errors-inside-the-shell) By default, this only calls `console.error`. If you override it to [log crash reports,](#logging-crashes-on-the-server) make sure that you still call `console.error`.
-  * **optional** `onShellReady`: A callback that fires right after the [initial shell](#specifying-what-goes-into-the-shell) has been replayed. You can call `pipe` here to start streaming. React will [stream the additional content](#streaming-more-content-as-it-loads) after the shell along with the inline `<script>` tags that replace the HTML loading fallbacks with the content.
-  * **optional** `onShellError`: A callback that fires if there was an error rendering the initial shell.  It receives the error as an argument. No bytes were emitted from the stream yet, and neither `onShellReady` nor `onAllReady` will get called, so you can [output a fallback HTML shell.](#recovering-from-errors-inside-the-shell)
-
-TODO: what's the behavior of `onShellError`? Is this only for when the shell replay errors?
+  * **optional** `signal`: An [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that lets you [abort server rendering](#aborting-server-rendering) and render the rest on the client.
+  * **optional** `onError`: A callback that fires whenever there is a server error, whether [recoverable](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-outside-the-shell) or [not.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell) By default, this only calls `console.error`. If you override it to [log crash reports,](/reference/react-dom/server/renderToReadableStream#logging-crashes-on-the-server) make sure that you still call `console.error`.
+  * **optional** `onShellReady`: A callback that fires right after the [shell](#specifying-what-goes-into-the-shell) has finished. You can call `pipe` here to start streaming. React will [stream the additional content](#streaming-more-content-as-it-loads) after the shell along with the inline `<script>` tags that replace the HTML loading fallbacks with the content.
+  * **optional** `onShellError`: A callback that fires if there was an error rendering the shell. It receives the error as an argument. No bytes were emitted from the stream yet, and neither `onShellReady` nor `onAllReady` will get called, so you can [output a fallback HTML shell](#recovering-from-errors-inside-the-shell) or use the prelude.
 
 
 #### Returns {/*returns*/}
 
-`resume` returns a Promise:
-
-returns an object with two methods:
+`resume` returns an object with two methods:
 
 * `pipe` outputs the HTML into the provided [Writable Node.js Stream.](https://nodejs.org/api/stream.html#writable-streams) Call `pipe` in `onShellReady` if you want to enable streaming, or in `onAllReady` for crawlers and static generation.
 * `abort` lets you [abort server rendering](#aborting-server-rendering) and render the rest on the client.
 
-
 #### Caveats {/*caveats*/}
-- `resume` does not accept options for `bootstrapScripts`, `bootstrapScriptContent`, or `bootstrapModules`. Instead, you need to pass these options to the `prerender` call that generates the `postponedState`. These may be injected either during pre-render or resume.
-- `resume` does not accept `identifierPrefix`, `namespaceURI`, or `progressiveChunkSize` since these need to be the same in both `prerender` and `resume`.
-- Since `nonce` cannot be provided to prerender, you should only provide `nonce` to `resume` if you're not providing scripts to prerender.
-- `resume` re-renders from the root until it finds a component that was not fully pre-rendered, and skips fully pre-rendered components.
-- TODO: no `namespaceURI`
-- TODO: can't set status codes.
 
----
+- `resumeToPipeableStream` does not accept options for `bootstrapScripts`, `bootstrapScriptContent`, or `bootstrapModules`. Instead, you need to pass these options to the `prerender` call that generates the `postponedState`. You can also inject bootstrap content into the writable stream manually.
+- `resumeToPipeableStream` does not accept `identifierPrefix` since the prefix needs to be the same in both `prerender` and `resumeToPipeableStream`.
+- Since `nonce` cannot be provided to prerender, you should only provide `nonce` to `resumeToPipeableStream` if you're not providing scripts to prerender.
+- `resumeToPipeableStream` re-renders from the root until it finds a component that was not fully pre-rendered. Only fully prerendered Components (the Component and its children finished prerendering) are skipped entirely.
 
 ## Usage {/*usage*/}
 
-### Resuming a prerender to a Node.js Stream {/*resuming-a-prerender-to-a-node-js-stream*/}
+### Further reading {/*further-reading*/}
 
-TODO
-
----
-
-### Logging crashes on the server {/*logging-crashes-on-the-server*/}
-
-By default, all errors on the server are logged to console. You can override this behavior to log crash reports:
-
-```js {9-10}
-import { resume } from 'react-dom/server';
-import { getPostponedState } from 'storage';
-import { logServerCrashReport } from 'logging';
-
-async function handler(request, response) {
-  const postponed = await getPostponedState(request);
-  const {pipe} = await resumeToPipeableStream(<App />, postponed, {
-    onShellReady: () => {
-      pipe(response);
-    },
-    onError(error) {
-      console.error(error);
-      logServerCrashReport(error);
-    }
-  });
-}
-```
-
-If you provide a custom `onError` implementation, don't forget to also log errors to the console like above.
-
----
-
-### Recovering from errors replaying the shell {/*recovering-from-errors-inside-the-shell*/}
-
-TODO: this is for when the shell completed.
-
-In this example, prerender successfully rendered a shell containing `ProfileLayout`, `ProfileCover`, and `PostsGlimmer`:
-
-```js {3-5,7-8}
-function ProfilePage() {
-  return (
-    <ProfileLayout>
-      <ProfileCover />
-      <Suspense fallback={<PostsGlimmer />}>
-        <Posts />
-      </Suspense>
-    </ProfileLayout>
-  );
-}
-```
-
-If an error occurs while replaying those components, React won't have any meaningful HTML to send to the client. TODO: how to recover from this, since the promise is resolved. I think it will just encode an error in the stream and trigger an error boundary?
-
-```js {2,13-18}
-// TODO
-```
-
-If there is an error while replaying the shell, it will be logged to `onError`.
-
-### Recovering from errors re-creating the shell {/*recovering-from-errors-re-creating-the-shell*/}
-
-TODO: this is for when the shell errors, and re-creating the shell fails.
-
----
-
-### Recovering from errors outside the shell {/*recovering-from-errors-outside-the-shell*/}
-
-TODO: confirm this section is correct.
-
-In this example, the `<Posts />` component is wrapped in `<Suspense>` so it is *not* a part of the shell:
-
-```js {6}
-function ProfilePage() {
-  return (
-    <ProfileLayout>
-      <ProfileCover />
-      <Suspense fallback={<PostsGlimmer />}>
-        <Posts />
-      </Suspense>
-    </ProfileLayout>
-  );
-}
-```
-
-If an error happens in the `Posts` component or somewhere inside it, React will [try to recover from it:](/reference/react/Suspense#providing-a-fallback-for-server-errors-and-client-only-content)
-
-1. It will emit the loading fallback for the closest `<Suspense>` boundary (`PostsGlimmer`) into the HTML.
-2. It will "give up" on trying to render the `Posts` content on the server anymore.
-3. When the JavaScript code loads on the client, React will *retry* rendering `Posts` on the client.
-
-If retrying rendering `Posts` on the client *also* fails, React will throw the error on the client. As with all the errors thrown during rendering, the [closest parent error boundary](/reference/react/Component#static-getderivedstatefromerror) determines how to present the error to the user. In practice, this means that the user will see a loading indicator until it is certain that the error is not recoverable.
-
-If retrying rendering `Posts` on the client succeeds, the loading fallback from the server will be replaced with the client rendering output. The user will not know that there was a server error. However, the server `onError` callback and the client [`onRecoverableError`](/reference/react-dom/client/hydrateRoot#hydrateroot) callbacks will fire so that you can get notified about the error.
-
----
-
-### Setting the status code {/*setting-the-status-code*/}
-
-TODO: you can't set the status code in resume, unless you're calling prerender in the same request. If so, set the status code between `prerender` and `resume`.
-
----
-
-### Handling different errors in different ways {/*handling-different-errors-in-different-ways*/}
-
-TODO: update this example.
-
-You can [create your own `Error` subclasses](https://javascript.info/custom-errors) and use the [`instanceof`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) operator to check which error is thrown. For example, you can define a custom `NotFoundError` and throw it from your component. Then you can save the error in `onError` and do something different before returning the response depending on the error type:
-
-```js {2-3,5-15,22,28,33}
-async function handler(request) {
-  let didError = false;
-  let caughtError = null;
-
-  function getStatusCode() {
-    if (didError) {
-      if (caughtError instanceof NotFoundError) {
-        return 404;
-      } else {
-        return 500;
-      }
-    } else {
-      return 200;
-    }
-  }
-
-  try {
-    const stream = await renderToReadableStream(<App />, {
-      bootstrapScripts: ['/main.js'],
-      onError(error) {
-        didError = true;
-        caughtError = error;
-        console.error(error);
-        logServerCrashReport(error);
-      }
-    });
-    return new Response(stream, {
-      status: getStatusCode(),
-      headers: { 'content-type': 'text/html' },
-    });
-  } catch (error) {
-    return new Response('<h1>Something went wrong</h1>', {
-      status: getStatusCode(),
-      headers: { 'content-type': 'text/html' },
-    });
-  }
-}
-```
-
----
-
-### Waiting for all content to load for crawlers and static generation {/*waiting-for-all-content-to-load-for-crawlers-and-static-generation*/}
-
-TODO: this doesn't make sense for `resume` right?
-
----
-
-### Aborting server rendering {/*aborting-server-rendering*/}
-
-TODO
+Resuming behaves like `renderToReadableStream`. For more examples, check out the [usage section of `renderToReadableStream`](/reference/react-dom/server/renderToReadableStream#usage).
+The [usage section of `prerender`](/reference/react-dom/static/prerender#usage) includes examples of how to use `prerenderToNodeStream` specifically.

--- a/src/content/reference/react-dom/static/index.md
+++ b/src/content/reference/react-dom/static/index.md
@@ -15,7 +15,9 @@ The `react-dom/static` APIs let you generate static HTML for React components. T
 These methods are only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), which includes browsers, Deno, and some modern edge runtimes:
 
 * [`prerender`](/reference/react-dom/static/prerender) renders a React tree to static HTML with a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+* <ExperimentalBadge /> [`resumeAndPrerender`](/reference/react-dom/static/resumeAndPrerender) continues a prerendered React tree to static HTML with a [Readable Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
+Node.js also includes these methods for compatibility, but they are not recommended due to worse performance. Use the [dedicated Node.js APIs](#static-apis-for-nodejs-streams) instead.
 
 ---
 
@@ -24,5 +26,5 @@ These methods are only available in the environments with [Web Streams](https://
 These methods are only available in the environments with [Node.js Streams](https://nodejs.org/api/stream.html):
 
 * [`prerenderToNodeStream`](/reference/react-dom/static/prerenderToNodeStream) renders a React tree to static HTML with a [Node.js Stream.](https://nodejs.org/api/stream.html)
-
+* <ExperimentalBadge /> [`resumeAndPrerenderToNodeStream`](/reference/react-dom/static/resumeAndPrerenderToNodeStream) continues a prerendered React tree to static HTML with a [Node.js Stream.](https://nodejs.org/api/stream.html)
 

--- a/src/content/reference/react-dom/static/prerender.md
+++ b/src/content/reference/react-dom/static/prerender.md
@@ -31,7 +31,7 @@ Call `prerender` to render your app to static HTML.
 ```js
 import { prerender } from 'react-dom/static';
 
-async function handler(request) {
+async function handler(request, response) {
   const {prelude} = await prerender(<App />, {
     bootstrapScripts: ['/main.js']
   });
@@ -64,6 +64,7 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 `prerender` returns a Promise:
 - If rendering the is successful, the Promise will resolve to an object containing:
   - `prelude`: a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
+  - `postponed` <CanaryBadge />: an opaque object that can be passed to `resume` if `prerender` is aborted.
 - If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell)
 
 #### Caveats {/*caveats*/}
@@ -76,6 +77,8 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 ### When should I use `prerender`? {/*when-to-use-prerender*/}
 
 The static `prerender` API is used for static server-side generation (SSG). Unlike `renderToString`, `prerender` waits for all data to load before resolving. This makes it suitable for generating static HTML for a full page, including data that needs to be fetched using Suspense. To stream content as it loads, use a streaming server-side render (SSR) API like [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
+
+In Canary versions of React DOM, `prerender` can be aborted and resumed later with `resume` to support partial pre-rendering.
 
 </Note>
 
@@ -312,6 +315,10 @@ async function renderToString() {
 Any Suspense boundaries with incomplete children will be included in the prelude in the fallback state.
 
 ---
+
+## Partial pre-rendering and resuming later {/*partial-pre-rendering-and-resuming-later*/}
+
+TODO
 
 ## Troubleshooting {/*troubleshooting*/}
 

--- a/src/content/reference/react-dom/static/prerender.md
+++ b/src/content/reference/react-dom/static/prerender.md
@@ -7,7 +7,7 @@ title: prerender
 `prerender` renders a React tree to a static HTML string using a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).
 
 ```js
-const {prelude} = await prerender(reactNode, options?)
+const {prelude, postponed} = await prerender(reactNode, options?)
 ```
 
 </Intro>
@@ -64,13 +64,12 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 `prerender` returns a Promise:
 - If rendering the is successful, the Promise will resolve to an object containing:
   - `prelude`: a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
-  - `postponed` <CanaryBadge />: an opaque object that can be passed to `resume` if `prerender` is aborted.
+  - `postponed` <CanaryBadge />: a JSON-serializeable, opaque object that can be passed to [`resume`](/reference/react-dom/server/resume) if `prerender` did not finish. Otherwise `null` indicating that the `prelude` contains all the content and no resume is necessary.
 - If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell)
 
 #### Caveats {/*caveats*/}
 
 `nonce` is not an available option when prerendering. Nonces must be unique per request and if you use nonces to secure your application with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) it would be inappropriate and insecure to include the nonce value in the prerender itself.
-
 
 <Note>
 
@@ -78,7 +77,7 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 
 The static `prerender` API is used for static server-side generation (SSG). Unlike `renderToString`, `prerender` waits for all data to load before resolving. This makes it suitable for generating static HTML for a full page, including data that needs to be fetched using Suspense. To stream content as it loads, use a streaming server-side render (SSR) API like [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
 
-In Canary versions of React DOM, `prerender` can be aborted and resumed later with `resume` to support partial pre-rendering.
+In Canary versions of React DOM, `prerender` can be aborted and later either continued with `resumeAndPrerender` or resumed with `resume` to support partial pre-rendering.
 
 </Note>
 
@@ -314,11 +313,7 @@ async function renderToString() {
 
 Any Suspense boundaries with incomplete children will be included in the prelude in the fallback state.
 
----
-
-## Partial pre-rendering and resuming later {/*partial-pre-rendering-and-resuming-later*/}
-
-TODO
+<CanaryBadge /> This can be used for partial prerendering together with [`resume`](/reference/react-dom/server/resume) or [`resumeAndPrerender`](/reference/react-dom/static/resumeAndPrerender).
 
 ## Troubleshooting {/*troubleshooting*/}
 

--- a/src/content/reference/react-dom/static/prerenderToNodeStream.md
+++ b/src/content/reference/react-dom/static/prerenderToNodeStream.md
@@ -65,6 +65,7 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 `prerenderToNodeStream` returns a Promise:
 - If rendering the is successful, the Promise will resolve to an object containing:
   - `prelude`: a [Node.js Stream.](https://nodejs.org/api/stream.html) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
+  - `postponed` <CanaryBadge />: an opaque object that can be passed to `resume` if `prerender` is aborted.
 - If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToPipeableStream#recovering-from-errors-inside-the-shell)
 
 #### Caveats {/*caveats*/}
@@ -76,6 +77,8 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 ### When should I use `prerenderToNodeStream`? {/*when-to-use-prerender*/}
 
 The static `prerenderToNodeStream` API is used for static server-side generation (SSG). Unlike `renderToString`, `prerenderToNodeStream` waits for all data to load before resolving. This makes it suitable for generating static HTML for a full page, including data that needs to be fetched using Suspense. To stream content as it loads, use a streaming server-side render (SSR) API like [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
+
+In canary versions of React DOM, `prerenderToNodeStream` can be aborted and resumed later with `resumeToNodeStream` to support partial pre-rendering.
 
 </Note>
 
@@ -312,6 +315,10 @@ async function renderToString() {
 Any Suspense boundaries with incomplete children will be included in the prelude in the fallback state.
 
 ---
+
+## Partial pre-rendering and resuming later {/*partial-pre-rendering-and-resuming-later*/}
+
+TODO
 
 ## Troubleshooting {/*troubleshooting*/}
 

--- a/src/content/reference/react-dom/static/prerenderToNodeStream.md
+++ b/src/content/reference/react-dom/static/prerenderToNodeStream.md
@@ -7,7 +7,7 @@ title: prerenderToNodeStream
 `prerenderToNodeStream` renders a React tree to a static HTML string using a [Node.js Stream.](https://nodejs.org/api/stream.html).
 
 ```js
-const {prelude} = await prerenderToNodeStream(reactNode, options?)
+const {prelude, postponed} = await prerenderToNodeStream(reactNode, options?)
 ```
 
 </Intro>
@@ -65,7 +65,7 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 `prerenderToNodeStream` returns a Promise:
 - If rendering the is successful, the Promise will resolve to an object containing:
   - `prelude`: a [Node.js Stream.](https://nodejs.org/api/stream.html) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
-  - `postponed` <CanaryBadge />: an opaque object that can be passed to `resume` if `prerender` is aborted.
+  - `postponed` <CanaryBadge />: a JSON-serializeable, opaque object that can be passed to [`resumeToPipeableStream`](/reference/react-dom/server/resumeToPipeableStream) if `prerenderToNodeStream` did not finish. Otherwise `null` indicating that the `prelude` contains all the content and no resume is necessary.
 - If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToPipeableStream#recovering-from-errors-inside-the-shell)
 
 #### Caveats {/*caveats*/}
@@ -78,7 +78,7 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 
 The static `prerenderToNodeStream` API is used for static server-side generation (SSG). Unlike `renderToString`, `prerenderToNodeStream` waits for all data to load before resolving. This makes it suitable for generating static HTML for a full page, including data that needs to be fetched using Suspense. To stream content as it loads, use a streaming server-side render (SSR) API like [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
 
-In canary versions of React DOM, `prerenderToNodeStream` can be aborted and resumed later with `resumeToNodeStream` to support partial pre-rendering.
+In canary versions of React DOM, `prerenderToNodeStream` can be aborted and resumed later with `resumeToPipeableStream` to support partial pre-rendering.
 
 </Note>
 
@@ -314,11 +314,7 @@ async function renderToString() {
 
 Any Suspense boundaries with incomplete children will be included in the prelude in the fallback state.
 
----
-
-## Partial pre-rendering and resuming later {/*partial-pre-rendering-and-resuming-later*/}
-
-TODO
+<CanaryBadge /> This can be used for partial prerendering together with [`resumeToPipeableStream`](/reference/react-dom/server/resumeToPipeableStream) or [`resumeAndPrerenderToNodeStream`](/reference/react-dom/static/resumeAndPrerenderToNodeStream).
 
 ## Troubleshooting {/*troubleshooting*/}
 

--- a/src/content/reference/react-dom/static/resumeAndPrerender.md
+++ b/src/content/reference/react-dom/static/resumeAndPrerender.md
@@ -1,0 +1,96 @@
+---
+title: resumeAndPrerender
+version: canary
+---
+
+<Canary>
+
+**The `resume` API is currently only available in React’s Canary and Experimental channels.** 
+
+[Learn more about React’s release channels here.](/community/versioning-policy#all-release-channels)
+
+</Canary>
+
+<Intro>
+
+`resumeAndPrerender` continues a prerendered React tree to a static HTML string using a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).
+
+```js
+const { prelude,postpone } = await resumeAndPrerender(reactNode, postponedState, options?)
+```
+
+</Intro>
+
+<InlineToc />
+
+<Note>
+
+This API depends on [Web Streams.](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) For Node.js, use [`resumeAndPrerenderToNodeStream`](/reference/react-dom/static/resumeAndPrerenderToNodeStream) instead.
+
+</Note>
+
+---
+
+## Reference {/*reference*/}
+
+### `resumeAndPrerender(reactNode, postponedState, options?)` {/*resumeandprerender*/}
+
+Call `resumeAndPrerender` to continue a prerendered React tree to a static HTML string.
+
+```js
+import { resumeAndPrerender } from 'react-dom/static';
+import { getPostponedState } from 'storage';
+
+async function handler(request, response) {
+  const postponedState = getPostponedState(request);
+  const { prelude } = await resumeAndPrerender(<App />, postponedState, {
+    bootstrapScripts: ['/main.js']
+  });
+  return new Response(prelude, {
+    headers: { 'content-type': 'text/html' },
+  });
+}
+```
+
+On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to make the server-generated HTML interactive.
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+* `reactNode`: The React node you called `prerender` (or a previous `resumeAndPrerender`) with. For example, a JSX element like `<App />`. It is expected to represent the entire document, so the `App` component should render the `<html>` tag.
+* `postponedState`: The opaque `postpone` object returned from a [prerender API](/reference/react-dom/static/index), loaded from wherever you stored it (e.g. redis, a file, or S3).
+* **optional** `options`: An object with streaming options.
+  * **optional** `signal`: An [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that lets you [abort server rendering](#aborting-server-rendering) and render the rest on the client.
+  * **optional** `onError`: A callback that fires whenever there is a server error, whether [recoverable](#recovering-from-errors-outside-the-shell) or [not.](#recovering-from-errors-inside-the-shell) By default, this only calls `console.error`. If you override it to [log crash reports,](#logging-crashes-on-the-server) make sure that you still call `console.error`.
+
+#### Returns {/*returns*/}
+
+`prerender` returns a Promise:
+- If rendering the is successful, the Promise will resolve to an object containing:
+  - `prelude`: a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
+  - `postponed`: an JSON-serializeable, opaque object that can be passed to [`resume`](/reference/react-dom/server/resume) or [`resumeAndPrerender`](/reference/react-dom/static/resumeAndPrerender) if `prerender` is aborted.
+- If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell)
+
+#### Caveats {/*caveats*/}
+
+`nonce` is not an available option when prerendering. Nonces must be unique per request and if you use nonces to secure your application with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) it would be inappropriate and insecure to include the nonce value in the prerender itself.
+
+<Note>
+
+### When should I use `resumeAndPrerender`? {/*when-to-use-prerender*/}
+
+The static `resumeAndPrerender` API is used for static server-side generation (SSG). Unlike `renderToString`, `resumeAndPrerender` waits for all data to load before resolving. This makes it suitable for generating static HTML for a full page, including data that needs to be fetched using Suspense. To stream content as it loads, use a streaming server-side render (SSR) API like [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
+
+`resumeAndPrerender` can be aborted and later either continued with another `resumeAndPrerender` or resumed with `resume` to support partial pre-rendering.
+
+</Note>
+
+---
+
+## Usage {/*usage*/}
+
+### Further reading {/*further-reading*/}
+
+`resumeAndPrerender` behaves similarly to [`prerender`](/reference/react-dom/static/prerender) but can be used to continue a previously started prerendering process that was aborted.
+For more information about resuming a prerendered tree, see the [resume documentation](/reference/react-dom/server/resume#resuming-a-prerender).

--- a/src/content/reference/react-dom/static/resumeAndPrerenderToNodeStream.md
+++ b/src/content/reference/react-dom/static/resumeAndPrerenderToNodeStream.md
@@ -1,0 +1,93 @@
+---
+title: resumeAndPrerenderToNodeStream
+version: canary
+---
+
+<Canary>
+
+**The `resumeAndPrerenderToNodeStream` API is currently only available in React’s Experimental channels.** 
+
+[Learn more about React’s release channels here.](/community/versioning-policy#all-release-channels)
+
+</Canary>
+
+<Intro>
+
+`resumeAndPrerenderToNodeStream` continues a prerendered React tree to a static HTML string using a a [Node.js Stream.](https://nodejs.org/api/stream.html).
+
+```js
+const {prelude, postponed} = await resumeAndPrerenderToNodeStream(reactNode, postponedState, options?)
+```
+
+</Intro>
+
+<InlineToc />
+
+<Note>
+
+This API is specific to Node.js. Environments with [Web Streams,](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) like Deno and modern edge runtimes, should use [`prerender`](/reference/react-dom/static/prerender) instead.
+
+</Note>
+
+---
+
+## Reference {/*reference*/}
+
+### `resumeAndPrerenderToNodeStream(reactNode, postponedState, options?)` {/*resumeandprerendertolnodestream*/}
+
+Call `resumeAndPrerenderToNodeStream` to continue a prerendered React tree to a static HTML string.
+
+```js
+import { resumeAndPrerenderToNodeStream } from 'react-dom/static';
+import { getPostponedState } from 'storage';
+
+async function handler(request, writable) {
+  const postponedState = getPostponedState(request);
+  const { prelude } = await resumeAndPrerenderToNodeStream(<App />, JSON.parse(postponedState));
+  prelude.pipe(writable);
+}
+```
+
+On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to make the server-generated HTML interactive.
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+* `reactNode`: The React node you called `prerender` (or a previous `resumeAndPrerenderToNodeStream`) with. For example, a JSX element like `<App />`. It is expected to represent the entire document, so the `App` component should render the `<html>` tag.
+* `postponedState`: The opaque `postpone` object returned from a [prerender API](/reference/react-dom/static/index), loaded from wherever you stored it (e.g. redis, a file, or S3).
+* **optional** `options`: An object with streaming options.
+  * **optional** `signal`: An [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that lets you [abort server rendering](#aborting-server-rendering) and render the rest on the client.
+  * **optional** `onError`: A callback that fires whenever there is a server error, whether [recoverable](#recovering-from-errors-outside-the-shell) or [not.](#recovering-from-errors-inside-the-shell) By default, this only calls `console.error`. If you override it to [log crash reports,](#logging-crashes-on-the-server) make sure that you still call `console.error`.
+
+#### Returns {/*returns*/}
+
+`resumeAndPrerenderToNodeStream` returns a Promise:
+- If rendering the is successful, the Promise will resolve to an object containing:
+  - `prelude`: a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
+  - `postponed`: an JSON-serializeable, opaque object that can be passed to [`resumeToNodeStream`](/reference/react-dom/server/resume) or [`resumeAndPrerenderToNodeStream`](/reference/react-dom/static/resumeAndPrerenderToNodeStream) if `resumeAndPrerenderToNodeStream` is aborted.
+- If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell)
+
+#### Caveats {/*caveats*/}
+
+`nonce` is not an available option when prerendering. Nonces must be unique per request and if you use nonces to secure your application with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) it would be inappropriate and insecure to include the nonce value in the prerender itself.
+
+<Note>
+
+### When should I use `resumeAndPrerenderToNodeStream`? {/*when-to-use-prerender*/}
+
+The static `resumeAndPrerenderToNodeStream` API is used for static server-side generation (SSG). Unlike `renderToString`, `resumeAndPrerenderToNodeStream` waits for all data to load before resolving. This makes it suitable for generating static HTML for a full page, including data that needs to be fetched using Suspense. To stream content as it loads, use a streaming server-side render (SSR) API like [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
+
+`resumeAndPrerenderToNodeStream` can be aborted and later either continued with another `resumeAndPrerenderToNodeStream` or resumed with `resume` to support partial pre-rendering.
+
+</Note>
+
+---
+
+## Usage {/*usage*/}
+
+### Further reading {/*further-reading*/}
+
+`resumeAndPrerenderToNodeStream` behaves similarly to [`prerender`](/reference/react-dom/static/prerender) but can be used to continue a previously started prerendering process that was aborted.
+For more information about resuming a prerendered tree, see the [resume documentation](/reference/react-dom/server/resume#resuming-a-prerender).
+

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -330,8 +330,18 @@
           "path": "/reference/react-dom/static/prerender"
         },
         {
+          "title": "resumeAndPrerender",
+          "path": "/reference/react-dom/static/resumeAndPrerender",
+          "version": "canary"
+        },
+        {
           "title": "prerenderToNodeStream",
           "path": "/reference/react-dom/static/prerenderToNodeStream"
+        },
+        {
+          "title": "resumeAndPrerenderToNodeStream",
+          "path": "/reference/react-dom/static/resumeAndPrerenderToNodeStream",
+          "version": "canary"
         }
       ]
     },

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -308,6 +308,16 @@
         {
           "title": "renderToString",
           "path": "/reference/react-dom/server/renderToString"
+        },
+        {
+          "title": "resume",
+          "path": "/reference/react-dom/server/resume",
+          "version": "canary"
+        },
+        {
+          "title": "resumeToPipeableStream",
+          "path": "/reference/react-dom/server/resumeToPipeableStream",
+          "version": "canary"
         }
       ]
     },

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -330,13 +330,13 @@
           "path": "/reference/react-dom/static/prerender"
         },
         {
+          "title": "prerenderToNodeStream",
+          "path": "/reference/react-dom/static/prerenderToNodeStream"
+        },
+        {
           "title": "resumeAndPrerender",
           "path": "/reference/react-dom/static/resumeAndPrerender",
           "version": "canary"
-        },
-        {
-          "title": "prerenderToNodeStream",
-          "path": "/reference/react-dom/static/prerenderToNodeStream"
         },
         {
           "title": "resumeAndPrerenderToNodeStream",


### PR DESCRIPTION
The main section to focus on is in the `resume` docs: https://react-c6xxv66nl-fbopensource.vercel.app/reference/react-dom/server/resume#resuming-a-prerender

Resume-and-prerender APIs behave no different than resume with the exception that you can continue a prerender. So referring to resume/prerender docs for concrete examples makes more sense.

The Node.js APIs behave no different other than having a slightly different interface so we don't need to repeat usage examples. 

There's room for a more detailed learn series about partial prerendering that can be distilled from blog posts and talks going into infra details. But that is out of scope for reference docs.