### PR TITLE
Fix incorrect negative in use-memo intro

### DIFF
--- a/src/content/reference/eslint-plugin-react-hooks/lints/use-memo.md
+++ b/src/content/reference/eslint-plugin-react-hooks/lints/use-memo.md
@@ -5,7 +5,7 @@ version: rc
 
 <Intro>
 
-Validates usage of the `useMemo` hook without a return value. See [`useMemo` docs](/reference/react/useMemo) for more information.
+Validates that the `useMemo` hook is used with a return value. See [`useMemo` docs](/reference/react/useMemo) for more information.
 
 </Intro>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

From the examples, it appears that [the `react-hooks/use-memo` rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo) validates for `useMemo()` **with** a return value, not **without**.

cc @poteto fix for small error in #7986 

### Alternatives considered

I first considered wording it as a double negative:

```
Validates against usage of the `useMemo` hook without a return value.
```

But that seemed more confusing, so I went with flipping to a positive.