### PR TITLE
Install eslint-local-rules as postinstall

### DIFF
--- a/.github/workflows/site_lint.yml
+++ b/.github/workflows/site_lint.yml
@@ -32,9 +32,6 @@ jobs:
 
       - name: Install deps
         run: yarn install --frozen-lockfile
-      - name: Install deps (eslint-local-rules)
-        run: yarn install --frozen-lockfile
-        working-directory: eslint-local-rules
 
       - name: Lint codebase
         run: yarn ci-check

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ci-check": "npm-run-all prettier:diff --parallel lint tsc lint-heading-ids rss deadlinks",
     "tsc": "tsc --noEmit",
     "start": "next start",
-    "postinstall": "is-ci || husky install .husky",
+    "postinstall": "yarn --cwd eslint-local-rules install && is-ci || husky install .husky",
     "check-all": "npm-run-all prettier lint:fix tsc rss",
     "rss": "node scripts/generateRss.js",
     "deadlinks": "node scripts/deadLinkChecker.js",


### PR DESCRIPTION

For local dev and CI we want to have the eslint-local-rules running, so let's make sure both have their dependencies installed. We don't use a monorepo setup here, which is why they're currently setup as a two completely independent yarn workspaces.
