### PR TITLE
Fix YouTube video overflow on mobile

### DIFF
--- a/src/content/versions.md
+++ b/src/content/versions.md
@@ -325,4 +325,7 @@ See the first blog post: [Why did we build React?](https://legacy.reactjs.org/bl
 
 React was open sourced at Facebook Seattle in 2013:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/XxVg_s8xAms?si=466vSJrnXTn05j9A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<YouTubeIframe
+  title="React was open sourced at Facebook Seattle in 2013"
+  src="https://www.youtube.com/embed/XxVg_s8xAms?si=466vSJrnXTn05j9A"
+/>


### PR DESCRIPTION
## Description
Fixes horizontal overflow on the Versions page caused by a fixed-size (560×315) YouTube iframe on mobile viewports (~430–440px wide). Replaced it with the existing responsive `YouTubeIframe` component already used elsewhere in the codebase, instead of introducing a new fix.

## Testing
- Tested at 320px, 768px, and 1440px viewport widths
- Verified the YouTube iframe scales responsively at all sizes
- Verified `scrollWidth` matches viewport width (no horizontal overflow)
- `yarn lint` passes
- `git diff --check` passes

Fixes #8452