### PR TITLE
docs: minor grammar correction

### DIFF
--- a/src/content/reference/react/cache.md
+++ b/src/content/reference/react/cache.md
@@ -321,7 +321,7 @@ All mentioned APIs offer memoization but the difference is what they're intended
 
 #### `useMemo` {/*deep-dive-use-memo*/}
 
-In general, you should use [`useMemo`](/reference/react/useMemo) for caching a expensive computation in a Client Component across renders. As an example, to memoize a transformation of data within a component.
+In general, you should use [`useMemo`](/reference/react/useMemo) for caching an expensive computation in a Client Component across renders. As an example, to memoize a transformation of data within a component.
 
 ```jsx {4}
 'use client';


### PR DESCRIPTION
`a expensive` should be `an expensive`

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
