### PR TITLE
[compiler] Fix misleading code example

### DIFF
--- a/src/content/learn/react-compiler/incremental-adoption.md
+++ b/src/content/learn/react-compiler/incremental-adoption.md
@@ -101,8 +101,7 @@ module.exports = {
       test: './src/experimental/**/*.{js,jsx,ts,tsx}',
       plugins: [
         ['babel-plugin-react-compiler', {
-          compilationMode: 'annotation', // Only compile "use memo" components
-          panicThreshold: 'none' // More permissive for experimental code
+          // options ...
         }]
       ]
     },
@@ -110,7 +109,7 @@ module.exports = {
       test: './src/production/**/*.{js,jsx,ts,tsx}',
       plugins: [
         ['babel-plugin-react-compiler', {
-          panicThreshold: 'critical_errors' // Stricter for production code
+          // options ...
         }]
       ]
     }


### PR DESCRIPTION

When the compiler bails out on code, it  leaves it untouched and unoptimized, so it's always safe for the compiler to bailout.

`panicThreshold` in most cases should be kept as `'none'` unless you want to fail the build on these safe bailouts. It's really only useful during dev when you're working on increasing the coverage of the compiler on your codebase.

I think having it shown here is confusing so I'm opting to just remove it for this particular code example.
