### PR TITLE
Fix typo in react-labs-view-transitions-activity-and-more.md  Fixes #7887

### DIFF
--- a/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
+++ b/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
@@ -2521,7 +2521,7 @@ export default function App() {
   const { url } = useRouter();
 
   // Define a default animation of .slow-fade.
-  // See animations.css for the animation definiton.
+  // See animations.css for the animation definition.
   return (
     <ViewTransition default="slow-fade">
       {url === '/' ? <Home /> : <Details />}


### PR DESCRIPTION
This PR fixes a minor typo in a code comment in the view transitions blog post.
Changed 'definiton' to 'definition'.

Fixes #7887

