### PR TITLE
Fix API Reference link to point to /reference/react

### DIFF
--- a/src/content/blog/2023/03/16/introducing-react-dev.md
+++ b/src/content/blog/2023/03/16/introducing-react-dev.md
@@ -42,7 +42,7 @@ When we released React Hooks in 2018, the Hooks docs assumed the reader is famil
 **The new docs teach React with Hooks from the beginning.** The docs are divided in two main sections:
 
 * **[Learn React](/learn)** is a self-paced course that teaches React from scratch.
-* **[API Reference](/reference)** provides the details and usage examples for every React API.
+* **[API Reference](/reference/react)** provides the details and usage examples for every React API.
 
 Let's have a closer look at what you can find in each section.
 


### PR DESCRIPTION
The `/reference` root has no landing page (only `/reference/react`, `/reference/react-dom`, etc.), so the link 404'd. Point it at the React API reference landing.