### PR TITLE
Ignore braces when building Sandpack file map

### DIFF
--- a/src/components/MDX/Sandpack/createFileMap.ts
+++ b/src/components/MDX/Sandpack/createFileMap.ts
@@ -16,6 +16,59 @@ export const AppJSPath = `/src/App.js`;
 export const StylesCSSPath = `/src/styles.css`;
 export const SUPPORTED_FILES = [AppJSPath, StylesCSSPath];
 
+/**
+ * Tokenize meta attributes while ignoring brace-wrapped metadata (e.g. {expectedErrors: …}).
+ */
+function splitMeta(meta: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let depth = 0;
+  const trimmed = meta.trim();
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const char = trimmed[index];
+
+    if (char === '{') {
+      if (depth === 0 && current) {
+        tokens.push(current);
+        current = '';
+      }
+      depth += 1;
+      continue;
+    }
+
+    if (char === '}') {
+      if (depth > 0) {
+        depth -= 1;
+      }
+      if (depth === 0) {
+        current = '';
+      }
+      continue;
+    }
+
+    if (depth > 0) {
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
 export const createFileMap = (codeSnippets: any) => {
   return codeSnippets.reduce(
     (result: Record<string, SandpackFile>, codeSnippet: React.ReactElement) => {
@@ -37,15 +90,33 @@ export const createFileMap = (codeSnippets: any) => {
       let fileActive = false; // if the file tab is shown by default
 
       if (props.meta) {
-        const [name, ...params] = props.meta.split(' ');
-        filePath = '/' + name;
-        if (params.includes('hidden')) {
+        const tokens = splitMeta(props.meta);
+        console.log(props.meta, tokens);
+        const name = tokens.find(
+          (token) => token.includes('/') || token.includes('.')
+        );
+        if (name) {
+          filePath = name.startsWith('/') ? name : `/${name}`;
+        }
+        if (tokens.includes('hidden')) {
           fileHidden = true;
         }
-        if (params.includes('active')) {
+        if (tokens.includes('active')) {
           fileActive = true;
         }
       } else {
+        if (props.className === 'language-js') {
+          filePath = AppJSPath;
+        } else if (props.className === 'language-css') {
+          filePath = StylesCSSPath;
+        } else {
+          throw new Error(
+            `Code block is missing a filename: ${props.children}`
+          );
+        }
+      }
+
+      if (!filePath) {
         if (props.className === 'language-js') {
           filePath = AppJSPath;
         } else if (props.className === 'language-css') {


### PR DESCRIPTION

Previously, `createFileMap` split the MDX meta string on spaces and assumed the first token was the filename. Once we prefixed code fences with `{expectedErrors: …}`, it would incorrectly parse the meta and crash.

This PR updates createFileMap to skip tokens in the meta containing a start and end brace pair (using a stack to ensure we close on the correct brace) while tokenizing the meta string as expected.

Test plan: pages reported in #7994 no longer crash on the next PR

Closes #7994
