### PR TITLE
docs: fix symbol in prerenderToNodeStream.md

### DIFF
--- a/src/content/reference/react-dom/static/prerenderToNodeStream.md
+++ b/src/content/reference/react-dom/static/prerenderToNodeStream.md
@@ -4,7 +4,7 @@ title: prerenderToNodeStream
 
 <Intro>
 
-`prerenderToNodeStream` renders a React tree to a static HTML string using a [Node.js Stream.](https://nodejs.org/api/stream.html).
+`prerenderToNodeStream` renders a React tree to a static HTML string using a [Node.js Stream.](https://nodejs.org/api/stream.html)
 
 ```js
 const {prelude} = await prerenderToNodeStream(reactNode, options?)
@@ -85,7 +85,7 @@ The static `prerenderToNodeStream` API is used for static server-side generation
 
 ### Rendering a React tree to a stream of static HTML {/*rendering-a-react-tree-to-a-stream-of-static-html*/}
 
-Call `prerenderToNodeStream` to render your React tree to static HTML into a [Node.js Stream.](https://nodejs.org/api/stream.html):
+Call `prerenderToNodeStream` to render your React tree to static HTML into a [Node.js Stream](https://nodejs.org/api/stream.html):
 
 ```js [[1, 5, "<App />"], [2, 6, "['/main.js']"]]
 import { prerenderToNodeStream } from 'react-dom/static';


### PR DESCRIPTION
[link here](https://react.dev/reference/react-dom/static/prerenderToNodeStream)
<img width="966" height="68" alt="Image" src="https://github.com/user-attachments/assets/245c8922-bbf1-442c-8be2-9ead0f376f99" />

[link here](https://react.dev/reference/react-dom/static/prerenderToNodeStream#usage)
<img width="850" height="75" alt="Image" src="https://github.com/user-attachments/assets/2e8d84ff-779e-4a7d-86ed-2864c92a50d6" />

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
