### PR TITLE
docs: clarify iterable render returns

### DIFF
--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -581,9 +581,9 @@ You should write the `render` method as a pure function, meaning that it should 
 
 - `render` will not get called if [`shouldComponentUpdate`](#shouldcomponentupdate) is defined and returns `false`.
 
-- If you return an iterator from `render`, make sure each render creates a fresh iterator. React may render more than once in development, and a reused iterator may already be consumed. When possible, prefer returning an array or another reusable iterable.
-
 - When [Strict Mode](/reference/react/StrictMode) is on, React will call `render` twice in development and then throw away one of the results. This helps you notice the accidental side effects that need to be moved out of the `render` method.
+
+- If you return an iterator from `render`, make sure each render creates a fresh iterator. Iterators are consumed on use, so a reused iterator may already be empty. When possible, prefer returning an array or another reusable iterable.
 
 - There is no one-to-one correspondence between the `render` call and the subsequent `componentDidMount` or `componentDidUpdate` call. Some of the `render` call results may be discarded by React when it's beneficial.
 

--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -573,13 +573,15 @@ You should write the `render` method as a pure function, meaning that it should 
 
 #### Returns {/*render-returns*/}
 
-`render` can return any valid React node. This includes React elements such as `<div />`, strings, numbers, [portals](/reference/react-dom/createPortal), empty nodes (`null`, `undefined`, `true`, and `false`), and arrays of React nodes.
+`render` can return any valid React node. This includes React elements such as `<div />`, strings, numbers, [portals](/reference/react-dom/createPortal), empty nodes (`null`, `undefined`, `true`, and `false`), arrays of React nodes, and iterables of React nodes.
 
 #### Caveats {/*render-caveats*/}
 
 - `render` should be written as a pure function of props, state, and context. It should not have side effects.
 
 - `render` will not get called if [`shouldComponentUpdate`](#shouldcomponentupdate) is defined and returns `false`.
+
+- If you return an iterator from `render`, make sure each render creates a fresh iterator. React may render more than once in development, and a reused iterator may already be consumed. When possible, prefer returning an array or another reusable iterable.
 
 - When [Strict Mode](/reference/react/StrictMode) is on, React will call `render` twice in development and then throw away one of the results. This helps you notice the accidental side effects that need to be moved out of the `render` method.
 


### PR DESCRIPTION
## Summary

Clarify that `render` may return iterables of React nodes, and warn that iterators should be recreated each render.

Fixes #286

## Why

This avoids confusion around returning iterators from class components in development, where React may call `render` more than once and a reused iterator can already be consumed.

## Changes

- mention iterables as valid render return values
- put the Strict Mode caveat first
- warn that iterators are consumed on use, so each render should create a fresh one