### PR TITLE
a11y: Add skip to main content link for keyboard navigation

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -148,6 +148,12 @@ export function Page({
         routeTree={routeTree}
         breadcrumbs={breadcrumbs}
       />
+      {/* Skip to main content link for accessibility */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:dark:bg-gray-900 focus:text-primary focus:dark:text-primary-dark focus:p-3 focus:rounded focus:border focus:border-border focus:dark:border-border-dark">
+        Skip to main content
+      </a>
       <div
         className={cn(
           hasColumns &&
@@ -166,7 +172,7 @@ export function Page({
         )}
         {/* No fallback UI so need to be careful not to suspend directly inside. */}
         <Suspense fallback={null}>
-          <main className="min-w-0 isolate">
+          <main id="main-content" className="min-w-0 isolate">
             <article
               className="font-normal break-words text-primary dark:text-primary-dark"
               key={asPath}>


### PR DESCRIPTION
## Summary

This PR adds a "Skip to main content" link to improve keyboard navigation accessibility on react.dev.

## Changes

- Added a visually hidden skip link at the top of the page that becomes visible when focused
- Added `id="main-content"` to the main content area for the skip link target
- Used Tailwind's `sr-only` and `focus:` utilities for the implementation

## Accessibility Impact

This addresses **WCAG 2.4.1 (Level A) - Bypass Blocks**:

> A mechanism is available to bypass blocks of content that are repeated on multiple Web pages.

Keyboard-only users previously had to tab through the entire navigation on every page load before reaching the main content. This is especially impactful on a documentation site where users navigate between many pages.

## Testing

1. Navigate to any page on the site
2. Press Tab key - the "Skip to main content" link should appear
3. Press Enter - focus should jump to the main content area

## Related Issue

Related to #8360

## Screenshot

When focused, the skip link appears in the top-left corner of the page.
