### PR TITLE
fix: typo on view transitions blog post

### DIFF
--- a/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
+++ b/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
@@ -2521,7 +2521,7 @@ export default function App() {
   const { url } = useRouter();
 
   // Define a default animation of .slow-fade.
-  // See animations.css for the animation definiton.
+  // See animations.css for the animation definition.
   return (
     <ViewTransition default="slow-fade">
       {url === '/' ? <Home /> : <Details />}


### PR DESCRIPTION
This PR corrects a small typo in src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md

- Changed definiton → definition
- No other changes were made

This PR closes [#7878](https://github.com/reactjs/react.dev/issues/7887)