### PR TITLE
Update form documentation for forms default reset behavior

### DIFF
--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -95,7 +95,7 @@ When you pass a function to `action`, React:
 * Propagates any errors to the nearest error boundary.
 * Resets the form's uncontrolled fields when the function succeeds. To keep their values, see [Preserving form values after submission](#preserve-form-values-after-submission).
 
-Because the action runs in a Transition, you can also use [`useActionState`](/reference/react/useActionState) to manage form state and [`useOptimistic`](/reference/react/useOptimistic) for optimistic UI.
+Because the Action runs in a Transition, you can also use [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) for submission status, [`useActionState`](/reference/react/useActionState) to manage form state, and [`useOptimistic`](/reference/react/useOptimistic) for optimistic UI.
 
 <Sandpack>
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -202,7 +202,7 @@ Because you call the action manually from `onSubmit`, [`useFormStatus`](/referen
 
 <DeepDive>
 
-#### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
+#### Reset only some fields, or reset on the server {/*resetting-only-some-fields*/}
 
 The `onSubmit` approach keeps every uncontrolled field. When you need finer control, two other patterns are available:
 
@@ -276,7 +276,7 @@ export async function submitForm(query) {
 
 To learn more about the `useFormStatus` Hook see the [reference documentation](/reference/react-dom/hooks/useFormStatus).
 
-### Optimistically updating form data {/*optimistically-updating-form-data*/}
+### Optimistically update form data {/*optimistically-updating-form-data*/}
 The `useOptimistic` Hook provides a way to optimistically update the user interface before a background operation, like a network request, completes. In the context of forms, this technique helps to make apps feel more responsive. When a user submits a form, instead of waiting for the server's response to reflect the changes, the interface is immediately updated with the expected outcome.
 
 For example, when a user types a message into the form and hits the "Send" button, the `useOptimistic` Hook allows the message to immediately appear in the list with a "Sending..." label, even before the message is actually sent to a server. This "optimistic" approach gives the impression of speed and responsiveness. The form then attempts to truly send the message in the background. Once the server confirms the message has been received, the "Sending..." label is removed.
@@ -346,7 +346,7 @@ export async function deliverMessage(message) {
 [//]: # 'Uncomment the next line, and delete this line after the `useOptimistic` reference documentation page is published'
 [//]: # 'To learn more about the `useOptimistic` Hook see the [reference documentation](/reference/react/useOptimistic).'
 
-### Handling form submission errors {/*handling-form-submission-errors*/}
+### Handle form submission errors {/*handling-form-submission-errors*/}
 
 In some cases the function called by a `<form>`'s `action` prop throws an error. You can handle these errors by wrapping `<form>` in an Error Boundary. If the function called by a `<form>`'s `action` prop throws an error, the fallback for the error boundary will be displayed.
 
@@ -446,7 +446,7 @@ export async function signUpNewUser(newEmail) {
 
 Learn more about updating state from a form action with the [`useActionState`](/reference/react/useActionState) docs
 
-### Handling multiple submission types {/*handling-multiple-submission-types*/}
+### Handle multiple submission types {/*handling-multiple-submission-types*/}
 
 A form can have more than one submit button, each running a different action. Set the `formAction` prop on a `<button>` to override the `<form>`'s `action` when that button submits the form.
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -472,7 +472,6 @@ export default function ArticleForm() {
     const content = payload.data.get('content');
     switch (payload.type) {
       case 'save':
-
         alert(`Your draft of '${content}' was saved!`);
         // Keep the submitted content as the current draft
         return payload.data;
@@ -481,23 +480,22 @@ export default function ArticleForm() {
         // reset the form
         return new FormData();
     }
-  });
+  }, new FormData());
 
   function publish(formData) {
     dispatchFormState({
       type: 'publish',
       data: formData
-    })
+    });
   }
 
   function save(formData) {
     dispatchFormState({
       type: 'save',
       data: formData
-    })
+    });
   }
 
