### PR TITLE
Update react-labs-view-transitions-activity-and-more.md

### DIFF
--- a/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
+++ b/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
@@ -2521,7 +2521,7 @@ export default function App() {
   const { url } = useRouter();
 
   // Define a default animation of .slow-fade.
-  // See animations.css for the animation definiton.
+  // See animations.css for the animation definition.
   return (
     <ViewTransition default="slow-fade">
       {url === '/' ? <Home /> : <Details />}


### PR DESCRIPTION
Fix typo in code comment: "definiton" → "definition"

Fixes a small typo in a code block comment from the React Labs blog post on View Transitions, Activity, and more.

In the comment above the ViewTransition component (App.js), the word "definition" is misspelled as "definiton":

Before:
// See animations.css for the animation definiton.

After:
// See animations.css for the animation definition.

It’s a small typo, but correcting it helps maintain quality and avoids it being overlooked, especially since it's from the latest blog post from react labs.