### PR TITLE
docs: fix curly quotes around Mirroring on state structure page

### DIFF
--- a/src/content/learn/choosing-the-state-structure.md
+++ b/src/content/learn/choosing-the-state-structure.md
@@ -355,7 +355,7 @@ function Message({ messageColor }) {
 
 Here, a `color` state variable is initialized to the `messageColor` prop. The problem is that **if the parent component passes a different value of `messageColor` later (for example, `'red'` instead of `'blue'`), the `color` *state variable* would not be updated!** The state is only initialized during the first render.
 
-This is why "mirroring" some prop in a state variable can lead to confusion. Instead, use the `messageColor` prop directly in your code. If you want to give it a shorter name, use a constant:
+This is why “mirroring” some prop in a state variable can lead to confusion. Instead, use the `messageColor` prop directly in your code. If you want to give it a shorter name, use a constant:
 
 ```js
 function Message({ messageColor }) {
@@ -364,7 +364,7 @@ function Message({ messageColor }) {
 
 This way it won't get out of sync with the prop passed from the parent component.
 
-"Mirroring" props into state only makes sense when you *want* to ignore all updates for a specific prop. By convention, start the prop name with `initial` or `default` to clarify that its new values are ignored:
+“Mirroring” props into state only makes sense when you *want* to ignore all updates for a specific prop. By convention, start the prop name with `initial` or `default` to clarify that its new values are ignored:
 
 ```js
 function Message({ initialColor }) {


### PR DESCRIPTION
## Summary

Closes #7913

On the Choosing the State Structure page, straight ASCII quotes around "Mirroring" were converted by the smartypants plugin into two closing curly quotes (`"Mirroring"`), which is a typographic error.

This PR replaces them with explicit opening and closing curly quotes in the source so they render correctly as `"Mirroring"`, and fixes the same issue for lowercase "mirroring" in the preceding paragraph.

## Before / After

**Before:** `"Mirroring"` and `"mirroring"` (both closing curly quotes)

**After:** `"Mirroring"` and `"mirroring"` (opening + closing curly quotes)

## Page

https://react.dev/learn/choosing-the-state-structure