### PR TITLE
Fix broken anchor link for async components on the client

### DIFF
--- a/src/content/reference/rsc/server-components.md
+++ b/src/content/reference/rsc/server-components.md
@@ -293,4 +293,12 @@ function Comments({commentsPromise}) {
 
 The `note` content is important data for the page to render, so we `await` it on the server. The comments are below the fold and lower-priority, so we start the promise on the server, and wait for it on the client with the `use` API. This will Suspend on the client, without blocking the `note` content from rendering.
 
-Since async components are not supported on the client, we await the promise with `use`.
+Since async components are [not supported on the client](#why-cant-i-use-async-components-on-the-client), we await the promise with `use`.
+
+<Note>
+
+#### Why can't I use async components on the client? {/*why-cant-i-use-async-components-on-the-client*/}
+
+Async components are a Server Component feature. Client Components need to run synchronously so they can use Hooks and respond to interactions. To wait for async data on the client, pass a Promise from a Server Component and read it with [`use`](/reference/react/use) instead.
+
+</Note>


### PR DESCRIPTION
## Summary

Closes #7305

The Server Components docs referenced a `#why-cant-i-use-async-components-on-the-client` anchor that did not exist, resulting in a broken in-page link.

This PR adds the missing section with a `Note` explaining why async components are a Server Component feature and how to use `use()` on the client instead.

## Before / After

**Before:** Link to `#why-cant-i-use-async-components-on-the-client` with no matching section on the page.

**After:** Link resolves to a new `Note` section titled "Why can't I use async components on the client?" with the anchor `{/*why-cant-i-use-async-components-on-the-client*/}`.

## Type of change

- [x] Documentation fix (broken link / missing note)