### PR TITLE
Fix "Purity" hydration error, add random content example

### DIFF
--- a/src/content/reference/eslint-plugin-react-hooks/lints/purity.md
+++ b/src/content/reference/eslint-plugin-react-hooks/lints/purity.md
@@ -62,6 +62,41 @@ function Component() {
 
 ## Troubleshooting {/*troubleshooting*/}
 
+### I need to show random content {/*random-content*/}
+
+Calling `Math.random()` during render makes your component impure:
+
+```js {expectedErrors: {'react-compiler': [7]}}
+const messages = ['a', 'b', 'c'];
+
+// ❌ Wrong: Random message changes every render
+function RandomMessage() {
+  return (
+    <div>
+      Random message: {messages[Math.floor(messages.length * Math.random())]}
+    </div>
+  );
+}
+```
+
+Instead, move the impure function into an effect:
+
+```js
+const messages = ['a', 'b', 'c'];
+
+function RandomMessage() {
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setMessage(messages[Math.floor(messages.length * Math.random())]);
+  }, []);
+
+  if (message === '') return;
+
+  return <div>Random message: {message}</div>;
+}
+```
+
 ### I need to show the current time {/*current-time*/}
 
 Calling `Date.now()` during render makes your component impure:
@@ -77,7 +112,7 @@ Instead, [move the impure function outside of render](/reference/rules/component
 
 ```js
 function Clock() {
-  const [time, setTime] = useState(() => Date.now());
+  const [time, setTime] = useState(0);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -86,6 +121,8 @@ function Clock() {
 
     return () => clearInterval(interval);
   }, []);
+
+  if (time === 0) return;
 
   return <div>Current time: {time}</div>;
 }


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The last example on [the `react-hooks/purity` rule docs](https://react.dev/reference/eslint-plugin-react-hooks/lints/purity) causes a hydration error when SSRed:

CodeSandbox: https://codesandbox.io/p/devbox/date-now-with-hydration-error-ntchmm?workspaceId=ws_GfAuHrswXyA1DoeSwsjjjz

<img width="2137" height="1365" alt="Screenshot 2025-10-01 at 10 47 10" src="https://github.com/user-attachments/assets/db4490e6-60ab-4e35-b406-3297fbb26c56" />

The `useState()` docs mention that the initializer function should be pure:

> If you pass a function as initialState, it will be treated as an initializer function. It should be pure,

- https://react.dev/reference/react/useState#parameters

### Suggested solution

1. Move the `Math.random()` call from the `useState()` initializer function to `useEffect()`
2. Initializing the state variable with `0` to avoid TypeScript type errors
3. Use early return to render nothing if state variable is set to `0`

CodeSandbox: https://codesandbox.io/p/devbox/date-now-without-hydration-error-lq5t8c?workspaceId=ws_GfAuHrswXyA1DoeSwsjjjz

<img width="2099" height="1280" alt="Screenshot 2025-10-01 at 10 58 07" src="https://github.com/user-attachments/assets/f210bb44-3aca-471e-b49e-c2cbd325fa6e" />


As part of this work, I also added an additional example for random content, which seems like a fairly common use case:

4. Create a `message` state variable, initializing with `''`
5. Set a random value of the state variable in `useEffect()`
6. Use early return to render nothing if the state variable is set to `''`

CodeSandbox: https://codesandbox.io/p/devbox/math-random-without-hydration-error-sjdcmh?file=%2Fapp%2FRandomMessage.tsx%3A7%2C16-17%2C2&workspaceId=ws_GfAuHrswXyA1DoeSwsjjjz

<img width="2103" height="1284" alt="Screenshot 2025-10-01 at 11 11 50" src="https://github.com/user-attachments/assets/9a86d283-5a1c-45f6-8479-2838fbec1533" />

cc @poteto @josephsavona 

### Additional notes

If the change to the `Date.now()` example is accepted, then it probably should also be changed in the example on this page:

- Components and Hooks must be pure -> Components and Hooks must be idempotent https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent

### Alternatives considered

A) Leaving out the early return - this would cause Flash of Unhydrated Content as the page loads, which is probably undesirable (could be changed to a loading message, but that seems out of scope)
B) Different approach: using `next/dynamic` with `ssr: false` (downside: this requires an additional Client Component in between, because `ssr: false` cannot be used in the `page.tsx`, because it's a Server Component)