### PR TITLE
Update conferences.md

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -10,6 +10,16 @@ Do you know of a local React.js conference? Add it here! (Please keep the list c
 
 ## Upcoming Conferences {/*upcoming-conferences*/}
 
+### React Advanced Canada 2026 {/*react-advanced-canada-2026*/}
+March 24 - 26, 2026. In-person in Toronto, Canada + online (hybrid event)
+
+[Website](https://reactadvanced.com/) - [Twitter](https://x.com/reactadvanced)
+
+### React Advanced London 2025 {/*react-advanced-london-2025*/}
+Novermber 28 - December 2, 2025. In-person in London, UK + online (hybrid event)
+
+[Website](https://reactadvanced.com/) - [Twitter](https://x.com/reactadvanced)
+
 ### CityJS London 2025 {/*cityjs-london*/}
 April 23 - 25, 2025. In-person in London, UK 
 


### PR DESCRIPTION
Add React Advanced London 2025 and React Advanced Canada 2026 to the list of upcoming conferences (conferences.md).

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
