### PR TITLE
DOC: clarify SSR metadata hoisting for fragments

### DIFF
--- a/src/content/reference/react-dom/components/title.md
+++ b/src/content/reference/react-dom/components/title.md
@@ -38,6 +38,8 @@ To specify the title of the document, render the [built-in browser `<title>` com
 
 React will always place the DOM element corresponding to the `<title>` component within the document’s `<head>`, regardless of where in the React tree it is rendered. The `<head>` is the only valid place for `<title>` to exist within the DOM, yet it’s convenient and keeps things composable if a component representing a specific page can render its `<title>` itself.
 
+When using server rendering for only a fragment of a document (for example, rendering into a `<div id="root">`), React cannot move the `<title>` into the actual HTML `<head>` in the server response. For metadata that must be present in the initial HTML, render it in your server-side document template as well.
+
 There are two exception to this:
 * If `<title>` is within an `<svg>` component, then there is no special behavior, because in this context it doesn’t represent the document’s title but rather is an [accessibility annotation for that SVG graphic](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title).
 * If the `<title>` has an [`itemProp`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemprop) prop, there is no special behavior, because in this case it doesn’t represent the document’s title but rather metadata about a specific part of the page.


### PR DESCRIPTION
This clarifies the SSR edge case for `<title>` when React renders only a fragment inside an existing document. In that setup, the initial server response cannot move the tag into the real HTML `<head>`, so SEO-critical metadata should also be rendered by the server-side document template.

Fixes #8559