### PR TITLE
Add reload button, rename reset to clear

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/MDX/Sandpack/ClearButton.tsx
+++ b/src/components/MDX/Sandpack/ClearButton.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ */
+
+import * as React from 'react';
+import {IconClose} from '../../Icon/IconClose';
+export interface ClearButtonProps {
+  onClear: () => void;
+}
+
+export function ClearButton({onClear}: ClearButtonProps) {
+  return (
+    <button
+      className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
+      onClick={onClear}
+      title="Clear all edits and reload sandbox"
+      type="button">
+      <IconClose className="inline mx-1 relative" />
+      <span className="hidden md:block">Clear</span>
+    </button>
+  );
+}

--- a/src/components/MDX/Sandpack/NavigationBar.tsx
+++ b/src/components/MDX/Sandpack/NavigationBar.tsx
@@ -17,7 +17,8 @@ import {
   useSandpackNavigation,
 } from '@codesandbox/sandpack-react/unstyled';
 import {OpenInCodeSandboxButton} from './OpenInCodeSandboxButton';
-import {ResetButton} from './ResetButton';
+import {ReloadButton} from './ReloadButton';
+import {ClearButton} from './ClearButton';
 import {DownloadButton} from './DownloadButton';
 import {IconChevron} from '../../Icon/IconChevron';
 import {Listbox} from '@headlessui/react';
@@ -95,7 +96,7 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
     // Note: in a real useEvent, onContainerResize would be omitted.
   }, [isMultiFile, onContainerResize]);
 
-  const handleReset = () => {
+  const handleClear = () => {
     /**
      * resetAllFiles must come first, otherwise
      * the previous content will appear for a second
@@ -103,13 +104,13 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
      *
      * Plus, it should only prompt if there's any file changes
      */
-    if (
-      sandpack.editorState === 'dirty' &&
-      confirm('Reset all your edits too?')
-    ) {
+    if (sandpack.editorState === 'dirty' && confirm('Clear all your edits?')) {
       sandpack.resetAllFiles();
     }
+    refresh();
+  };
 
+  const handleReload = () => {
     refresh();
   };
 
@@ -188,7 +189,8 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
         className="px-3 flex items-center justify-end text-start"
         translate="yes">
         <DownloadButton providedFiles={providedFiles} />
-        <ResetButton onReset={handleReset} />
+        <ReloadButton onReload={handleReload} />
+        <ClearButton onClear={handleClear} />
         <OpenInCodeSandboxButton />
         {activeFile.endsWith('.tsx') && (
           <OpenInTypeScriptPlaygroundButton

--- a/src/components/MDX/Sandpack/ReloadButton.tsx
+++ b/src/components/MDX/Sandpack/ReloadButton.tsx
@@ -4,18 +4,19 @@
 
 import * as React from 'react';
 import {IconRestart} from '../../Icon/IconRestart';
-export interface ResetButtonProps {
-  onReset: () => void;
+export interface ReloadButtonProps {
+  onReload: () => void;
 }
 
-export function ResetButton({onReset}: ResetButtonProps) {
+export function ReloadButton({onReload}: ReloadButtonProps) {
   return (
     <button
       className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
-      onClick={onReset}
-      title="Reset Sandbox"
+      onClick={onReload}
+      title="Keep your edits and reload sandbox"
       type="button">
-      <IconRestart className="inline mx-1 relative" /> Reset
+      <IconRestart className="inline mx-1 relative" />
+      <span className="hidden md:block">Reload</span>
     </button>
   );
 }


### PR DESCRIPTION
## Overview

Closes #4776 #7848

The "reset" button is weird. 

<img width="469" height="163" alt="Screenshot 2025-08-28 at 3 13 42 PM" src="https://github.com/user-attachments/assets/eaea1d4a-161c-48c5-bad7-565aaf10175c" />


When you click it, it alerts with "Do you want to reset your edits too"
- Cancel - only reload
- Ok - clear edits and reload

That would be fine I guess if we just relabeled the buttons, but when you're making edits, it's actually annoying to have to keep clicking "cancel". 

So this PR separates the two into different buttons:
- Reload: reload the iframe "page" (no confirmation)
- Clear: clear all edits and reload (with confirmation)

https://github.com/user-attachments/assets/50840ee3-9dd5-4caa-b9f3-29ef38f2cab2




On mobile we'll now collapse to all icons:

<img width="498" height="425" alt="Screenshot 2025-08-28 at 3 12 29 PM" src="https://github.com/user-attachments/assets/ef069c95-27e2-4ac5-bd6f-f2604635ff4f" />
