### PR TITLE
Fix resume and resumeToPipeableStream links

### DIFF
--- a/src/content/reference/react-dom/server/index.md
+++ b/src/content/reference/react-dom/server/index.md
@@ -15,7 +15,7 @@ The `react-dom/server` APIs let you server-side render React components to HTML.
 These methods are only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), which includes browsers, Deno, and some modern edge runtimes:
 
 * [`renderToReadableStream`](/reference/react-dom/server/renderToReadableStream) renders a React tree to a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
-* [`resume`](/reference/react-dom/server/renderToPipeableStream) resumes [`prerender`](/reference/react-dom/static/prerender) to a [Readable Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+* [`resume`](/reference/react-dom/server/resume) resumes [`prerender`](/reference/react-dom/static/prerender) to a [Readable Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
 
 <Note>
@@ -30,7 +30,7 @@ Node.js also includes these methods for compatibility, but they are not recommen
 These methods are only available in the environments with [Node.js Streams:](https://nodejs.org/api/stream.html)
 
 * [`renderToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) renders a React tree to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
-* [`resumeToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) resumes [`prerenderToNodeStream`](/reference/react-dom/static/prerenderToNodeStream) to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
+* [`resumeToPipeableStream`](/reference/react-dom/server/resumeToPipeableStream) resumes [`prerenderToNodeStream`](/reference/react-dom/static/prerenderToNodeStream) to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
 
 ---
 


### PR DESCRIPTION
The `resume` and `resumeToPipeableStream` entries in the Server React DOM APIs page linked to `renderToPipeableStream` instead of their own reference pages. This fixes both links.

**Before**: `resume` redirected to `renderToPipeableStream`
<img width="2032" height="1232" alt="Screenshot 2026-08-15 at 7 11 13 AM" src="https://github.com/user-attachments/assets/98f216cd-4f43-46a1-9e1c-da51632427e0" />
<img width="1072" height="1232" alt="Screenshot 2026-08-15 at 7 10 21 AM" src="https://github.com/user-attachments/assets/be8bd61b-f52c-40cf-b899-41862dc81953" />

**After**: `resume` redirects to its own page
<img width="1072" height="1232" alt="Screenshot 2026-08-15 at 7 10 25 AM" src="https://github.com/user-attachments/assets/73e4e59c-4b14-474a-b454-fcac0cf6c121" />
