### PR TITLE
docs:Replace 'Twitter' with 'X'

### DIFF
--- a/src/content/blog/index.md
+++ b/src/content/blog/index.md
@@ -6,7 +6,7 @@ title: React Blog
 
 This blog is the official source for the updates from the React team. Anything important, including release notes or deprecation notices, will be posted here first.
 
-You can also follow the [@react.dev](https://bsky.app/profile/react.dev) account on Bluesky, or [@reactjs](https://twitter.com/reactjs) account on Twitter, but you won’t miss anything essential if you only read this blog.
+You can also follow the [@react.dev](https://bsky.app/profile/react.dev) account on Bluesky, or [@reactjs](https://x.com/reactjs) account on X, but you won’t miss anything essential if you only read this blog.
 
 </Intro>
 

--- a/src/content/community/acknowledgements.md
+++ b/src/content/community/acknowledgements.md
@@ -69,6 +69,6 @@ We'd like to give special thanks to [Tom Occhino](https://github.com/tomocchino)
 Additionally, we're grateful to:
 
 * [Jeff Barczewski](https://github.com/jeffbski) for allowing us to use the `react` package name on npm
-* [Christopher Aue](https://christopheraue.net/) for letting us use the reactjs.com domain name and the [@reactjs](https://twitter.com/reactjs) username on Twitter
+* [Christopher Aue](https://christopheraue.net/) for letting us use the reactjs.com domain name and the [@reactjs](https://x.com/reactjs) username on X
 * [ProjectMoon](https://github.com/ProjectMoon) for letting us use the [flux](https://www.npmjs.com/package/flux) package name on npm
 * Shane Anderson for allowing us to use the [react](https://github.com/react) org on GitHub

--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -29,4 +29,4 @@ Each community consists of many thousands of React users.
 
 ## News {/*news*/}
 
-For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs), [**@react.dev** on Bluesky](https://bsky.app/profile/react.dev) and the [official React blog](/blog/) on this website.
+For the latest news about React, [follow **@reactjs** on X](https://x.com/reactjs), [**@react.dev** on Bluesky](https://bsky.app/profile/react.dev) and the [official React blog](/blog/) on this website.


### PR DESCRIPTION
docs: Update "Twitter" references to "X"

This pull request changes all instances of "Twitter" to "X" in the following files:
- src/content/blog/index.md
- src/content/community/acknowledgements.md
- src/content/community/index.md