### PR TITLE
docs: use parameter instead of argument in tic-tac-toe tutorial

### DIFF
--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -1138,7 +1138,7 @@ JavaScript supports [closures](https://developer.mozilla.org/en-US/docs/Web/Java
 
 </Note>
 
-Now you can add X's to the board...  but only to the upper left square. Your `handleClick` function is hardcoded to update the index for the upper left square (`0`). Let's update `handleClick` to be able to update any square. Add an argument `i` to the `handleClick` function that takes the index of the square to update:
+Now you can add X's to the board...  but only to the upper left square. Your `handleClick` function is hardcoded to update the index for the upper left square (`0`). Let's update `handleClick` to be able to update any square. Add a parameter `i` to the `handleClick` function that takes the index of the square to update:
 
 ```js {4,6}
 export default function Board() {


### PR DESCRIPTION
## Summary

Closes #8375

In the tic-tac-toe tutorial, the text incorrectly called `i` in `function handleClick(i)` an "argument" when it is a parameter in a function definition.

This PR updates one sentence to say "Add a parameter `i`" instead of "Add an argument `i`", matching standard JavaScript terminology.

## Before / After

**Before:** "Add an argument `i` to the `handleClick` function"

**After:** "Add a parameter `i` to the `handleClick` function"