### PR TITLE
fix: prevent partial reset when canceling reset confirmation.

### DIFF
--- a/src/components/MDX/Sandpack/NavigationBar.tsx
+++ b/src/components/MDX/Sandpack/NavigationBar.tsx
@@ -103,10 +103,9 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
      *
      * Plus, it should only prompt if there's any file changes
      */
-    if (
-      sandpack.editorState === 'dirty' &&
-      confirm('Reset all your edits too?')
-    ) {
+    if (sandpack.editorState === 'dirty') {
+      const confirmed = confirm('Reset all your edits too?');
+      if (!confirmed) return;
       sandpack.resetAllFiles();
     }
 


### PR DESCRIPTION
"[Bug]: "Reset state" on the playgrounds UX is confusing" was open in github issues and the user addressed the issue as the following: "The only way I found is clicking on "Reset", which triggers a popup saying "Reset all your edits too?" and then pressing "Cancel". This will successfully reset the state but not the code."

I looked into the issue and it was a minor bug where the refresh() is called even if the confirm is not true which is clicking on cancel. 

`const handleReset = () => {
    /**
     * resetAllFiles must come first, otherwise
     * the previous content will appear for a second
     * when the iframe loads.
     *
     * Plus, it should only prompt if there's any file changes
     */
    if (sandpack.editorState === 'dirty') {
      const confirmed = confirm('Reset all your edits too?');
      if (!confirmed) return;
      sandpack.resetAllFiles();
    }

    refresh();
  };`
  
  Now, it's all changed and the bug is fixed. Thank you : )