### PR TITLE
Fix ViewTransition example

### DIFF
--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -159,7 +159,11 @@ Enter/Exit Transitions trigger when a `<ViewTransition>` is added or removed by 
 
 ```js
 function Child() {
-  return <ViewTransition>Hi</ViewTransition>
+  return (
+    <ViewTransition>
+      <div>Hi</div>
+    </ViewTransition>
+  );
 }
 
 function Parent() {
@@ -352,11 +356,7 @@ button:hover {
 
 ```js [3, 5]
 function Component() {
-  return (
-    <div>
-      <ViewTransition>Hi</ViewTransition>
-    </div>
-  );
+  return <ViewTransition>Hi</ViewTransition>;
 }
 ```
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The first example shown in the `<ViewTransition>` docs actually did not work, since the `<ViewTransition>` element was not wrapping a DOM node. Updated the Pitfall section for more clarity as well.
