### PR TITLE
Fix typo in prerender documentation

### DIFF
--- a/src/content/reference/react-dom/static/prerender.md
+++ b/src/content/reference/react-dom/static/prerender.md
@@ -62,7 +62,7 @@ On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to 
 #### Returns {/*returns*/}
 
 `prerender` returns a Promise:
-- If rendering the is successful, the Promise will resolve to an object containing:
+- If rendering is successful, the Promise will resolve to an object containing:
   - `prelude`: a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
 - If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell)
 


### PR DESCRIPTION
## Summary
Fixed a grammatical error in the prerender API documentation.

## Changes
- Removed extra "the" from "If rendering the is successful" → "If rendering is successful"

## Type of Change
- [ ] Bug fix
- [x] Documentation update
- [ ] New feature
- [ ] Breaking change

Small typo fix in the Returns section of the prerender documentation.