### PR TITLE
docs: Change a Action to an Action in useOptimistic.md

### DIFF
--- a/src/content/reference/react/useOptimistic.md
+++ b/src/content/reference/react/useOptimistic.md
@@ -83,7 +83,7 @@ function handleClick() {
 
 #### How optimistic state works {/*how-optimistic-state-works*/}
 
-`useOptimistic` lets you show a temporary value while a Action is in progress:
+`useOptimistic` lets you show a temporary value while an Action is in progress:
 
 ```js
 const [value, setValue] = useState('a');


### PR DESCRIPTION
## Summary

This PR fixes a grammar error in the `useOptimistic` documentation where "a Action" should be "an Action" since "Action" starts with a vowel sound.

## Changes

- Changed "a Action" to "an Action" in `src/content/reference/react/useOptimistic.md`

## Related Issue

Related to #6713 - Capitalize React concepts in docs

## Checklist

- [x] I have tested the changes (documentation only)
- [x] I have followed the contribution guidelines
