### PR TITLE
docs: improve wording on Your First Component page

### DIFF
--- a/src/content/learn/your-first-component.md
+++ b/src/content/learn/your-first-component.md
@@ -18,7 +18,7 @@ title: Your First Component
 
 ## Components: UI building blocks {/*components-ui-building-blocks*/}
 
-On the Web, HTML lets us create rich structured documents with its built-in set of tags like `<h1>` and `<li>`:
+On the Web, HTML allows us to create rich, structured documents with its built-in set of tags like `<h1>` and `<li>`:
 
 ```html
 <article>


### PR DESCRIPTION
## Summary

Closes #7269

The Your First Component page used informal wording ("lets") and omitted a comma in a compound adjective phrase, reducing clarity for technical documentation.

This PR replaces "lets" with "allows" and adds a comma in "rich, structured documents" for a more formal, precise tone.

## Before / After

**Before:** "HTML lets us create rich structured documents"

**After:** "HTML allows us to create rich, structured documents"

## Page

https://react.dev/learn/your-first-component