### PR TITLE
Use stable release in demos with HTML output

### DIFF
--- a/src/components/MDX/SandpackWithHTMLOutput.tsx
+++ b/src/components/MDX/SandpackWithHTMLOutput.tsx
@@ -56,8 +56,8 @@ export default function formatHTML(markup) {
 const packageJSON = `
 {
   "dependencies": {
-    "react": "18.3.0-canary-6db7f4209-20231021",
-    "react-dom": "18.3.0-canary-6db7f4209-20231021",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-scripts": "^5.0.0",
     "html-format": "^1.1.2"
   },


### PR DESCRIPTION
Still broken when trying to resolve `scheduler` but that's the same error as everywhere. This at least makes the forks make sense.

Preview: https://react-i6r6c6cll-fbopensource.vercel.app/reference/react-dom/components/link#linking-to-related-resources

These demos use a separate template that was still using v18 Canaries. The behavior they were demoing has been shipped in 19.0.

Using ^19.1 here to match current sandpacks. https://github.com/reactjs/react.dev/pull/8037 will update it to 19.2 once that's possible.