### PR TITLE
doc: Update from /react to /react/hooks in /reference/react-dom/hooks…

### DIFF
--- a/src/content/reference/react-dom/hooks/index.md
+++ b/src/content/reference/react-dom/hooks/index.md
@@ -4,7 +4,7 @@ title: "Built-in React DOM Hooks"
 
 <Intro>
 
-The `react-dom` package contains Hooks that are only supported for web applications (which run in the browser DOM environment). These Hooks are not supported in non-browser environments like iOS, Android, or Windows applications. If you are looking for Hooks that are supported in web browsers *and other environments* see [the React Hooks page](/reference/react). This page lists all the Hooks in the `react-dom` package.
+The `react-dom` package contains Hooks that are only supported for web applications (which run in the browser DOM environment). These Hooks are not supported in non-browser environments like iOS, Android, or Windows applications. If you are looking for Hooks that are supported in web browsers *and other environments* see [the React Hooks page](/reference/react/hooks). This page lists all the Hooks in the `react-dom` package.
 
 </Intro>
 


### PR DESCRIPTION
…/index.md

Suggestion: Link to /reference/react/hooks rather than /reference/react. The preceding sentence refers to “If you are looking for Hooks that are supported in web browsers *and other environments* see [the React Hooks page](/reference/react/hooks). This page lists all the Hooks in the `react-dom` package.” which matches the React Hooks page better.

<img width="1287" height="452" alt="image" src="https://github.com/user-attachments/assets/490d1c11-1f49-4290-a6c7-2a0c6145f0b2" />

## original link
<img width="1167" height="408" alt="image" src="https://github.com/user-attachments/assets/a9b8dbe9-a717-4a5c-b82b-aebc32b78fea" />

## I suggestion this page
<img width="1469" height="885" alt="image" src="https://github.com/user-attachments/assets/88fb3b6b-193d-4e94-99c9-857ee2dab6a1" />

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
