### PR TITLE
Add cache, cacheSignal, and captureOwnerStack to the APIs overview

### DIFF
--- a/src/content/reference/react/apis.md
+++ b/src/content/reference/react/apis.md
@@ -15,6 +15,9 @@ In addition to [Hooks](/reference/react/hooks) and [Components](/reference/react
 * [`memo`](/reference/react/memo) lets your component skip re-renders with same props. Used with [`useMemo`](/reference/react/useMemo) and [`useCallback`.](/reference/react/useCallback)
 * [`startTransition`](/reference/react/startTransition) lets you mark a state update as non-urgent. Similar to [`useTransition`.](/reference/react/useTransition)
 * [`act`](/reference/react/act) lets you wrap renders and interactions in tests to ensure updates have processed before making assertions.
+* [`cache`](/reference/react/cache) lets you cache the result of a data fetch or computation.
+* [`cacheSignal`](/reference/react/cacheSignal) lets you know when the `cache()` lifetime is over.
+* [`captureOwnerStack`](/reference/react/captureOwnerStack) reads the current Owner Stack in development and returns it as a string if available.
 
 ---
 


### PR DESCRIPTION
The Built-in React APIs page lists all modern React APIs, but it was missing `cache`, `cacheSignal`, and `captureOwnerStack`, each of which has a dedicated reference page. This adds all three.

**Before**: missing `cache`, `cacheSignal`, and `captureOwnerStack`
<img width="2032" height="1232" alt="Screenshot 2026-08-15 at 6 48 53 AM" src="https://github.com/user-attachments/assets/4bfcc16b-d91b-45b3-8497-e4c0eceeefdf" />

**After**: with `cache`, `cacheSignal`, and `captureOwnerStack` added
<img width="2032" height="1232" alt="Screenshot 2026-08-15 at 6 49 01 AM" src="https://github.com/user-attachments/assets/70ff85a2-b2fa-453b-8e2b-a4e9e5526264" />