### PR TITLE
docs: document fetchPriority support for preloadModule and preinitModule

### DIFF
--- a/src/content/reference/react-dom/preinitModule.md
+++ b/src/content/reference/react-dom/preinitModule.md
@@ -50,6 +50,7 @@ The `preinitModule` function provides the browser with a hint that it should sta
   *  `crossOrigin`: a string. The [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) to use. Its possible values are `anonymous` and `use-credentials`.
   *  `integrity`: a string. A cryptographic hash of the module, to [verify its authenticity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).
   *  `nonce`: a string. A cryptographic [nonce to allow the module](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) when using a strict Content Security Policy.
+  *  `fetchPriority`: a string. Suggests a relative priority for fetching the resource. The possible values are `auto` (the default), `high`, and `low`.
 
 #### Returns {/*returns*/}
 

--- a/src/content/reference/react-dom/preloadModule.md
+++ b/src/content/reference/react-dom/preloadModule.md
@@ -50,6 +50,7 @@ The `preloadModule` function provides the browser with a hint that it should sta
   *  `crossOrigin`: a string. The [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) to use. Its possible values are `anonymous` and `use-credentials`.
   *  `integrity`: a string. A cryptographic hash of the module, to [verify its authenticity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).
   *  `nonce`: a string. A cryptographic [nonce to allow the module](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) when using a strict Content Security Policy.
+  *  `fetchPriority`: a string. Suggests a relative priority for fetching the resource. The possible values are `auto` (the default), `high`, and `low`.
 
 
 #### Returns {/*returns*/}


### PR DESCRIPTION
This PR documents the `fetchPriority` option for the ESM module resource-loading APIs (`preloadModule` and `preinitModule`) in the React DOM reference, following its addition in `react/react#36835`.

### Changes

- Added documentation for the `fetchPriority` option under the `options` parameter in `src/content/reference/react-dom/preloadModule.md`.
- Added documentation for the `fetchPriority` option under the `options` parameter in `src/content/reference/react-dom/preinitModule.md`.

Closes #8498