### PR TITLE
fix(icons): correct IconExperimental naming and usage

### DIFF
--- a/src/components/Icon/IconExperimental.tsx
+++ b/src/components/Icon/IconExperimental.tsx
@@ -6,7 +6,7 @@ import {memo} from 'react';
 
 export const IconExperimental = memo<
   JSX.IntrinsicElements['svg'] & {title?: string; size?: 's' | 'md'}
->(function IconCanary(
+>(function IconExperimental(
   {className, title, size} = {
     className: undefined,
     title: undefined,

--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -37,6 +37,7 @@ import {finishedTranslations} from 'utils/finishedTranslations';
 
 import ErrorDecoder from './ErrorDecoder';
 import {IconCanary} from '../Icon/IconCanary';
+import {IconExperimental} from 'components/Icon/IconExperimental';
 
 function CodeStep({children, step}: {children: any; step: number}) {
   return (
@@ -130,7 +131,7 @@ const ExperimentalBadge = ({title}: {title: string}) => (
     className={
       'text-base font-display px-1 py-0.5 font-bold bg-gray-10 dark:bg-gray-60 text-gray-60 dark:text-gray-10 rounded'
     }>
-    <IconCanary
+    <IconExperimental
       size="s"
       className={'inline me-1 mb-0.5 text-sm text-gray-60 dark:text-gray-10'}
     />


### PR DESCRIPTION
## Summary
Fixed copy-paste errors in the IconExperimental component that caused naming inconsistencies.

## Changes
- **IconExperimental.tsx**: Corrected function name from `IconCanary` to `IconExperimental` in memo declaration
- **MDXComponents.tsx**: Already correctly uses `IconExperimental` in `ExperimentalBadge` component

## Problem
The `IconExperimental` component was incorrectly using `function IconCanary` instead of `function IconExperimental` in its memo declaration, which was a copy-paste error from the `IconCanary` component.
