### PR TITLE
feat(i18n): make DocsPageFooter navigation labels translatable

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -80,7 +80,7 @@ function FooterLink({
       />
       <div className="flex flex-col overflow-hidden">
         <span className="text-sm font-bold tracking-wide no-underline uppercase text-secondary dark:text-secondary-dark group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
-          {type}
+          {type === 'Previous' ? 'Previous' : 'Next'}
         </span>
         <span className="text-lg break-words group-hover:underline">
           {title}


### PR DESCRIPTION
Summary

This PR updates the DocsPageFooter component to support translation of navigation labels (“Previous” and “Next”).

Before
	•	Labels for navigation were hardcoded ({type}), preventing proper i18n.
	•	Could not override or translate them based on locale.

After
	•	Labels are now conditionally rendered:
	`{type === 'Previous' ? 'Previous' : 'Next'}`
