### PR TITLE
fix: replace hardcoded sidebar width (342px) with responsive Tailwind…

### DIFF
--- a/src/components/Layout/SidebarNav/SidebarNav.tsx
+++ b/src/components/Layout/SidebarNav/SidebarNav.tsx
@@ -41,7 +41,7 @@ export default function SidebarNav({
         'sticky top-0 lg:bottom-0 lg:h-[calc(100vh-4rem)] flex flex-col'
       )}>
       <div
-        className="overflow-y-scroll no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark"
+        className="overflow-y-scroll no-bg-scrollbar lg:w-80 grow bg-wash dark:bg-wash-dark"
         style={{
           overscrollBehavior: 'contain',
         }}>

--- a/src/components/Layout/TopNav/TopNav.tsx
+++ b/src/components/Layout/TopNav/TopNav.tsx
@@ -403,7 +403,7 @@ export default function TopNav({
         {isMenuOpen && (
           <div
             ref={scrollParentRef}
-            className="overflow-y-scroll isolate no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark">
+            className="overflow-y-scroll isolate no-bg-scrollbar lg:w-80 grow bg-wash dark:bg-wash-dark">
             <aside
               className={cn(
                 `lg:grow lg:flex flex-col w-full pb-8 lg:pb-0 lg:max-w-custom-xs z-40`,


### PR DESCRIPTION
### Summary
Replaced the hardcoded sidebar width (`lg:w-[342px]`) with Tailwind’s responsive utility (`lg:w-80`).  
This prevents overflow issues in **Firefox** and ensures better cross-browser consistency.  

### Related Issue
Fixes #7976  

### Changes
- Updated `SidebarNav.tsx` and `TopNav.tsx` to remove arbitrary `lg:w-[342px]`
- Replaced with `lg:w-80` (closest Tailwind equivalent) for responsive and accessible layout  

### Before/After
- **Before (Firefox)**: Sidebar overflowed onto main content  
- **After**: Sidebar aligns correctly and no longer overlaps  
