### PR TITLE
docs: fix confusing useMemo initial render wording (fixes #7752)

### DIFF
--- a/src/content/reference/react/useMemo.md
+++ b/src/content/reference/react/useMemo.md
@@ -50,7 +50,7 @@ function TodoList({ todos, tab }) {
 
 #### Returns {/*returns*/}
 
-On the initial render, `useMemo` returns the result of calling `calculateValue` with no arguments.
+On the initial render, `useMemo` returns the result of calling `calculateValue`.
 
 During next renders, it will either return an already stored value from the last render (if the dependencies haven't changed), or call `calculateValue` again, and return the result that `calculateValue` has returned.
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The Returns section of the `useMemo` reference stated that React calls `calculateValue` "with no arguments," which reads as if the memoized computation itself takes no inputs even though examples pass dependencies.

Removed the redundant "with no arguments" phrase so the initial-render description matches the Usage section below it.

**Before:**
> On the initial render, `useMemo` returns the result of calling `calculateValue` with no arguments.

**After:**
> On the initial render, `useMemo` returns the result of calling `calculateValue`.

Closes #7752