### PR TITLE
docs: fix in link.md link style

### DIFF
--- a/src/content/reference/react-dom/components/link.md
+++ b/src/content/reference/react-dom/components/link.md
@@ -129,7 +129,9 @@ export default function BlogPage() {
 If a component depends on a certain stylesheet in order to be displayed correctly, you can render a link to that stylesheet within the component. Your component will [suspend](/reference/react/Suspense) while the stylesheet is loading. You must supply the `precedence` prop, which tells React where to place this stylesheet relative to others — stylesheets with higher precedence can override those with lower precedence.
 
 <Note>
+  
 When you want to use a stylesheet, it can be beneficial to call the [preinit](/reference/react-dom/preinit) function. Calling this function may allow the browser to start fetching the stylesheet earlier than if you just render a `<link>` component, for example by sending an [HTTP Early Hints response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103).
+
 </Note>
 
 <SandpackWithHTMLOutput>


### PR DESCRIPTION
[fix link](https://github.com/reactjs/react.dev/blob/main/src/content/reference/react-dom/components/link.md#linking-to-a-stylesheet-linking-to-a-stylesheet)
<img width="1032" height="217" alt="image" src="https://github.com/user-attachments/assets/8ee7e88d-987e-4e84-a343-8cde294a9190" />


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