-  // const savedContent = draft.get('content') || '';
   return (
     <form action={publish}>
       <textarea

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -43,13 +43,13 @@ To create interactive controls for submitting information, render the [built-in 
 #### Caveats {/*caveats*/}
 
 * When a function is passed to `action` or `formAction` the HTTP method will be POST regardless of the value of the `method` prop.
-* When a function is passed to `action` or `formAction`, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements after the action succeeds. See [Preserve form values after submission](#preserve-form-values-after-submission).
+* When a function is passed to `action` or `formAction`, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements after the action succeeds. See [Preserving form values after submission](#preserve-form-values-after-submission).
 
 ---
 
 ## Usage {/*usage*/}
 
-### Handle form submission with an event handler {/*handle-form-submission-with-an-event-handler*/}
+### Handling form submission with an event handler {/*handle-form-submission-with-an-event-handler*/}
 
 Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Call [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in your handler to override that behavior. Read the submitted data with [`new FormData(e.target)`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
 
@@ -82,9 +82,9 @@ Reading form data with `onSubmit` works in every version of React and gives you 
 
 </Note>
 
-### Handle form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
+### Handling form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
 
-Pass a function to the `action` prop of form to run the function when the form is submitted. [`formData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) will be passed to the function as an argument so you can access the data submitted by the form. This differs from the conventional [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts URLs. Unlike `onSubmit`, an `action` runs in a [Transition](/reference/react/useTransition) and calling `e.preventDefault()` isn't needed. After the `action` function succeeds, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements in the form. To keep their values, see [Preserve form values after submission](#preserve-form-values-after-submission).
+Pass a function to the `action` prop of form to run the function when the form is submitted. [`formData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) will be passed to the function as an argument so you can access the data submitted by the form. This differs from the conventional [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts URLs. Unlike `onSubmit`, an `action` runs in a [Transition](/reference/react/useTransition) and calling `e.preventDefault()` isn't needed. After the `action` function succeeds, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements in the form. To keep their values, see [Preserving form values after submission](#preserve-form-values-after-submission).
 
 <Sandpack>
 
@@ -106,7 +106,7 @@ export default function Search() {
 </Sandpack>
 
 
-### Handle form submission with a Server Function {/*handle-form-submission-with-a-server-function*/}
+### Handling form submission with a Server Function {/*handle-form-submission-with-a-server-function*/}
 
 Render a `<form>` with an input and submit button. Pass a Server Function (a function marked with [`'use server'`](/reference/rsc/use-server)) to the `action` prop of form to run the function when the form is submitted.
 
@@ -153,7 +153,8 @@ function AddToCart({productId}) {
 ```
 
 When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), and a [Server Function](/reference/rsc/server-functions) is passed to the `<form>`'s `action` prop, the form is [progressively enhanced](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement).
-### Preserve form values after submission {/*preserve-form-values-after-submission*/}
+
+### Preserving form values after submission {/*preserve-form-values-after-submission*/}
 
 The browser clears a form's input state on submit. A URL `action` follows this same behavior. React does the same when `action` is a function, so your form works consistently before and after JavaScript loads.
 
@@ -202,7 +203,7 @@ Because you call the action manually from `onSubmit`, [`useFormStatus`](/referen
 
 <DeepDive>
 
-#### Reset only some fields, or reset on the server {/*resetting-only-some-fields*/}
+#### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
 
 The `onSubmit` approach keeps every uncontrolled field. When you need finer control, two other patterns are available:
 
@@ -233,7 +234,7 @@ Return the original `FormData` object rather than a new one so React can restore
 </DeepDive>
 
 
-### Display a pending state during form submission {/*display-a-pending-state-during-form-submission*/}
+### Displaying a pending state during form submission {/*display-a-pending-state-during-form-submission*/}
 To display a pending state when a form is being submitted, you can call the `useFormStatus` Hook in a component rendered in a `<form>` and read the `pending` property returned.
 
 Here, we use the `pending` property to indicate the form is submitting.
@@ -276,7 +277,7 @@ export async function submitForm(query) {
 
 To learn more about the `useFormStatus` Hook see the [reference documentation](/reference/react-dom/hooks/useFormStatus).
 
-### Optimistically update form data {/*optimistically-updating-form-data*/}
+### Optimistically updating form data {/*optimistically-updating-form-data*/}
 The `useOptimistic` Hook provides a way to optimistically update the user interface before a background operation, like a network request, completes. In the context of forms, this technique helps to make apps feel more responsive. When a user submits a form, instead of waiting for the server's response to reflect the changes, the interface is immediately updated with the expected outcome.
 
 For example, when a user types a message into the form and hits the "Send" button, the `useOptimistic` Hook allows the message to immediately appear in the list with a "Sending..." label, even before the message is actually sent to a server. This "optimistic" approach gives the impression of speed and responsiveness. The form then attempts to truly send the message in the background. Once the server confirms the message has been received, the "Sending..." label is removed.
@@ -344,7 +345,7 @@ export async function deliverMessage(message) {
 </Sandpack>
 To learn more about the `useOptimistic` Hook see the [reference documentation](/reference/react/useOptimistic).
 
-### Handle form submission errors {/*handling-form-submission-errors*/}
+### Handling form submission errors {/*handling-form-submission-errors*/}
 
 In some cases the function called by a `<form>`'s `action` prop throws an error. You can handle these errors by wrapping `<form>` in an Error Boundary. If the function called by a `<form>`'s `action` prop throws an error, the fallback for the error boundary will be displayed.
 
@@ -386,7 +387,7 @@ export default function Search() {
 
 </Sandpack>
 
-### Display a form submission error without JavaScript {/*display-a-form-submission-error-without-javascript*/}
+### Displaying a form submission error without JavaScript {/*display-a-form-submission-error-without-javascript*/}
 
 Displaying a form submission error message before the JavaScript bundle loads for progressive enhancement requires that:
 
@@ -444,7 +445,7 @@ export async function signUpNewUser(newEmail) {
 
 Learn more about updating state from a form action with the [`useActionState`](/reference/react/useActionState) docs
 
-### Handle multiple submission types {/*handling-multiple-submission-types*/}
+### Handling multiple submission types {/*handling-multiple-submission-types*/}
 
 A form can have more than one submit button, each running a different action. Set the `formAction` prop on a `<button>` to override the `<form>`'s `action` when that button submits the form.
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -38,7 +38,7 @@ To create interactive controls for submitting information, render the [built-in 
 
 `<form>` supports all [common element props.](/reference/react-dom/components/common#common-props)
 
-[`action`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action): a URL or function. When a URL is passed to `action` the form will behave like the [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form#action). When a function is passed to `action` the function will handle the form submission in a Transition following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components). The function passed to `action` may be async and will be called with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form. The `action` prop can be overridden by a `formAction` attribute on a `<button>`, `<input type="submit">`, or `<input type="image">` component.
+`action`: a URL or function. When a URL is passed to `action` the form will behave like the [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action). When a function is passed to `action` the function will handle the form submission in a Transition following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components). The function passed to `action` may be async and will be called with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form. The `action` prop can be overridden by a `formAction` attribute on a `<button>`, `<input type="submit">`, or `<input type="image">` component.
 
 #### Caveats {/*caveats*/}
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -38,7 +38,7 @@ To create interactive controls for submitting information, render the [built-in 
 
 `<form>` supports all [common element props.](/reference/react-dom/components/common#common-props)
 
-`action`: a URL or function. When a URL is passed to `action` the form will behave like the [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action). When a function is passed to `action` the function will handle the form submission in a Transition following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components). The function passed to `action` may be async and will be called with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form. The `action` prop can be overridden by a `formAction` attribute on a `<button>`, `<input type="submit">`, or `<input type="image">` component.
+[`action`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action): a URL or function. When a URL is passed to `action` the form will behave like the HTML form component. When a function is passed to `action` the function will handle the form submission in a Transition following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components). The function passed to `action` may be async and will be called with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form. The `action` prop can be overridden by a `formAction` attribute on a `<button>`, `<input type="submit">`, or `<input type="image">` component.
 
 #### Caveats {/*caveats*/}
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -84,20 +84,18 @@ Reading form data with `onSubmit` works in every version of React and gives you 
 
 ### Handling form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
 
-Pass a function to the `action` prop of `<form>` to handle submission. When the form is submitted, React calls your function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the field values.
+Pass a function to the `action` prop to run it when the form is submitted. React calls the function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the values of every input with a `name` attribute. This means your inputs can be [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) - no need for `value`/`onChange` pairs, `onSubmit` handler, or `e.preventDefault()`.
 
-Give each input a `name` attribute so its value is included in `FormData`. You can use [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) inputs instead of controlled `value`/`onChange` pairs, and you don't need an `onSubmit` handler or `e.preventDefault()`.
-
-This extends the [HTML `action` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts a URL, to also accept a function. Because the form stays a native HTML form, it can be submitted before JavaScript loads; with a [Server Function](/reference/rsc/server-functions), it works without JavaScript enabled.
+When the `action` prop is a [Server Function](/reference/rsc/server-functions), the form is progressively enhanced: submission works before JavaScript loads, and even with JavaScript disabled.
 
 When you pass a function to `action`, React:
 
-* Runs the submission function in a [Transition](/reference/react/useTransition).
-* Tracks pending state so child components can read it with [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
-* Sends thrown errors to the nearest error boundary.
-* Works with [`useActionState`](/reference/react/useActionState) and [`useOptimistic`](/reference/react/useOptimistic) for form state and optimistic UI.
+* Runs the function in a [Transition](/reference/react/useTransition), keeping the page responsive.
+* Makes the pending state available to child components via [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
+* Propagates any errors to the nearest error boundary.
+* Resets the form's uncontrolled fields when the function succeeds. To keep their values, see [Preserving form values after submission](#preserve-form-values-after-submission).
 
-After the function succeeds, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements in the form. To keep their values, see [Preserving form values after submission](#preserve-form-values-after-submission).
+Because the action runs in a Transition, you can also use [`useActionState`](/reference/react/useActionState) to manage form state and [`useOptimistic`](/reference/react/useOptimistic) for optimistic UI.
 
 <Sandpack>
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -51,20 +51,14 @@ To create interactive controls for submitting information, render the [built-in 
 
 ### Handle form submission with an event handler {/*handle-form-submission-with-an-event-handler*/}
 
-Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page, so call [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) to override that behavior.
+Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Call [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in your handler to override that behavior. Read the submitted data with [`new FormData(e.target)`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
 
-This example reads the submitted values with [`new FormData(e.target)`](https://developer.mozilla.org/en-US/docs/Web/API/FormData), which collects every field by its `name`. This keeps the inputs [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form). If you instead [control an input with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable), read from that state on submit rather than from `FormData`.
 
 <Sandpack>
 
 ```js src/App.js
 export default function Search() {
   function handleSubmit(e) {
-    // Prevent the default browser behavior
-    // of reloading the page and resetting the form
-    e.preventDefault();
-
-    // Read the form data
     const form = e.target;
     const formData = new FormData(form);
     const query = formData.get("query");
@@ -111,6 +105,54 @@ export default function Search() {
 
 </Sandpack>
 
+
+### Handle form submission with a Server Function {/*handle-form-submission-with-a-server-function*/}
+
+Render a `<form>` with an input and submit button. Pass a Server Function (a function marked with [`'use server'`](/reference/rsc/use-server)) to the `action` prop of form to run the function when the form is submitted.
+
+Passing a Server Function to `<form action>` allow users to submit forms without JavaScript enabled or before the code has loaded. This is beneficial to users who have a slow connection, device, or have JavaScript disabled and is similar to the way forms work when a URL is passed to the `action` prop.
+
+You can use hidden form fields to provide data to the `<form>`'s action. The Server Function will be called with the hidden form field data as an instance of [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
+
+```jsx
+import { updateCart } from './lib.js';
+
+function AddToCart({productId}) {
+  async function addToCart(formData) {
+    'use server'
+    const productId = formData.get('productId')
+    await updateCart(productId)
+  }
+  return (
+    <form action={addToCart}>
+        <input type="hidden" name="productId" value={productId} />
+        <button type="submit">Add to Cart</button>
+    </form>
+
+  );
+}
+```
+
+In lieu of using hidden form fields to provide data to the `<form>`'s action, you can call the <CodeStep step={1}>`bind`</CodeStep> method to supply it with extra arguments. This will bind a new argument (<CodeStep step={2}>`productId`</CodeStep>) to the function in addition to the <CodeStep step={3}>`formData`</CodeStep> that is passed as an argument to the function.
+
+```jsx [[1, 8, "bind"], [2,8, "productId"], [2,4, "productId"], [3,4, "formData"]]
+import { updateCart } from './lib.js';
+
+function AddToCart({productId}) {
+  async function addToCart(productId, formData) {
+    "use server";
+    await updateCart(productId)
+  }
+  const addProductToCart = addToCart.bind(null, productId);
+  return (
+    <form action={addProductToCart}>
+      <button type="submit">Add to Cart</button>
+    </form>
+  );
+}
+```
+
+When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), and a [Server Function](/reference/rsc/server-functions) is passed to the `<form>`'s `action` prop, the form is [progressively enhanced](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement).
 ### Preserve form values after submission {/*preserve-form-values-after-submission*/}
 
 The browser clears a form's input state on submit. A URL `action` follows this same behavior. React does the same when `action` is a function, so your form works consistently before and after JavaScript loads.
@@ -190,53 +232,6 @@ Return the original `FormData` object rather than a new one so React can restore
 
 </DeepDive>
 
-### Handle form submission with a Server Function {/*handle-form-submission-with-a-server-function*/}
-
-Render a `<form>` with an input and submit button. Pass a Server Function (a function marked with [`'use server'`](/reference/rsc/use-server)) to the `action` prop of form to run the function when the form is submitted.
-
-Passing a Server Function to `<form action>` allow users to submit forms without JavaScript enabled or before the code has loaded. This is beneficial to users who have a slow connection, device, or have JavaScript disabled and is similar to the way forms work when a URL is passed to the `action` prop.
-
-You can use hidden form fields to provide data to the `<form>`'s action. The Server Function will be called with the hidden form field data as an instance of [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
-
-```jsx
-import { updateCart } from './lib.js';
-
-function AddToCart({productId}) {
-  async function addToCart(formData) {
-    'use server'
-    const productId = formData.get('productId')
-    await updateCart(productId)
-  }
-  return (
-    <form action={addToCart}>
-        <input type="hidden" name="productId" value={productId} />
-        <button type="submit">Add to Cart</button>
-    </form>
-
-  );
-}
-```
-
-In lieu of using hidden form fields to provide data to the `<form>`'s action, you can call the <CodeStep step={1}>`bind`</CodeStep> method to supply it with extra arguments. This will bind a new argument (<CodeStep step={2}>`productId`</CodeStep>) to the function in addition to the <CodeStep step={3}>`formData`</CodeStep> that is passed as an argument to the function.
-
-```jsx [[1, 8, "bind"], [2,8, "productId"], [2,4, "productId"], [3,4, "formData"]]
-import { updateCart } from './lib.js';
-
-function AddToCart({productId}) {
-  async function addToCart(productId, formData) {
-    "use server";
-    await updateCart(productId)
-  }
-  const addProductToCart = addToCart.bind(null, productId);
-  return (
-    <form action={addProductToCart}>
-      <button type="submit">Add to Cart</button>
-    </form>
-  );
-}
-```
-
-When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), and a [Server Function](/reference/rsc/server-functions) is passed to the `<form>`'s `action` prop, the form is [progressively enhanced](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement).
 
 ### Display a pending state during form submission {/*display-a-pending-state-during-form-submission*/}
 To display a pending state when a form is being submitted, you can call the `useFormStatus` Hook in a component rendered in a `<form>` and read the `pending` property returned.

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -167,11 +167,11 @@ When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), an
 
 ### Preserving form values after submission {/*preserve-form-values-after-submission*/}
 
-The browser clears a form's input state on submit. A URL `action` follows this same behavior. React does the same when `action` is a function, so your form works consistently before and after JavaScript loads.
+By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function-ensuring your form behaves consistently both before and after JavaScript loads.
 
-When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the action succeeds. The reset only applies to uncontrolled fields, so [inputs you control with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
+When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the action succeeds. This reset only affects uncontrolled fields—[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
 
-To keep the values of uncontrolled fields, add an `onSubmit` handler that calls `e.preventDefault()` and runs the action inside a [Transition](/reference/react/useTransition). Keep the `action` prop on the form so it still works before JavaScript loads.
+To preserve the values of uncontrolled fields after submission, add an `onSubmit` handler that calls `e.preventDefault()` and runs the action inside a [Transition](/reference/react/useTransition). Keep the `action` prop on the form so it continues to work before JavaScript loads.
 
 <Sandpack>
 
@@ -210,8 +210,6 @@ export async function submitForm(formData) {
 
 </Sandpack>
 
-Because you call the action manually from `onSubmit`, [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) won't report its pending state. Read `isPending` from the same [`useTransition`](/reference/react/useTransition) call instead.
-
 <DeepDive>
 
 #### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
@@ -228,11 +226,12 @@ import { submitForm } from "./actions.js";
 
 function EditForm() {
   // The action returns { submitted: formData, error } on failure
-  const [state, formAction] = useActionState(submitForm, {});
-  const values = state.submitted ?? new FormData();
+  const [state, formAction] = useActionState(submitForm, {
+    error: '',
+  });
   return (
     <form action={formAction}>
-      <input name="title" defaultValue={values.get("title") ?? ""} />
+      <input name="title" defaultValue={state.submitted?.get("title") ?? ""} />
       {state.error && <p>{state.error}</p>}
       <button type="submit">Save</button>
     </form>

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -165,177 +165,6 @@ function AddToCart({productId}) {
 
 When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), and a [Server Function](/reference/rsc/server-functions) is passed to the `<form>`'s `action` prop, the form is [progressively enhanced](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement).
 
-### Preserving form values after submission {/*preserve-form-values-after-submission*/}
-
-By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function-ensuring your form behaves consistently both before and after JavaScript loads.
-
-When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields—[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
-
-<Recipes titleText="Examples of preserving form values" titleId="examples-preserve-form-values">
-
-#### With `onSubmit` {/*with-onsubmit*/}
-
-Handle submission in an `onSubmit` handler and call `e.preventDefault()` to stop the browser from navigating and refreshing the page.
-
-<Sandpack>
-
-```js src/App.js
-import { useState } from "react";
-import { submitForm } from "./api.js";
-
-export default function EditForm() {
-  const [isPending, setIsPending] = useState(false);
-
-  async function handleSubmit(e) {
-    e.preventDefault();
-    const formData = new FormData(e.target);
-    setIsPending(true);
-    try {
-      await submitForm(formData);
-    } finally {
-      setIsPending(false);
-    }
-  }
-
-  return (
-    <form onSubmit={handleSubmit}>
-      <input name="title" defaultValue="My draft" />
-      <button type="submit" disabled={isPending}>
-        {isPending ? "Saving..." : "Save"}
-      </button>
-    </form>
-  );
-}
-```
-
-```js src/api.js hidden
-export async function submitForm(formData) {
-  await new Promise((res) => setTimeout(res, 1000));
-}
-```
-
-</Sandpack>
-
-<Solution />
-
-#### With `onSubmit` and `useTransition` {/*with-onsubmit-and-usetransition*/}
-
-If you also pass a function to the `action` prop—for example, to support [progressive enhancement](/reference/rsc/server-functions)—add an `onSubmit` handler that calls `e.preventDefault()` and runs the Action inside a [Transition](/reference/react/useTransition).
-
-<Sandpack>
-
-```js src/App.js
-import { useTransition } from "react";
-import { submitForm } from "./api.js";
-
-export default function EditForm() {
-  const [isPending, startTransition] = useTransition();
-
-  function handleSubmit(e) {
-    // Stop React from resetting the form after the Action succeeds
-    e.preventDefault();
-    const formData = new FormData(e.target);
-    startTransition(async () => {
-      await submitForm(formData);
-    });
-  }
-
-  return (
-    <form action={submitForm} onSubmit={handleSubmit}>
-      <input name="title" defaultValue="My draft" />
-      <button type="submit" disabled={isPending}>
-        {isPending ? "Saving..." : "Save"}
-      </button>
-    </form>
-  );
-}
-```
-
-```js src/api.js hidden
-export async function submitForm(formData) {
-  await new Promise((res) => setTimeout(res, 1000));
-}
-```
-
-</Sandpack>
-
-<Solution />
-
-#### With `useActionState` {/*with-useactionstate*/}
-
-Alternatively, pass the dispatcher from [`useActionState`](/reference/react/useActionState) to the `action` prop. Return the values you want to keep from your Action, and pass them to each field's `defaultValue`. React restores those values instead of clearing them.
-
-<Sandpack>
-
-```js src/App.js
-import { useActionState } from "react";
-import { submitForm } from "./api.js";
-
-export default function EditForm() {
-  const [state, dispatchAction, isPending] = useActionState(submitForm, {
-    title: "My draft",
-  });
-
-  return (
-    <form action={dispatchAction}>
-      <input name="title" defaultValue={state.title} />
-      <button type="submit" disabled={isPending}>
-        {isPending ? "Saving..." : "Save"}
-      </button>
-    </form>
-  );
-}
-```
-
-```js src/api.js hidden
-export async function submitForm(previousState, formData) {
-  await new Promise((res) => setTimeout(res, 1000));
-  return {
-    title: formData.get("title"),
-  };
-}
-```
-
-</Sandpack>
-
-<Solution />
-
-</Recipes>
-
-<DeepDive>
-
-#### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
-
-The `onSubmit` approach above keeps every uncontrolled field. When you need finer control, two other patterns are available:
-
-* **Reset from your own Action API.** If you build an Action-based API and still want the form to reset after the Action runs, call the `requestFormReset` API from `react-dom` with the form element inside the Transition.
-
-* **Reset to server-provided values on validation failure.** The [`useActionState`](#with-useactionstate) example above preserves values after a successful submission. When an Action validates input on the server, you can return the submitted `FormData` and pass it to each field's `defaultValue`. React restores those values instead of clearing them, and the form keeps working before JavaScript loads:
-
-```js
-import { useActionState } from "react";
-import { submitForm } from "./actions.js";
-
-function EditForm() {
-  // The action returns { submitted: formData, error } on failure
-  const [state, formAction] = useActionState(submitForm, {
-    error: '',
-  });
-  return (
-    <form action={formAction}>
-      <input name="title" defaultValue={state.submitted?.get("title") ?? ""} />
-      {state.error && <p>{state.error}</p>}
-      <button type="submit">Save</button>
-    </form>
-  );
-}
-```
-
-Return the original `FormData` object rather than a new one so React can restore the values even before JavaScript has loaded.
-
-</DeepDive>
-
-
 ### Displaying a pending state during form submission {/*display-a-pending-state-during-form-submission*/}
 To display a pending state when a form is being submitted, you can call the `useFormStatus` Hook in a component rendered in a `<form>` and read the `pending` property returned.
 
@@ -546,6 +375,131 @@ export async function signUpNewUser(newEmail) {
 </Sandpack>
 
 Learn more about updating state from a form Action with the [`useActionState`](/reference/react/useActionState) docs
+
+### Preserving form values after submission {/*preserve-form-values-after-submission*/}
+
+By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function-ensuring your form behaves consistently both before and after JavaScript loads.
+
+When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields—[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
+
+<Recipes titleText="Examples of preserving form values" titleId="examples-preserve-form-values">
+
+#### `useActionState` {/*with-useactionstate*/}
+
+Pass the dispatcher from [`useActionState`](/reference/react/useActionState) to the `action` prop. Return the values you want to keep from your Action, and pass them to each field's `defaultValue`. React restores those values instead of clearing them.
+
+<Sandpack>
+
+```js src/App.js
+import { useActionState } from "react";
+import { submitForm } from "./api.js";
+
+export default function EditForm() {
+  const [state, dispatchAction, isPending] = useActionState(submitForm, {
+    title: "My draft",
+  });
+
+  return (
+    <form action={dispatchAction}>
+      <input name="title" defaultValue={state.title} />
+      <button type="submit" disabled={isPending}>
+        {isPending ? "Saving..." : "Save"}
+      </button>
+    </form>
+  );
+}
+```
+
+```js src/api.js hidden
+export async function submitForm(previousState, formData) {
+  await new Promise((res) => setTimeout(res, 1000));
+  return {
+    title: formData.get("title"),
+  };
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+#### `onSubmit` and `action` {/*with-onsubmit-and-usetransition*/}
+
+Adding an `onSubmit` handler that calls `e.preventDefault()` will run instead of the `action` prop.
+
+<Sandpack>
+
+```js src/App.js
+import { useTransition } from "react";
+import { submitForm } from "./api.js";
+
+export default function EditForm() {
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(e) {
+    // Stop React from resetting the form after the Action succeeds
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    startTransition(async () => {
+      await submitForm(formData);
+    });
+  }
+
+  return (
+    <form action={submitForm} onSubmit={handleSubmit}>
+      <input name="title" defaultValue="My draft" />
+      <button type="submit" disabled={isPending}>
+        {isPending ? "Saving..." : "Save"}
+      </button>
+    </form>
+  );
+}
+```
+
+```js src/api.js hidden
+export async function submitForm(formData) {
+  await new Promise((res) => setTimeout(res, 1000));
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+</Recipes>
+
+<DeepDive>
+
+#### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
+
+The `onSubmit` approach above keeps every uncontrolled field. When you need finer control, two other patterns are available:
+
+* **Reset from your own Action API.** If you build an Action-based API and still want the form to reset after the Action runs, call the `requestFormReset` API from `react-dom` with the form element inside the Transition.
+
+* **Reset to server-provided values on validation failure.** The [`useActionState`](#with-useactionstate) example above preserves values after a successful submission. When an Action validates input on the server, you can return the submitted `FormData` and pass it to each field's `defaultValue`. React restores those values instead of clearing them, and the form keeps working before JavaScript loads:
+
+```js
+import { useActionState } from "react";
+import { submitForm } from "./actions.js";
+
+function EditForm() {
+  // The action returns { submitted: formData, error } on failure
+  const [state, formAction] = useActionState(submitForm, {
+    error: '',
+  });
+  return (
+    <form action={formAction}>
+      <input name="title" defaultValue={state.submitted?.get("title") ?? ""} />
+      {state.error && <p>{state.error}</p>}
+      <button type="submit">Save</button>
+    </form>
+  );
+}
+```
+
+Return the original `FormData` object rather than a new one so React can restore the values even before JavaScript has loaded.
+
+</DeepDive>
 
 ### Handling multiple submission types {/*handling-multiple-submission-types*/}
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -51,7 +51,7 @@ To create interactive controls for submitting information, render the [built-in 
 
 ### Handling form submission with an event handler {/*handle-form-submission-with-an-event-handler*/}
 
-Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Call [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in your handler to override that behavior. Read the submitted data with [`new FormData(e.target)`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
+Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Call [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in your handler to override that behavior.
 
 
 <Sandpack>
@@ -84,7 +84,20 @@ Reading form data with `onSubmit` works in every version of React and gives you 
 
 ### Handling form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
 
-Pass a function to the `action` prop of form to run the function when the form is submitted. [`formData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) will be passed to the function as an argument so you can access the data submitted by the form. This differs from the conventional [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts URLs. Unlike `onSubmit`, an `action` runs in a [Transition](/reference/react/useTransition) and calling `e.preventDefault()` isn't needed. After the `action` function succeeds, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements in the form. To keep their values, see [Preserving form values after submission](#preserve-form-values-after-submission).
+Pass a function to the `action` prop of `<form>` to handle submission. When the form is submitted, React calls your function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the field values.
+
+Give each input a `name` attribute so its value is included in `FormData`. You can use [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) inputs instead of controlled `value`/`onChange` pairs, and you don't need an `onSubmit` handler or `e.preventDefault()`.
+
+This extends the [HTML `action` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts a URL, to also accept a function. Because the form stays a native HTML form, it can be submitted before JavaScript loads; with a [Server Function](/reference/rsc/server-functions), it works without JavaScript enabled.
+
+When you pass a function to `action`, React:
+
+* Runs the submission function in a [Transition](/reference/react/useTransition).
+* Tracks pending state so child components can read it with [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
+* Sends thrown errors to the nearest error boundary.
+* Works with [`useActionState`](/reference/react/useActionState) and [`useOptimistic`](/reference/react/useOptimistic) for form state and optimistic UI.
+
+After the function succeeds, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements in the form. To keep their values, see [Preserving form values after submission](#preserve-form-values-after-submission).
 
 <Sandpack>
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -38,11 +38,12 @@ To create interactive controls for submitting information, render the [built-in 
 
 `<form>` supports all [common element props.](/reference/react-dom/components/common#common-props)
 
-[`action`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action): a URL or function. When a URL is passed to `action` the form will behave like the HTML form component. When a function is passed to `action` the function will handle the form submission in a Transition following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components). The function passed to `action` may be async and will be called with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form. The `action` prop can be overridden by a `formAction` attribute on a `<button>`, `<input type="submit">`, or `<input type="image">` component.
+[`action`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action): a URL or function. When a URL is passed to `action` the form will behave like the [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form#action). When a function is passed to `action` the function will handle the form submission in a Transition following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components). The function passed to `action` may be async and will be called with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form. The `action` prop can be overridden by a `formAction` attribute on a `<button>`, `<input type="submit">`, or `<input type="image">` component.
 
 #### Caveats {/*caveats*/}
 
 * When a function is passed to `action` or `formAction` the HTTP method will be POST regardless of value of the `method` prop.
+* When a function is passed to `action` or `formAction`, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements after the action succeeds. See [Preserve form values after submission](#preserve-form-values-after-submission).
 
 ---
 
@@ -59,7 +60,8 @@ This example reads the submitted values with [`new FormData(e.target)`](https://
 ```js src/App.js
 export default function Search() {
   function handleSubmit(e) {
-    // Prevent the browser from reloading the page
+    // Prevent the default browser behavior
+    // of reloading the page and resetting the form
     e.preventDefault();
 
     // Read the form data
@@ -88,7 +90,7 @@ Reading form data with `onSubmit` works in every version of React and gives you 
 
 ### Handle form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
 
-Pass a function to the `action` prop of form to run the function when the form is submitted. [`formData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) will be passed to the function as an argument so you can access the data submitted by the form. This differs from the conventional [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts URLs. Unlike `onSubmit`, an `action` runs in a [Transition](/reference/react/useTransition) and calling `e.preventDefault()` isn't needed. After the `action` function succeeds, all uncontrolled field elements in the form are reset.
+Pass a function to the `action` prop of form to run the function when the form is submitted. [`formData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) will be passed to the function as an argument so you can access the data submitted by the form. This differs from the conventional [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts URLs. Unlike `onSubmit`, an `action` runs in a [Transition](/reference/react/useTransition) and calling `e.preventDefault()` isn't needed. After the `action` function succeeds, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements in the form. To keep their values, see [Preserve form values after submission](#preserve-form-values-after-submission).
 
 <Sandpack>
 
@@ -108,6 +110,85 @@ export default function Search() {
 ```
 
 </Sandpack>
+
+### Preserve form values after submission {/*preserve-form-values-after-submission*/}
+
+The browser clears a form's input state on submit. A URL `action` follows this same behavior. React does the same when `action` is a function, so your form works consistently before and after JavaScript loads.
+
+When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the action succeeds. The reset only applies to uncontrolled fields, so [inputs you control with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
+
+To keep the values of uncontrolled fields, add an `onSubmit` handler that calls `e.preventDefault()` and runs the action inside a [Transition](/reference/react/useTransition). Keep the `action` prop on the form so it still works before JavaScript loads.
+
+<Sandpack>
+
+```js src/App.js
+import { useTransition } from "react";
+import { submitForm } from "./api.js";
+
+export default function EditForm() {
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(e) {
+    // Stop React from resetting the form after the action succeeds
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    startTransition(async () => {
+      await submitForm(formData);
+    });
+  }
+
+  return (
+    <form action={submitForm} onSubmit={handleSubmit}>
+      <input name="title" defaultValue="My draft" />
+      <button type="submit" disabled={isPending}>
+        {isPending ? "Saving..." : "Save"}
+      </button>
+    </form>
+  );
+}
+```
+
+```js src/api.js hidden
+export async function submitForm(formData) {
+  await new Promise((res) => setTimeout(res, 1000));
+}
+```
+
+</Sandpack>
+
+Because you call the action manually from `onSubmit`, [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) won't report its pending state. Read `isPending` from the same [`useTransition`](/reference/react/useTransition) call instead.
+
+<DeepDive>
+
+#### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
+
+The `onSubmit` approach keeps every uncontrolled field. When you need finer control, two other patterns are available:
+
+* **Reset from your own action API.** If you build an action-based API and still want the form to reset after the action runs, call the `requestFormReset` API from `react-dom` with the form element inside the Transition.
+
+* **Reset to server-provided values.** When an action validates input on the server, return the submitted `FormData` and pass it to each field's `defaultValue`. React restores those values instead of clearing them, and the form keeps working before JavaScript loads:
+
+```js
+import { useActionState } from "react";
+import { submitForm } from "./actions.js";
+
+function EditForm() {
+  // The action returns { submitted: formData, error } on failure
+  const [state, formAction] = useActionState(submitForm, {});
+  const values = state.submitted ?? new FormData();
+  return (
+    <form action={formAction}>
+      <input name="title" defaultValue={values.get("title") ?? ""} />
+      {state.error && <p>{state.error}</p>}
+      <button type="submit">Save</button>
+    </form>
+  );
+}
+```
+
+Return the original `FormData` object rather than a new one so React can restore the values even before JavaScript has loaded.
+
+</DeepDive>
 
 ### Handle form submission with a Server Function {/*handle-form-submission-with-a-server-function*/}
 
@@ -372,28 +453,45 @@ Learn more about updating state from a form action with the [`useActionState`](/
 
 ### Handling multiple submission types {/*handling-multiple-submission-types*/}
 
-Forms can be designed to handle multiple submission actions based on the button pressed by the user. Each button inside a form can be associated with a distinct action or behavior by setting the `formAction` prop.
+A form can have more than one submit button, each running a different action. Set the `formAction` prop on a `<button>` to override the `<form>`'s `action` when that button submits the form.
 
-When a user taps a specific button, the form is submitted, and a corresponding action, defined by that button's attributes and action, is executed. For instance, a form might submit an article for review by default but have a separate button with `formAction` set to save the article as a draft.
+When a button without `formAction` submits the form, React calls the form's `action`. When a button with `formAction` submits the form, React calls that button's action instead. For example, the form below publishes an article by default, but its **Save draft** button stores the current content without publishing it.
+
+In this example the draft is held in state, so the saved content stays in the textarea after you submit it. In a real app you would persist the draft on the server. Pass a [Server Function](/reference/rsc/server-functions) (a function marked with [`'use server'`](/reference/rsc/use-server)) to `formAction` to save the draft from the server, optionally combined with [`useActionState`](/reference/react/useActionState) to track its pending state and result.
 
 <Sandpack>
 
 ```js src/App.js
-export default function Search() {
+import { useState } from 'react';
+
+export default function ArticleForm() {
+  const [draft, setDraft] = useState(() => new FormData());
+
   function publish(formData) {
-    const content = formData.get("content");
-    const button = formData.get("button");
-    alert(`'${content}' was published with the '${button}' button`);
+    const content = formData.get('content');
+    alert(`'${content}' was published!`);
+    // Clear the saved draft after publishing.
+    setDraft(new FormData());
   }
 
   function save(formData) {
-    const content = formData.get("content");
-    alert(`Your draft of '${content}' has been saved!`);
+    const content = formData.get('content');
+    alert(`Your draft of '${content}' was saved!`);
+    // Keep the submitted content as the current draft.
+    setDraft(formData);
   }
 
+  const savedContent = draft.get('content') || '';
   return (
     <form action={publish}>
-      <textarea name="content" rows={4} cols={40} />
+      <textarea
+        // Changing the key resets the textarea to the saved draft.
+        key={`${savedContent}-content`}
+        name="content"
+        rows={4}
+        cols={40}
+        defaultValue={savedContent}
+      />
       <br />
       <button type="submit" name="button" value="submit">Publish</button>
       <button formAction={save}>Save draft</button>

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -342,9 +342,7 @@ export async function deliverMessage(message) {
 ```
 
 </Sandpack>
-
-[//]: # 'Uncomment the next line, and delete this line after the `useOptimistic` reference documentation page is published'
-[//]: # 'To learn more about the `useOptimistic` Hook see the [reference documentation](/reference/react/useOptimistic).'
+To learn more about the `useOptimistic` Hook see the [reference documentation](/reference/react/useOptimistic).
 
 ### Handle form submission errors {/*handling-form-submission-errors*/}
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -461,40 +461,50 @@ A form can have more than one submit button, each running a different action. Se
 
 When a button without `formAction` submits the form, React calls the form's `action`. When a button with `formAction` submits the form, React calls that button's action instead. For example, the form below publishes an article by default, but its **Save draft** button stores the current content without publishing it.
 
-In this example the draft is held in state, so the saved content stays in the textarea after you submit it. In a real app you would persist the draft on the server. Pass a [Server Function](/reference/rsc/server-functions) (a function marked with [`'use server'`](/reference/rsc/use-server)) to `formAction` to save the draft from the server, optionally combined with [`useActionState`](/reference/react/useActionState) to track its pending state and result.
-
 <Sandpack>
 
 ```js src/App.js
-import { useState } from 'react';
+import { useActionState } from 'react';
 
 export default function ArticleForm() {
-  const [draft, setDraft] = useState(() => new FormData());
+  // Hold the saved draft in state so the textarea keeps its content after saving
+  const [formState, dispatchFormState] = useActionState((state, payload) => {
+    const content = payload.data.get('content');
+    switch (payload.type) {
+      case 'save':
+
+        alert(`Your draft of '${content}' was saved!`);
+        // Keep the submitted content as the current draft
+        return payload.data;
+      case 'publish':
+        alert(`'${content}' was published!`);
+        // reset the form
+        return new FormData();
+    }
+  });
 
   function publish(formData) {
-    const content = formData.get('content');
-    alert(`'${content}' was published!`);
-    // Clear the saved draft after publishing.
-    setDraft(new FormData());
+    dispatchFormState({
+      type: 'publish',
+      data: formData
+    })
   }
 
   function save(formData) {
-    const content = formData.get('content');
-    alert(`Your draft of '${content}' was saved!`);
-    // Keep the submitted content as the current draft.
-    setDraft(formData);
+    dispatchFormState({
+      type: 'save',
+      data: formData
+    })
   }
 
-  const savedContent = draft.get('content') || '';
+  // const savedContent = draft.get('content') || '';
   return (
     <form action={publish}>
       <textarea
-        // Changing the key resets the textarea to the saved draft.
-        key={`${savedContent}-content`}
         name="content"
         rows={4}
         cols={40}
-        defaultValue={savedContent}
+        defaultValue={formState?.get('content') || ""}
       />
       <br />
       <button type="submit" name="button" value="submit">Publish</button>
@@ -502,6 +512,7 @@ export default function ArticleForm() {
     </form>
   );
 }
+
 ```
 
 </Sandpack>

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -51,7 +51,7 @@ To create interactive controls for submitting information, render the [built-in 
 
 ### Handling form submission with an event handler {/*handle-form-submission-with-an-event-handler*/}
 
-Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Call [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in your handler to override that behavior.
+Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Calling [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in the event handler overrides this behavior.
 
 
 <Sandpack>
@@ -59,6 +59,8 @@ Pass a function to the `onSubmit` event handler to run code when the form is sub
 ```js src/App.js
 export default function Search() {
   function handleSubmit(e) {
+    // Prevent the browser from reloading the page
+    e.preventDefault();
     const form = e.target;
     const formData = new FormData(form);
     const query = formData.get("query");
@@ -378,7 +380,7 @@ Learn more about updating state from a form Action with the [`useActionState`](/
 
 ### Preserving form values after submission {/*preserve-form-values-after-submission*/}
 
-By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function-ensuring your form behaves consistently both before and after JavaScript loads.
+By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function, ensuring your form behaves consistently both before and after JavaScript loads.
 
 When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields—[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
 
@@ -425,7 +427,8 @@ export async function submitForm(previousState, formData) {
 
 #### `onSubmit` and `action` {/*with-onsubmit-and-usetransition*/}
 
-Adding an `onSubmit` handler that calls `e.preventDefault()` will run instead of the `action` prop.
+Calling `e.preventDefault()` in an `onSubmit` handler prevents the `action` prop from running. Without `e.preventDefault()`, both the `action` prop and the `onSubmit` handler will run.
+
 
 <Sandpack>
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -169,9 +169,58 @@ When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), an
 
 By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function-ensuring your form behaves consistently both before and after JavaScript loads.
 
-When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the action succeeds. This reset only affects uncontrolled fields—[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
+When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields—[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
 
-To preserve the values of uncontrolled fields after submission, add an `onSubmit` handler that calls `e.preventDefault()` and runs the action inside a [Transition](/reference/react/useTransition). Keep the `action` prop on the form so it continues to work before JavaScript loads.
+<Recipes titleText="Examples of preserving form values" titleId="examples-preserve-form-values">
+
+#### With `onSubmit` {/*with-onsubmit*/}
+
+Handle submission in an `onSubmit` handler and call `e.preventDefault()` to stop the browser from navigating and refreshing the page.
+
+<Sandpack>
+
+```js src/App.js
+import { useState } from "react";
+import { submitForm } from "./api.js";
+
+export default function EditForm() {
+  const [isPending, setIsPending] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    setIsPending(true);
+    try {
+      await submitForm(formData);
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input name="title" defaultValue="My draft" />
+      <button type="submit" disabled={isPending}>
+        {isPending ? "Saving..." : "Save"}
+      </button>
+    </form>
+  );
+}
+```
+
+```js src/api.js hidden
+export async function submitForm(formData) {
+  await new Promise((res) => setTimeout(res, 1000));
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+#### With `onSubmit` and `useTransition` {/*with-onsubmit-and-usetransition*/}
+
+If you also pass a function to the `action` prop—for example, to support [progressive enhancement](/reference/rsc/server-functions)—add an `onSubmit` handler that calls `e.preventDefault()` and runs the Action inside a [Transition](/reference/react/useTransition).
 
 <Sandpack>
 
@@ -183,7 +232,7 @@ export default function EditForm() {
   const [isPending, startTransition] = useTransition();
 
   function handleSubmit(e) {
-    // Stop React from resetting the form after the action succeeds
+    // Stop React from resetting the form after the Action succeeds
     e.preventDefault();
     const formData = new FormData(e.target);
     startTransition(async () => {
@@ -210,15 +259,58 @@ export async function submitForm(formData) {
 
 </Sandpack>
 
+<Solution />
+
+#### With `useActionState` {/*with-useactionstate*/}
+
+Alternatively, pass the dispatcher from [`useActionState`](/reference/react/useActionState) to the `action` prop. Return the values you want to keep from your Action, and pass them to each field's `defaultValue`. React restores those values instead of clearing them.
+
+<Sandpack>
+
+```js src/App.js
+import { useActionState } from "react";
+import { submitForm } from "./api.js";
+
+export default function EditForm() {
+  const [state, dispatchAction, isPending] = useActionState(submitForm, {
+    title: "My draft",
+  });
+
+  return (
+    <form action={dispatchAction}>
+      <input name="title" defaultValue={state.title} />
+      <button type="submit" disabled={isPending}>
+        {isPending ? "Saving..." : "Save"}
+      </button>
+    </form>
+  );
+}
+```
+
+```js src/api.js hidden
+export async function submitForm(previousState, formData) {
+  await new Promise((res) => setTimeout(res, 1000));
+  return {
+    title: formData.get("title"),
+  };
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+</Recipes>
+
 <DeepDive>
 
 #### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
 
-The `onSubmit` approach keeps every uncontrolled field. When you need finer control, two other patterns are available:
+The `onSubmit` approach above keeps every uncontrolled field. When you need finer control, two other patterns are available:
 
-* **Reset from your own action API.** If you build an action-based API and still want the form to reset after the action runs, call the `requestFormReset` API from `react-dom` with the form element inside the Transition.
+* **Reset from your own Action API.** If you build an Action-based API and still want the form to reset after the Action runs, call the `requestFormReset` API from `react-dom` with the form element inside the Transition.
 
-* **Reset to server-provided values.** When an action validates input on the server, return the submitted `FormData` and pass it to each field's `defaultValue`. React restores those values instead of clearing them, and the form keeps working before JavaScript loads:
+* **Reset to server-provided values on validation failure.** The [`useActionState`](#with-useactionstate) example above preserves values after a successful submission. When an Action validates input on the server, you can return the submitted `FormData` and pass it to each field's `defaultValue`. React restores those values instead of clearing them, and the form keeps working before JavaScript loads:
 
 ```js
 import { useActionState } from "react";
@@ -405,7 +497,7 @@ Displaying a form submission error message before the JavaScript bundle loads fo
 1. the function passed to the `<form>`'s `action` prop be a [Server Function](/reference/rsc/server-functions)
 1. the `useActionState` Hook be used to display the error message
 
-`useActionState` takes two parameters: a [Server Function](/reference/rsc/server-functions) and an initial state. `useActionState` returns two values, a state variable and an action. The action returned by `useActionState` should be passed to the `action` prop of the form. The state variable returned by `useActionState` can be used to display an error message. The value returned by the Server Function passed to `useActionState` will be used to update the state variable.
+`useActionState` takes two parameters: a [Server Function](/reference/rsc/server-functions) and an initial state. `useActionState` returns two values, a state variable and an Action. The Action returned by `useActionState` should be passed to the `action` prop of the form. The state variable returned by `useActionState` can be used to display an error message. The value returned by the Server Function passed to `useActionState` will be used to update the state variable.
 
 <Sandpack>
 
@@ -453,7 +545,7 @@ export async function signUpNewUser(newEmail) {
 
 </Sandpack>
 
-Learn more about updating state from a form action with the [`useActionState`](/reference/react/useActionState) docs
+Learn more about updating state from a form Action with the [`useActionState`](/reference/react/useActionState) docs
 
 ### Handling multiple submission types {/*handling-multiple-submission-types*/}
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -42,7 +42,7 @@ To create interactive controls for submitting information, render the [built-in 
 
 #### Caveats {/*caveats*/}
 
-* When a function is passed to `action` or `formAction` the HTTP method will be POST regardless of value of the `method` prop.
+* When a function is passed to `action` or `formAction` the HTTP method will be POST regardless of the value of the `method` prop.
 * When a function is passed to `action` or `formAction`, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements after the action succeeds. See [Preserve form values after submission](#preserve-form-values-after-submission).
 
 ---
@@ -110,7 +110,7 @@ export default function Search() {
 
 Render a `<form>` with an input and submit button. Pass a Server Function (a function marked with [`'use server'`](/reference/rsc/use-server)) to the `action` prop of form to run the function when the form is submitted.
 
-Passing a Server Function to `<form action>` allow users to submit forms without JavaScript enabled or before the code has loaded. This is beneficial to users who have a slow connection, device, or have JavaScript disabled and is similar to the way forms work when a URL is passed to the `action` prop.
+Passing a Server Function to `<form action>` allows users to submit forms without JavaScript enabled or before the code has loaded. This is beneficial to users who have a slow connection, device, or have JavaScript disabled and is similar to the way forms work when a URL is passed to the `action` prop.
 
 You can use hidden form fields to provide data to the `<form>`'s action. The Server Function will be called with the hidden form field data as an instance of [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -42,7 +42,7 @@ To create interactive controls for submitting information, render the [built-in 
   * If you pass a function to `action`, React runs it in a [Transition](/reference/react/useTransition) following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components).
   * The function may be async. React calls it with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form.
   * A `formAction` prop on a `<button>`, `<input type="submit">`, or `<input type="image">` overrides this `action`.
-* [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method): A string. Specifies the [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) (`get` or `post`). Defaults to `get`. Ignored when `action` is a function—see [Caveats](#caveats).
+* [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method): A string. Specifies the [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) (`get` or `post`). Defaults to `get`. Ignored when `action` is a function.
 * `onSubmit`: An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires when the form is submitted. If you also pass a function to `action`, both run unless you call `e.preventDefault()`. See [Handling form submission with an event handler](#handle-form-submission-with-an-event-handler).
 
 #### Caveats {/*caveats*/}
@@ -67,7 +67,7 @@ export default function Search() {
     e.preventDefault();
     const form = e.target;
     const formData = new FormData(form);
-    const query = formData.get("query");
+    const query = formData.get('query');
     alert(`You searched for '${query}'`);
   }
 
@@ -92,7 +92,7 @@ Reading form data with `onSubmit` works in every version of React and gives you 
 
 ### Handling form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
 
-Pass a function to the `action` prop to run it when the form is submitted. React calls the function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the values of every input with a `name` attribute. Your inputs can be [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form)—you don't need `value`/`onChange` pairs, an `onSubmit` handler, or `e.preventDefault()`.
+Pass a function to the `action` prop to run it when the form is submitted. React calls the function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the values of every input with a `name` attribute. Your inputs can be [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form)-you don't need `value`/`onChange` pairs, an `onSubmit` handler, or `e.preventDefault()`.
 
 When you pass a function to `action`, React:
 
@@ -108,7 +108,7 @@ Because the Action runs in a Transition, you can also use [`useActionState`](/re
 ```js src/App.js
 export default function Search() {
   function search(formData) {
-    const query = formData.get("query");
+    const query = formData.get('query');
     alert(`You searched for '${query}'`);
   }
   return (
@@ -169,7 +169,6 @@ function AddToCart({productId}) {
 }
 ```
 
-When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), and a [Server Function](/reference/rsc/server-functions) is passed to the `<form>`'s `action` prop, the form is [progressively enhanced](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement).
 ---
 
 ### Displaying a pending state during form submission {/*display-a-pending-state-during-form-submission*/}
@@ -395,7 +394,7 @@ To learn more about updating state from a form Action, see the [`useActionState`
 
 By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function so the form behaves consistently before and after JavaScript loads.
 
-When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields-[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
+When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields-[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are not cleared.
 
 <Recipes titleText="Examples of preserving form values" titleId="examples-preserve-form-values">
 

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -38,12 +38,17 @@ To create interactive controls for submitting information, render the [built-in 
 
 `<form>` supports all [common element props.](/reference/react-dom/components/common#common-props)
 
-[`action`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action): a URL or function. When a URL is passed to `action` the form will behave like the HTML form component. When a function is passed to `action` the function will handle the form submission in a Transition following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components). The function passed to `action` may be async and will be called with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form. The `action` prop can be overridden by a `formAction` attribute on a `<button>`, `<input type="submit">`, or `<input type="image">` component.
+* [`action`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action): A string containing a URL, or a function. If you pass a URL, the form behaves like a standard HTML form. If you pass a function, it handles the submission. See [Handling form submission with an action prop](#handle-form-submission-with-an-action-prop).
+  * If you pass a function to `action`, React runs it in a [Transition](/reference/react/useTransition) following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components).
+  * The function may be async. React calls it with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form.
+  * A `formAction` prop on a `<button>`, `<input type="submit">`, or `<input type="image">` overrides this `action`.
+* [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method): A string. Specifies the [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) (`get` or `post`). Defaults to `get`. Ignored when `action` is a function—see [Caveats](#caveats).
+* `onSubmit`: An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires when the form is submitted. If you also pass a function to `action`, both run unless you call `e.preventDefault()`. See [Handling form submission with an event handler](#handle-form-submission-with-an-event-handler).
 
 #### Caveats {/*caveats*/}
 
-* When a function is passed to `action` or `formAction` the HTTP method will be POST regardless of the value of the `method` prop.
-* When a function is passed to `action` or `formAction`, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements after the action succeeds. See [Preserving form values after submission](#preserve-form-values-after-submission).
+* If you pass a function to `action` or `formAction`, the HTTP method will be `POST` regardless of the value of the `method` prop.
+* If you pass a function to `action` or `formAction`, React resets all [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) field elements after the Action succeeds. See [Preserving form values after submission](#preserve-form-values-after-submission).
 
 ---
 
@@ -52,7 +57,6 @@ To create interactive controls for submitting information, render the [built-in 
 ### Handling form submission with an event handler {/*handle-form-submission-with-an-event-handler*/}
 
 Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Calling [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in the event handler overrides this behavior.
-
 
 <Sandpack>
 
@@ -80,24 +84,24 @@ export default function Search() {
 
 <Note>
 
-Reading form data with `onSubmit` works in every version of React and gives you direct access to the [submit event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event), so you can call `e.preventDefault()` and read the data yourself. Passing the function to the `action` prop instead runs the submission in a [Transition](/reference/react/useTransition). React then tracks the pending state, sends thrown errors to the nearest error boundary, and lets the form work with [`useActionState`](/reference/react/useActionState) and [`useOptimistic`](/reference/react/useOptimistic). An `action` can also be a [Server Function](/reference/rsc/server-functions), which `onSubmit` does not support.
+Reading form data with `onSubmit` works in every version of React and gives you direct access to the [submit event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event). Prefer the [`action` prop](#handle-form-submission-with-an-action-prop) when you want Transitions, pending state, Error Boundaries, or [Server Functions](/reference/rsc/server-functions).
 
 </Note>
 
+---
+
 ### Handling form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
 
-Pass a function to the `action` prop to run it when the form is submitted. React calls the function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the values of every input with a `name` attribute. This means your inputs can be [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) - no need for `value`/`onChange` pairs, `onSubmit` handler, or `e.preventDefault()`.
-
-When the `action` prop is a [Server Function](/reference/rsc/server-functions), the form is progressively enhanced: submission works before JavaScript loads, and even with JavaScript disabled.
+Pass a function to the `action` prop to run it when the form is submitted. React calls the function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the values of every input with a `name` attribute. Your inputs can be [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form)—you don't need `value`/`onChange` pairs, an `onSubmit` handler, or `e.preventDefault()`.
 
 When you pass a function to `action`, React:
 
 * Runs the function in a [Transition](/reference/react/useTransition), keeping the page responsive.
 * Makes the pending state available to child components via [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
-* Propagates any errors to the nearest error boundary.
+* Propagates any errors to the nearest Error Boundary.
 * Resets the form's uncontrolled fields when the function succeeds. To keep their values, see [Preserving form values after submission](#preserve-form-values-after-submission).
 
-Because the Action runs in a Transition, you can also use [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) for submission status, [`useActionState`](/reference/react/useActionState) to manage form state, and [`useOptimistic`](/reference/react/useOptimistic) for optimistic UI.
+Because the Action runs in a Transition, you can also use [`useActionState`](/reference/react/useActionState) to manage form state and [`useOptimistic`](/reference/react/useOptimistic) for optimistic UI. For [Server Functions](/reference/rsc/server-functions) and progressive enhancement, see [Handling form submission with a Server Function](#handle-form-submission-with-a-server-function).
 
 <Sandpack>
 
@@ -118,6 +122,7 @@ export default function Search() {
 
 </Sandpack>
 
+---
 
 ### Handling form submission with a Server Function {/*handle-form-submission-with-a-server-function*/}
 
@@ -132,16 +137,15 @@ import { updateCart } from './lib.js';
 
 function AddToCart({productId}) {
   async function addToCart(formData) {
-    'use server'
-    const productId = formData.get('productId')
-    await updateCart(productId)
+    'use server';
+    const productId = formData.get('productId');
+    await updateCart(productId);
   }
   return (
     <form action={addToCart}>
-        <input type="hidden" name="productId" value={productId} />
-        <button type="submit">Add to Cart</button>
+      <input type="hidden" name="productId" value={productId} />
+      <button type="submit">Add to Cart</button>
     </form>
-
   );
 }
 ```
@@ -153,8 +157,8 @@ import { updateCart } from './lib.js';
 
 function AddToCart({productId}) {
   async function addToCart(productId, formData) {
-    "use server";
-    await updateCart(productId)
+    'use server';
+    await updateCart(productId);
   }
   const addProductToCart = addToCart.bind(null, productId);
   return (
@@ -166,8 +170,10 @@ function AddToCart({productId}) {
 ```
 
 When `<form>` is rendered by a [Server Component](/reference/rsc/use-client), and a [Server Function](/reference/rsc/server-functions) is passed to the `<form>`'s `action` prop, the form is [progressively enhanced](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement).
+---
 
 ### Displaying a pending state during form submission {/*display-a-pending-state-during-form-submission*/}
+
 To display a pending state when a form is being submitted, you can call the `useFormStatus` Hook in a component rendered in a `<form>` and read the `pending` property returned.
 
 Here, we use the `pending` property to indicate the form is submitting.
@@ -175,14 +181,14 @@ Here, we use the `pending` property to indicate the form is submitting.
 <Sandpack>
 
 ```js src/App.js
-import { useFormStatus } from "react-dom";
-import { submitForm } from "./actions.js";
+import { useFormStatus } from 'react-dom';
+import { submitForm } from './actions.js';
 
 function Submit() {
   const { pending } = useFormStatus();
   return (
     <button type="submit" disabled={pending}>
-      {pending ? "Submitting..." : "Submit"}
+      {pending ? 'Submitting...' : 'Submit'}
     </button>
   );
 }
@@ -201,31 +207,33 @@ export default function App() {
 ```
 
 ```js src/actions.js hidden
-export async function submitForm(query) {
-    await new Promise((res) => setTimeout(res, 1000));
+export async function submitForm(formData) {
+  await new Promise((res) => setTimeout(res, 1000));
 }
 ```
 
 </Sandpack>
 
-To learn more about the `useFormStatus` Hook see the [reference documentation](/reference/react-dom/hooks/useFormStatus).
+To learn more about the `useFormStatus` Hook, see the [reference documentation](/reference/react-dom/hooks/useFormStatus).
+
+---
 
 ### Optimistically updating form data {/*optimistically-updating-form-data*/}
+
 The `useOptimistic` Hook provides a way to optimistically update the user interface before a background operation, like a network request, completes. In the context of forms, this technique helps to make apps feel more responsive. When a user submits a form, instead of waiting for the server's response to reflect the changes, the interface is immediately updated with the expected outcome.
 
 For example, when a user types a message into the form and hits the "Send" button, the `useOptimistic` Hook allows the message to immediately appear in the list with a "Sending..." label, even before the message is actually sent to a server. This "optimistic" approach gives the impression of speed and responsiveness. The form then attempts to truly send the message in the background. Once the server confirms the message has been received, the "Sending..." label is removed.
 
 <Sandpack>
 
-
 ```js src/App.js
-import { useOptimistic, useState, useRef } from "react";
-import { deliverMessage } from "./actions.js";
+import { useOptimistic, useState, useRef } from 'react';
+import { deliverMessage } from './actions.js';
 
 function Thread({ messages, sendMessage }) {
   const formRef = useRef();
   async function formAction(formData) {
-    addOptimisticMessage(formData.get("message"));
+    addOptimisticMessage(formData.get('message'));
     formRef.current.reset();
     await sendMessage(formData);
   }
@@ -258,17 +266,17 @@ function Thread({ messages, sendMessage }) {
 
 export default function App() {
   const [messages, setMessages] = useState([
-    { text: "Hello there!", sending: false, key: 1 }
+    { text: 'Hello there!', sending: false, key: 1 }
   ]);
   async function sendMessage(formData) {
-    const sentMessage = await deliverMessage(formData.get("message"));
+    const sentMessage = await deliverMessage(formData.get('message'));
     setMessages((messages) => [...messages, { text: sentMessage }]);
   }
   return <Thread messages={messages} sendMessage={sendMessage} />;
 }
 ```
 
-```js src/actions.js
+```js src/actions.js hidden
 export async function deliverMessage(message) {
   await new Promise((res) => setTimeout(res, 1000));
   return message;
@@ -276,20 +284,23 @@ export async function deliverMessage(message) {
 ```
 
 </Sandpack>
-To learn more about the `useOptimistic` Hook see the [reference documentation](/reference/react/useOptimistic).
+
+To learn more about the `useOptimistic` Hook, see the [reference documentation](/reference/react/useOptimistic).
+
+---
 
 ### Handling form submission errors {/*handling-form-submission-errors*/}
 
-In some cases the function called by a `<form>`'s `action` prop throws an error. You can handle these errors by wrapping `<form>` in an Error Boundary. If the function called by a `<form>`'s `action` prop throws an error, the fallback for the error boundary will be displayed.
+In some cases the function called by a `<form>`'s `action` prop throws an error. You can handle these errors by wrapping `<form>` in an Error Boundary. If the Action throws, the Error Boundary fallback will be displayed.
 
 <Sandpack>
 
 ```js src/App.js
-import { ErrorBoundary } from "react-error-boundary";
+import { ErrorBoundary } from 'react-error-boundary';
 
 export default function Search() {
   function search() {
-    throw new Error("search error");
+    throw new Error('search error');
   }
   return (
     <ErrorBoundary
@@ -302,7 +313,6 @@ export default function Search() {
     </ErrorBoundary>
   );
 }
-
 ```
 
 ```json package.json hidden
@@ -313,12 +323,13 @@ export default function Search() {
     "react-scripts": "^5.0.0",
     "react-error-boundary": "4.0.3"
   },
-  "main": "/index.js",
-  "devDependencies": {}
+  "main": "/index.js"
 }
 ```
 
 </Sandpack>
+
+---
 
 ### Displaying a form submission error without JavaScript {/*display-a-form-submission-error-without-javascript*/}
 
@@ -333,13 +344,13 @@ Displaying a form submission error message before the JavaScript bundle loads fo
 <Sandpack>
 
 ```js src/App.js
-import { useActionState } from "react";
-import { signUpNewUser } from "./api";
+import { useActionState } from 'react';
+import { signUpNewUser } from './api.js';
 
 export default function Page() {
   async function signup(prevState, formData) {
-    "use server";
-    const email = formData.get("email");
+    'use server';
+    const email = formData.get('email');
     try {
       await signUpNewUser(email);
       alert(`Added "${email}"`);
@@ -368,7 +379,7 @@ let emails = [];
 
 export async function signUpNewUser(newEmail) {
   if (emails.includes(newEmail)) {
-    throw new Error("This email address has already been added");
+    throw new Error('This email address has already been added');
   }
   emails.push(newEmail);
 }
@@ -376,36 +387,38 @@ export async function signUpNewUser(newEmail) {
 
 </Sandpack>
 
-Learn more about updating state from a form Action with the [`useActionState`](/reference/react/useActionState) docs
+To learn more about updating state from a form Action, see the [`useActionState`](/reference/react/useActionState) docs.
+
+---
 
 ### Preserving form values after submission {/*preserve-form-values-after-submission*/}
 
-By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function, ensuring your form behaves consistently both before and after JavaScript loads.
+By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function so the form behaves consistently before and after JavaScript loads.
 
-When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields—[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
+When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields-[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are never cleared.
 
 <Recipes titleText="Examples of preserving form values" titleId="examples-preserve-form-values">
 
-#### `useActionState` {/*with-useactionstate*/}
+#### Restore fields with `useActionState` {/*with-useactionstate*/}
 
-Pass the dispatcher from [`useActionState`](/reference/react/useActionState) to the `action` prop. Return the values you want to keep from your Action, and pass them to each field's `defaultValue`. React restores those values instead of clearing them.
+Pass the action returned by [`useActionState`](/reference/react/useActionState) to the `action` prop. Return the values you want to keep from your Action, and pass them to each field's `defaultValue`. React restores those values instead of clearing them.
 
 <Sandpack>
 
 ```js src/App.js
-import { useActionState } from "react";
-import { submitForm } from "./api.js";
+import { useActionState } from 'react';
+import { submitForm } from './api.js';
 
 export default function EditForm() {
   const [state, dispatchAction, isPending] = useActionState(submitForm, {
-    title: "My draft",
+    title: 'My draft',
   });
 
   return (
     <form action={dispatchAction}>
       <input name="title" defaultValue={state.title} />
       <button type="submit" disabled={isPending}>
-        {isPending ? "Saving..." : "Save"}
+        {isPending ? 'Saving...' : 'Save'}
       </button>
     </form>
   );
@@ -416,7 +429,7 @@ export default function EditForm() {
 export async function submitForm(previousState, formData) {
   await new Promise((res) => setTimeout(res, 1000));
   return {
-    title: formData.get("title"),
+    title: formData.get('title'),
   };
 }
 ```
@@ -425,16 +438,15 @@ export async function submitForm(previousState, formData) {
 
 <Solution />
 
-#### `onSubmit` and `action` {/*with-onsubmit-and-usetransition*/}
+#### Keep every field with `onSubmit` {/*with-onsubmit-and-usetransition*/}
 
-Calling `e.preventDefault()` in an `onSubmit` handler prevents the `action` prop from running. Without `e.preventDefault()`, both the `action` prop and the `onSubmit` handler will run.
-
+Call `e.preventDefault()` in an `onSubmit` handler and run the Action yourself with [`startTransition`](/reference/react/useTransition). React doesn't reset the form because the `action` prop never runs. Keep passing `action` so the form still submits before JavaScript loads.
 
 <Sandpack>
 
 ```js src/App.js
-import { useTransition } from "react";
-import { submitForm } from "./api.js";
+import { useTransition } from 'react';
+import { submitForm } from './api.js';
 
 export default function EditForm() {
   const [isPending, startTransition] = useTransition();
@@ -452,7 +464,7 @@ export default function EditForm() {
     <form action={submitForm} onSubmit={handleSubmit}>
       <input name="title" defaultValue="My draft" />
       <button type="submit" disabled={isPending}>
-        {isPending ? "Saving..." : "Save"}
+        {isPending ? 'Saving...' : 'Save'}
       </button>
     </form>
   );
@@ -471,28 +483,30 @@ export async function submitForm(formData) {
 
 </Recipes>
 
+You can also reset only some fields, or restore values from the server on validation failure.
+
 <DeepDive>
 
 #### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
 
-The `onSubmit` approach above keeps every uncontrolled field. When you need finer control, two other patterns are available:
+The `onSubmit` approach above keeps every uncontrolled field. For finer control, you can:
 
-* **Reset from your own Action API.** If you build an Action-based API and still want the form to reset after the Action runs, call the `requestFormReset` API from `react-dom` with the form element inside the Transition.
+* **Reset from your own Action API.** If you build an Action-based API and still want the form to reset after the Action runs, call [`requestFormReset`](/blog/2024/12/05/react-19#form-actions) from `react-dom` with the form element inside the Transition.
 
 * **Reset to server-provided values on validation failure.** The [`useActionState`](#with-useactionstate) example above preserves values after a successful submission. When an Action validates input on the server, you can return the submitted `FormData` and pass it to each field's `defaultValue`. React restores those values instead of clearing them, and the form keeps working before JavaScript loads:
 
 ```js
-import { useActionState } from "react";
-import { submitForm } from "./actions.js";
+import { useActionState } from 'react';
+import { submitForm } from './actions.js';
 
 function EditForm() {
-  // The action returns { submitted: formData, error } on failure
+  // The Action returns { submitted: formData, error } on failure
   const [state, formAction] = useActionState(submitForm, {
     error: '',
   });
   return (
     <form action={formAction}>
-      <input name="title" defaultValue={state.submitted?.get("title") ?? ""} />
+      <input name="title" defaultValue={state.submitted?.get('title') ?? ''} />
       {state.error && <p>{state.error}</p>}
       <button type="submit">Save</button>
     </form>
@@ -504,11 +518,13 @@ Return the original `FormData` object rather than a new one so React can restore
 
 </DeepDive>
 
+---
+
 ### Handling multiple submission types {/*handling-multiple-submission-types*/}
 
-A form can have more than one submit button, each running a different action. Set the `formAction` prop on a `<button>` to override the `<form>`'s `action` when that button submits the form.
+A form can have more than one submit button, each running a different Action. Set the `formAction` prop on a `<button>` to override the `<form>`'s `action` when that button submits the form.
 
-When a button without `formAction` submits the form, React calls the form's `action`. When a button with `formAction` submits the form, React calls that button's action instead. For example, the form below publishes an article by default, but its **Save draft** button stores the current content without publishing it.
+When a button without `formAction` submits the form, React calls the form's `action`. When a button with `formAction` submits the form, React calls that button's `formAction` instead. For example, the form below publishes an article by default, but its **Save draft** button stores the current content without publishing it:
 
 <Sandpack>
 
@@ -526,22 +542,24 @@ export default function ArticleForm() {
         return payload.data;
       case 'publish':
         alert(`'${content}' was published!`);
-        // reset the form
+        // Reset the form
         return new FormData();
+      default:
+        return state;
     }
   }, new FormData());
 
   function publish(formData) {
     dispatchFormState({
       type: 'publish',
-      data: formData
+      data: formData,
     });
   }
 
   function save(formData) {
     dispatchFormState({
       type: 'save',
-      data: formData
+      data: formData,
     });
   }
 
@@ -551,7 +569,7 @@ export default function ArticleForm() {
         name="content"
         rows={4}
         cols={40}
-        defaultValue={formState?.get('content') || ""}
+        defaultValue={formState?.get('content') || ''}
       />
       <br />
       <button type="submit" name="button" value="submit">Publish</button>
@@ -559,7 +577,6 @@ export default function ArticleForm() {
     </form>
   );
 }
-
 ```
 
 </Sandpack>

--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -42,8 +42,8 @@ To create interactive controls for submitting information, render the [built-in 
   * If you pass a function to `action`, React runs it in a [Transition](/reference/react/useTransition) following [the Action prop pattern](/reference/react/useTransition#exposing-action-props-from-components).
   * The function may be async. React calls it with a single argument containing the [form data](https://developer.mozilla.org/en-US/docs/Web/API/FormData) of the submitted form.
   * A `formAction` prop on a `<button>`, `<input type="submit">`, or `<input type="image">` overrides this `action`.
-* [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method): A string. Specifies the [HTTP method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) (`get` or `post`). Defaults to `get`. Ignored when `action` is a function.
-* `onSubmit`: An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires when the form is submitted. If you also pass a function to `action`, both run unless you call `e.preventDefault()`. See [Handling form submission with an event handler](#handle-form-submission-with-an-event-handler).
+* [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method): A string that specifies the HTTP method to use when `action` is a URL. Defaults to `get`.
+* `onSubmit`: An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires when the form is submitted. See [Handling form submission with an event handler](#handle-form-submission-with-an-event-handler).
 
 #### Caveats {/*caveats*/}
 
@@ -57,6 +57,8 @@ To create interactive controls for submitting information, render the [built-in 
 ### Handling form submission with an event handler {/*handle-form-submission-with-an-event-handler*/}
 
 Pass a function to the `onSubmit` event handler to run code when the form is submitted. By default, the browser sends the form data to the current URL and refreshes the page. Calling [`e.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) in the event handler overrides this behavior.
+
+If you also pass a function to `action`, React runs it after `onSubmit` unless `onSubmit` calls `e.preventDefault()`.
 
 <Sandpack>
 
@@ -92,7 +94,7 @@ Reading form data with `onSubmit` works in every version of React and gives you 
 
 ### Handling form submission with an action prop {/*handle-form-submission-with-an-action-prop*/}
 
-Pass a function to the `action` prop to run it when the form is submitted. React calls the function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the values of every input with a `name` attribute. Your inputs can be [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form)-you don't need `value`/`onChange` pairs, an `onSubmit` handler, or `e.preventDefault()`.
+Pass a function to the `action` prop to run it when the form is submitted. React calls the function with a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing the values of every input with a `name` attribute. Your inputs can be [uncontrolled](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form). You don't need `value`/`onChange` pairs, an `onSubmit` handler, or `e.preventDefault()`.
 
 When you pass a function to `action`, React:
 
@@ -126,11 +128,11 @@ export default function Search() {
 
 ### Handling form submission with a Server Function {/*handle-form-submission-with-a-server-function*/}
 
-Render a `<form>` with an input and submit button. Pass a Server Function (a function marked with [`'use server'`](/reference/rsc/use-server)) to the `action` prop of form to run the function when the form is submitted.
+Render a `<form>` with an input and submit button. Pass a Server Function (a function marked with [`'use server'`](/reference/rsc/use-server)) to the form's `action` prop to run the function when the form is submitted.
 
-Passing a Server Function to `<form action>` allows users to submit forms without JavaScript enabled or before the code has loaded. This is beneficial to users who have a slow connection, device, or have JavaScript disabled and is similar to the way forms work when a URL is passed to the `action` prop.
+Passing a Server Function to a form's `action` prop allows users to submit the form before JavaScript loads or when JavaScript is disabled. This matches how forms behave when you pass a URL to `action`.
 
-You can use hidden form fields to provide data to the `<form>`'s action. The Server Function will be called with the hidden form field data as an instance of [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
+You can use hidden form fields to pass data to the Server Function. React includes the hidden field values in the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) passed to the function.
 
 ```jsx
 import { updateCart } from './lib.js';
@@ -150,7 +152,7 @@ function AddToCart({productId}) {
 }
 ```
 
-In lieu of using hidden form fields to provide data to the `<form>`'s action, you can call the <CodeStep step={1}>`bind`</CodeStep> method to supply it with extra arguments. This will bind a new argument (<CodeStep step={2}>`productId`</CodeStep>) to the function in addition to the <CodeStep step={3}>`formData`</CodeStep> that is passed as an argument to the function.
+Instead of using a hidden form field, call the <CodeStep step={1}>`bind`</CodeStep> method to pass an extra argument to the Server Function. This binds <CodeStep step={2}>`productId`</CodeStep> as an argument before the <CodeStep step={3}>`formData`</CodeStep> that React passes to the function.
 
 ```jsx [[1, 8, "bind"], [2,8, "productId"], [2,4, "productId"], [3,4, "formData"]]
 import { updateCart } from './lib.js';
@@ -290,7 +292,7 @@ To learn more about the `useOptimistic` Hook, see the [reference documentation](
 
 ### Handling form submission errors {/*handling-form-submission-errors*/}
 
-In some cases the function called by a `<form>`'s `action` prop throws an error. You can handle these errors by wrapping `<form>` in an Error Boundary. If the Action throws, the Error Boundary fallback will be displayed.
+To handle errors thrown by a function passed to a `<form>`'s `action` prop, wrap the form in an Error Boundary. React displays the boundary's fallback when the function throws.
 
 <Sandpack>
 
@@ -338,69 +340,58 @@ Displaying a form submission error message before the JavaScript bundle loads fo
 1. the function passed to the `<form>`'s `action` prop be a [Server Function](/reference/rsc/server-functions)
 1. the `useActionState` Hook be used to display the error message
 
-`useActionState` takes two parameters: a [Server Function](/reference/rsc/server-functions) and an initial state. `useActionState` returns two values, a state variable and an Action. The Action returned by `useActionState` should be passed to the `action` prop of the form. The state variable returned by `useActionState` can be used to display an error message. The value returned by the Server Function passed to `useActionState` will be used to update the state variable.
+Define the Server Function in a separate file with the [`'use server'`](/reference/rsc/use-server) directive. It receives the previous state followed by the submitted `FormData`:
 
-<Sandpack>
+```js
+// actions.js
+'use server';
 
-```js src/App.js
-import { useActionState } from 'react';
 import { signUpNewUser } from './api.js';
 
-export default function Page() {
-  async function signup(prevState, formData) {
-    'use server';
-    const email = formData.get('email');
-    try {
-      await signUpNewUser(email);
-      alert(`Added "${email}"`);
-    } catch (err) {
-      return err.toString();
-    }
+export async function signup(previousState, formData) {
+  const email = formData.get('email');
+  try {
+    await signUpNewUser(email);
+    return null;
+  } catch (error) {
+    return error.message;
   }
+}
+```
+
+In a Client Component, pass the Server Function to `useActionState`. Pass the returned Action to the form's `action` prop and render the returned state:
+
+```js
+// Signup.js
+'use client';
+
+import { useActionState } from 'react';
+import { signup } from './actions.js';
+
+export default function Signup() {
   const [message, signupAction] = useActionState(signup, null);
   return (
-    <>
-      <h1>Signup for my newsletter</h1>
-      <p>Signup with the same email twice to see an error</p>
-      <form action={signupAction} id="signup-form">
-        <label htmlFor="email">Email: </label>
-        <input name="email" id="email" placeholder="react@example.com" />
-        <button>Sign up</button>
-        {!!message && <p>{message}</p>}
-      </form>
-    </>
+    <form action={signupAction}>
+      <label htmlFor="email">Email: </label>
+      <input name="email" id="email" placeholder="react@example.com" />
+      <button>Sign up</button>
+      {message && <p>{message}</p>}
+    </form>
   );
 }
 ```
 
-```js src/api.js hidden
-let emails = [];
-
-export async function signUpNewUser(newEmail) {
-  if (emails.includes(newEmail)) {
-    throw new Error('This email address has already been added');
-  }
-  emails.push(newEmail);
-}
-```
-
-</Sandpack>
-
-To learn more about updating state from a form Action, see the [`useActionState`](/reference/react/useActionState) docs.
+If the form is submitted before JavaScript loads, React includes the Server Function's returned error message in the server-rendered response.
 
 ---
 
 ### Preserving form values after submission {/*preserve-form-values-after-submission*/}
 
-By default, the browser clears a form's input state after submission. Forms with a URL `action` follow this behavior, and React mirrors it when `action` is a function so the form behaves consistently before and after JavaScript loads.
-
-When you pass a function to `action` or `formAction`, React resets the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. This reset only affects uncontrolled fields-[inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are not cleared.
-
-<Recipes titleText="Examples of preserving form values" titleId="examples-preserve-form-values">
+Submitting a form with a URL `action` clears its input state. React mirrors this behavior when `action` is a function by resetting the form's [uncontrolled fields](/reference/react-dom/components/input#reading-the-input-values-when-submitting-a-form) after the Action succeeds. When a Server Function progressively enhances a form, this keeps its behavior consistent before and after JavaScript loads. [Inputs controlled with state](/reference/react-dom/components/input#controlling-an-input-with-a-state-variable) are not cleared.
 
 #### Restore fields with `useActionState` {/*with-useactionstate*/}
 
-Pass the action returned by [`useActionState`](/reference/react/useActionState) to the `action` prop. Return the values you want to keep from your Action, and pass them to each field's `defaultValue`. React restores those values instead of clearing them.
+Pass the Action returned by [`useActionState`](/reference/react/useActionState) to the `action` prop. Return the values you want to keep from your Action, and pass them to each field's `defaultValue`. The automatic form reset restores those default values instead of clearing the fields.
 
 <Sandpack>
 
@@ -435,85 +426,19 @@ export async function submitForm(previousState, formData) {
 
 </Sandpack>
 
-<Solution />
-
-#### Keep every field with `onSubmit` {/*with-onsubmit-and-usetransition*/}
-
-Call `e.preventDefault()` in an `onSubmit` handler and run the Action yourself with [`startTransition`](/reference/react/useTransition). React doesn't reset the form because the `action` prop never runs. Keep passing `action` so the form still submits before JavaScript loads.
-
-<Sandpack>
-
-```js src/App.js
-import { useTransition } from 'react';
-import { submitForm } from './api.js';
-
-export default function EditForm() {
-  const [isPending, startTransition] = useTransition();
-
-  function handleSubmit(e) {
-    // Stop React from resetting the form after the Action succeeds
-    e.preventDefault();
-    const formData = new FormData(e.target);
-    startTransition(async () => {
-      await submitForm(formData);
-    });
-  }
-
-  return (
-    <form action={submitForm} onSubmit={handleSubmit}>
-      <input name="title" defaultValue="My draft" />
-      <button type="submit" disabled={isPending}>
-        {isPending ? 'Saving...' : 'Save'}
-      </button>
-    </form>
-  );
-}
-```
-
-```js src/api.js hidden
-export async function submitForm(formData) {
-  await new Promise((res) => setTimeout(res, 1000));
-}
-```
-
-</Sandpack>
-
-<Solution />
-
-</Recipes>
-
-You can also reset only some fields, or restore values from the server on validation failure.
-
 <DeepDive>
 
-#### Resetting only some fields, or resetting on the server {/*resetting-only-some-fields*/}
+#### Choosing how to manage form values {/*choosing-how-to-manage-form-values*/}
 
-The `onSubmit` approach above keeps every uncontrolled field. For finer control, you can:
+Choose an approach based on what should happen after submission:
 
-* **Reset from your own Action API.** If you build an Action-based API and still want the form to reset after the Action runs, call [`requestFormReset`](/blog/2024/12/05/react-19#form-actions) from `react-dom` with the form element inside the Transition.
+* **Preserve selected values with `useActionState`.** The example above returns the submitted title after every submission. To preserve values only when validation fails, return the submitted `FormData` in the error state and use it to set each field's `defaultValue`. With a Server Function, React can include those values in the server response before JavaScript loads.
 
-* **Reset to server-provided values on validation failure.** The [`useActionState`](#with-useactionstate) example above preserves values after a successful submission. When an Action validates input on the server, you can return the submitted `FormData` and pass it to each field's `defaultValue`. React restores those values instead of clearing them, and the form keeps working before JavaScript loads:
+* **Keep every value with `onSubmit`.** Call `e.preventDefault()`, then run the Action inside [`startTransition`](/reference/react/useTransition). Calling `preventDefault()` prevents the function passed to the form's `action` prop from running for that submission, so React does not automatically reset the form.
 
-```js
-import { useActionState } from 'react';
-import { submitForm } from './actions.js';
+* **Reset fields at a specific point.** Call the form element's [`reset()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset) method to immediately reset uncontrolled fields to their default values. To schedule the same reset inside an Action or Transition, call [`requestFormReset`](/blog/2024/12/05/react-19#form-actions) from `react-dom`.
 
-function EditForm() {
-  // The Action returns { submitted: formData, error } on failure
-  const [state, formAction] = useActionState(submitForm, {
-    error: '',
-  });
-  return (
-    <form action={formAction}>
-      <input name="title" defaultValue={state.submitted?.get('title') ?? ''} />
-      {state.error && <p>{state.error}</p>}
-      <button type="submit">Save</button>
-    </form>
-  );
-}
-```
-
-Return the original `FormData` object rather than a new one so React can restore the values even before JavaScript has loaded.
+* **Reset the fields and component state.** Change the [`key`](/learn/preserving-and-resetting-state#resetting-a-form-with-a-key) on the component that renders the form. React recreates the component and its DOM, so its fields and local state both start over.
 
 </DeepDive>
 
@@ -521,9 +446,7 @@ Return the original `FormData` object rather than a new one so React can restore
 
 ### Handling multiple submission types {/*handling-multiple-submission-types*/}
 
-A form can have more than one submit button, each running a different Action. Set the `formAction` prop on a `<button>` to override the `<form>`'s `action` when that button submits the form.
-
-When a button without `formAction` submits the form, React calls the form's `action`. When a button with `formAction` submits the form, React calls that button's `formAction` instead. For example, the form below publishes an article by default, but its **Save draft** button stores the current content without publishing it:
+A form can have more than one submit button, each running a different Action. A button without `formAction` runs the form's `action`; a button with `formAction` runs its own Action instead. For example, the form below publishes an article by default, but its **Save draft** button stores the current content without publishing it:
 
 <Sandpack>
 

--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -1184,13 +1184,70 @@ hr {
 
 In this example, when the user clicks the stepper arrows, the button submits the form and `useActionState` calls `updateCartAction` with the form data. The example uses `useOptimistic` to immediately show the new quantity while the server confirms the update.
 
+#### Displaying validation errors and preserving form values {/*displaying-validation-errors-and-preserving-form-values*/}
+
+Return validation errors and submitted values from the Action to display an error without clearing the affected fields. Try submitting a name with fewer than three characters:
+
+<Sandpack>
+
+```js src/App.js active
+import { useActionState } from 'react';
+import { updateName } from './api.js';
+
+const initialState = {
+  error: null,
+  submitted: null,
+};
+
+export default function UpdateName() {
+  const [state, submitAction, isPending] = useActionState(
+    updateName,
+    initialState
+  );
+
+  return (
+    <form action={submitAction}>
+      <label>
+        Name:{' '}
+        <input
+          name="name"
+          defaultValue={state.submitted?.get('name') ?? ''}
+          disabled={isPending}
+        />
+      </label>
+      <button type="submit" disabled={isPending}>Save</button>
+      {state.error && <p>{state.error}</p>}
+    </form>
+  );
+}
+```
+
+```js src/api.js hidden
+export async function updateName(previousState, formData) {
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  const name = formData.get('name');
+  if (typeof name !== 'string' || name.trim().length < 3) {
+    return {
+      error: 'Name must be at least three characters long',
+      submitted: formData,
+    };
+  }
+  return {
+    error: null,
+    submitted: null,
+  };
+}
+```
+
+</Sandpack>
+
+When validation fails, `updateName` returns an error and the submitted `FormData`. The component uses the submitted name as the input's new `defaultValue`, so React's automatic form reset preserves it. When validation succeeds, `submitted` is `null`, so the automatic reset clears the field.
+
 <RSC>
 
-When used with a [Server Function](/reference/rsc/server-functions), `useActionState` allows the server's response to be shown before hydration (when React attaches to server-rendered HTML) completes. You can also use the optional `permalink` parameter for progressive enhancement (allowing the form to work before JavaScript loads) on pages with dynamic content. This is typically handled by your framework for you.
+When the `reducerAction` passed to `useActionState` is a [Server Function](/reference/rsc/server-functions), pass the returned `submitAction` to the form's `action` prop. React can then display the Server Function's returned value before hydration completes. Return the submitted `FormData` and use it to set each field's `defaultValue` to preserve those values before JavaScript loads. On pages with dynamic content, you can also use the optional `permalink` parameter for progressive enhancement. This is typically handled by your framework for you.
 
 </RSC>
-
-See the [`<form>`](/reference/react-dom/components/form#handle-form-submission-with-a-server-function) docs for more information on using Actions with forms.
 
 ---
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

## Summary

Documents React’s default form-reset behavior when using the function `action` / `formAction` props, and explains how to preserve field values when you don’t want that reset. Applying @rickhanlonii's feedback from #7795 and building off of work @aurorascharff recentlly did. 

- Adds default reset behavior in Caveats, the `action` prop section, and a new Troubleshooting entry (“Why does my form reset when I use an action?”). React resets **uncontrolled** fields after a successful action, matching browser `<form action="...">` behavior (including before JS loads).
- **Adds “Preserve form values after submission”** with a Sandpack example: call `e.preventDefault()` in `onSubmit`, then run the action manually inside `useTransition` while keeping the `action` prop for progressive enhancement.
- **Adds a DeepDive** for finer control: `requestFormReset` from `react-dom`, and returning submitted `FormData` from server actions to restore values via `defaultValue` (with `useActionState`).
- **Updates the multiple-submission-types example** to a draft/publish scenario that shows how controlled state and `key`/`defaultValue` keep textarea content after “Save draft.”


Closes #8397 

Alternative to #7795  and #8465