### PR TITLE
Pin matching React Canary versions in Sandpack demos

### DIFF
--- a/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
+++ b/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
@@ -1245,8 +1245,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -2442,8 +2442,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -3670,8 +3670,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -4879,8 +4879,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -6195,8 +6195,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -7493,8 +7493,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -8814,8 +8814,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -10155,8 +10155,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -11441,8 +11441,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -12840,8 +12840,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -14178,8 +14178,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
+++ b/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
@@ -1245,8 +1245,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -2442,8 +2442,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -3670,8 +3670,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -4879,8 +4879,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -6195,8 +6195,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -7493,8 +7493,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -8814,8 +8814,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -10155,8 +10155,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -11441,8 +11441,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -12840,8 +12840,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -14178,8 +14178,8 @@ root.render(
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -169,8 +169,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -169,8 +169,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -511,8 +511,8 @@ export default function App() {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -620,8 +620,8 @@ label {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -716,8 +716,8 @@ p {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -828,8 +828,8 @@ export default function Card({ title }) {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -1018,8 +1018,8 @@ export default function Card({ title, className }) {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -511,8 +511,8 @@ export default function App() {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -620,8 +620,8 @@ label {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -716,8 +716,8 @@ p {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -828,8 +828,8 @@ export default function Card({ title }) {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -1018,8 +1018,8 @@ export default function Card({ title, className }) {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2478,8 +2478,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -2843,8 +2843,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -3001,8 +3001,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -3134,8 +3134,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -3351,8 +3351,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2478,8 +2478,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -2843,8 +2843,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -3001,8 +3001,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -3134,8 +3134,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -3351,8 +3351,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -436,8 +436,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -576,8 +576,8 @@ function Counter() {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -800,8 +800,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -1034,8 +1034,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -1235,8 +1235,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -1497,8 +1497,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -1728,8 +1728,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -1974,8 +1974,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -2303,8 +2303,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -2529,8 +2529,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }
@@ -2774,8 +2774,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -436,8 +436,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -576,8 +576,8 @@ function Counter() {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -800,8 +800,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -1034,8 +1034,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -1235,8 +1235,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -1497,8 +1497,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -1728,8 +1728,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -1974,8 +1974,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -2303,8 +2303,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -2529,8 +2529,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }
@@ -2774,8 +2774,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -1432,8 +1432,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-eafeac09-20260819",
-    "react-dom": "19.3.0-canary-eafeac09-20260819",
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -1432,8 +1432,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "canary",
-    "react-dom": "canary",
+    "react": "19.3.0-canary-eafeac09-20260819",
+    "react-dom": "19.3.0-canary-eafeac09-20260819",
     "react-scripts": "latest"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- pin `react` and `react-dom` to the same exact Canary build in all 34 Canary Sandpack manifests
- cover the `browser`, `use`, `Suspense`, `ViewTransition`, and `Fragment` references, plus the View Transitions Labs post
- prevent Sandpack caches from resolving identical floating `canary` tags to incompatible React builds

## Why

Sandpack can cache the two floating `canary` dependencies independently. One browser demo resolved `react` to `19.3.0-canary-eb8feb71-20260814` and `react-dom` to `19.3.0-canary-eafeac09-20260819`, which fails because the packages require exact version equality.

This pins both packages to the August 14 build, which is available through react.dev's custom Sandpack bundler and includes the `browser` API used by the new examples.

## Verification

- confirmed no floating `react` or `react-dom` Canary dependencies remain in source content
- ran the `browser` docs example against react.dev's custom Sandpack bundler: server rendering showed the Suspense fallback, then hydration displayed the browser-only editor
- Prettier check on all six changed Markdown files
- heading ID check on all six changed Markdown files
- `git diff --check`
