### PR TITLE
Improve the browser-only rendering example

### DIFF
--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -69,7 +69,7 @@ Call `browser` inside `use` in a component that should only render in the browse
 
 You can use this instead of checking `typeof window`, waiting for an [`Effect`](/reference/react/useEffect) to set mounted state, or using a framework option to disable server rendering.
 
-Press **Load draft**. The initial HTML contains the loading fallback. After hydration, React displays the draft loaded from `localStorage`.
+Click **Reload** to see the loading fallback in the initial HTML. After hydration, React displays the draft loaded from `localStorage`.
 
 <Sandpack>
 
@@ -104,9 +104,12 @@ function SavedDraft() {
 
 export default function App() {
   return (
-    <Suspense fallback={<p>Loading draft...</p>}>
-      <SavedDraft />
-    </Suspense>
+    <>
+      <h1>Saved draft</h1>
+      <Suspense fallback={<p>Loading draft...</p>}>
+        <SavedDraft />
+      </Suspense>
+    </>
   );
 }
 ```
@@ -120,6 +123,7 @@ export default function Document() {
       <head>
         <title>Saved draft</title>
         <style>{`
+          h1 { font-size: 24px; margin-top: 0; }
           label, textarea { display: block; }
           textarea { margin-top: 5px; }
         `}</style>
@@ -148,11 +152,7 @@ async function main(frame) {
   hydrateRoot(frame.contentDocument, <Document />);
 }
 
-const renderButton = document.getElementById('render');
-renderButton.addEventListener('click', () => {
-  renderButton.disabled = true;
-  main(document.getElementById('preview'));
-}, { once: true });
+main(document.getElementById('preview'));
 ```
 
 ```js src/demo-helpers.js hidden
@@ -182,8 +182,6 @@ export async function flushReadableStreamToFrame(readable, frame) {
   <title>Browser-only rendering</title>
 </head>
 <body>
-  <button id="render">Load draft</button>
-  <br /><br />
   <iframe id="preview" title="Rendered page"></iframe>
 </body>
 </html>
@@ -192,7 +190,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
 ```css src/styles.css hidden
 iframe {
   width: 100%;
-  height: 120px;
+  height: 160px;
   border: 0;
 }
 ```

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -69,7 +69,7 @@ Call `browser` inside `use` in a component that should only render in the browse
 
 You can use this instead of checking `typeof window`, waiting for an [`Effect`](/reference/react/useEffect) to set mounted state, or using a framework option to disable server rendering.
 
-Press **Render the page** to see the loading fallback. React then displays a draft loaded from `localStorage`.
+Press **Load draft**. The initial HTML contains the loading fallback. After hydration, React displays the draft loaded from `localStorage`.
 
 <Sandpack>
 
@@ -182,7 +182,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
   <title>Browser-only rendering</title>
 </head>
 <body>
-  <button id="render">Render the page</button>
+  <button id="render">Load draft</button>
   <br /><br />
   <iframe id="preview" title="Rendered page"></iframe>
 </body>

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -69,23 +69,43 @@ Call `browser` inside `use` in a component that should only render in the browse
 
 You can use this instead of checking `typeof window`, waiting for an [`Effect`](/reference/react/useEffect) to set mounted state, or using a framework option to disable server rendering.
 
-Press **Render the page**. The loading fallback appears first. After a short delay, React hydrates the page and displays the browser-only editor.
+Press **Render the page** to see the loading fallback. React then displays a draft loaded from `localStorage`.
 
 <Sandpack>
 
 ```js src/App.js active
-import { Suspense, use } from 'react';
+import { Suspense, use, useState } from 'react';
 import { browser } from 'react-dom';
 
-function BrowserOnlyEditor() {
-  use(browser('The editor requires browser APIs.'));
-  return <label>Draft: <input /></label>;
+function SavedDraft() {
+  use(browser('The draft is stored in localStorage.'));
+  const [draft, setDraft] = useState(
+    () => localStorage.getItem('draft') ?? ''
+  );
+
+  function handleChange(event) {
+    const nextDraft = event.target.value;
+    setDraft(nextDraft);
+    localStorage.setItem('draft', nextDraft);
+  }
+
+  return (
+    <label>
+      Draft:
+      <textarea
+        value={draft}
+        onChange={handleChange}
+        rows={4}
+        cols={30}
+      />
+    </label>
+  );
 }
 
 export default function App() {
   return (
-    <Suspense fallback={<p>Loading editor...</p>}>
-      <BrowserOnlyEditor />
+    <Suspense fallback={<p>Loading draft...</p>}>
+      <SavedDraft />
     </Suspense>
   );
 }
@@ -98,10 +118,13 @@ export default function Document() {
   return (
     <html lang="en">
       <head>
-        <title>Article editor</title>
+        <title>Saved draft</title>
+        <style>{`
+          label, textarea { display: block; }
+          textarea { margin-top: 5px; }
+        `}</style>
       </head>
       <body>
-        <h1>Article editor</h1>
         <App />
       </body>
     </html>
@@ -109,7 +132,7 @@ export default function Document() {
 }
 ```
 
-```js src/index.js
+```js src/index.js hidden
 import { hydrateRoot } from 'react-dom/client';
 import { renderToReadableStream } from 'react-dom/server';
 import Document from './Document.js';
@@ -151,7 +174,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
 }
 ```
 
-```html public/index.html
+```html public/index.html hidden
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -169,8 +192,8 @@ export async function flushReadableStreamToFrame(readable, frame) {
 ```css src/styles.css hidden
 iframe {
   width: 100%;
-  height: 180px;
-  border: 1px solid #aaa;
+  height: 120px;
+  border: 0;
 }
 ```
 
@@ -199,12 +222,13 @@ In a React Server Components app, `use(browser())` must be called from a Client 
 ```js {1}
 'use client';
 
-import { use } from 'react';
+import { use, useState } from 'react';
 import { browser } from 'react-dom';
 
-export default function BrowserOnlyEditor() {
-  use(browser('The editor requires browser APIs.'));
-  return <Editor />;
+export default function SavedDraft() {
+  use(browser('The saved draft is stored in localStorage.'));
+  const [draft] = useState(() => localStorage.getItem('draft') ?? '');
+  return <DraftEditor initialDraft={draft} />;
 }
 ```
 
@@ -243,18 +267,19 @@ On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is ava
 Pass an `onBrowserBailout` callback to the server renderer to report browser-only rendering. When React leaves a Suspense fallback for the browser, it does not call the server renderer's `onError` callback or [`hydrateRoot`'s `onRecoverableError`](/reference/react-dom/client/hydrateRoot#error-logging-in-production) callback. This example also passes a reason, which is available as the reported error's `cause`:
 
 ```js
-import { Suspense, use } from 'react';
+import { Suspense, use, useState } from 'react';
 import { browser } from 'react-dom';
 import { renderToPipeableStream } from 'react-dom/server';
 
-function BrowserOnlyEditor() {
-  use(browser(() => new Error('The editor requires a browser API.')));
-  return <Editor />;
+function SavedDraft() {
+  use(browser(() => new Error('The saved draft is stored in localStorage.')));
+  const [draft] = useState(() => localStorage.getItem('draft') ?? '');
+  return <DraftEditor initialDraft={draft} />;
 }
 
 const { pipe } = renderToPipeableStream(
-  <Suspense fallback={<p>Loading editor...</p>}>
-    <BrowserOnlyEditor />
+  <Suspense fallback={<p>Loading saved draft...</p>}>
+    <SavedDraft />
   </Suspense>,
   {
     onShellReady() {

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2386,7 +2386,7 @@ The server HTML will include the loading indicator. It will be replaced by the `
 
 A Suspense boundary can provide a fallback for a browser-only component. Wrap the component in `<Suspense>` and call [`use(browser())`](/reference/react/use#use-browser) inside it.
 
-Press **Load draft**. The initial HTML contains the loading fallback. After hydration, React displays the draft loaded from `localStorage`.
+Click **Reload** to see the loading fallback in the initial HTML. After hydration, React displays the draft loaded from `localStorage`.
 
 <Sandpack>
 
@@ -2421,9 +2421,12 @@ function SavedDraft() {
 
 export default function App() {
   return (
-    <Suspense fallback={<p>Loading draft...</p>}>
-      <SavedDraft />
-    </Suspense>
+    <>
+      <h1>Saved draft</h1>
+      <Suspense fallback={<p>Loading draft...</p>}>
+        <SavedDraft />
+      </Suspense>
+    </>
   );
 }
 ```
@@ -2437,6 +2440,7 @@ export default function Document() {
       <head>
         <title>Saved draft</title>
         <style>{`
+          h1 { font-size: 24px; margin-top: 0; }
           label, textarea { display: block; }
           textarea { margin-top: 5px; }
         `}</style>
@@ -2465,11 +2469,7 @@ async function main(frame) {
   hydrateRoot(frame.contentDocument, <Document />);
 }
 
-const renderButton = document.getElementById('render');
-renderButton.addEventListener('click', () => {
-  renderButton.disabled = true;
-  main(document.getElementById('preview'));
-}, { once: true });
+main(document.getElementById('preview'));
 ```
 
 ```js src/demo-helpers.js hidden
@@ -2499,8 +2499,6 @@ export async function flushReadableStreamToFrame(readable, frame) {
   <title>Browser-only rendering</title>
 </head>
 <body>
-  <button id="render">Load draft</button>
-  <br /><br />
   <iframe id="preview" title="Rendered page"></iframe>
 </body>
 </html>
@@ -2509,7 +2507,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
 ```css src/styles.css hidden
 iframe {
   width: 100%;
-  height: 120px;
+  height: 160px;
   border: 0;
 }
 ```

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2386,23 +2386,43 @@ The server HTML will include the loading indicator. It will be replaced by the `
 
 A Suspense boundary can provide a fallback for a browser-only component. Wrap the component in `<Suspense>` and call [`use(browser())`](/reference/react/use#use-browser) inside it.
 
-Press **Render the page**. The loading fallback appears first. After a short delay, React hydrates the page and displays the browser-only editor.
+Press **Render the page** to see the loading fallback. React then displays a draft loaded from `localStorage`.
 
 <Sandpack>
 
 ```js src/App.js active
-import { Suspense, use } from 'react';
+import { Suspense, use, useState } from 'react';
 import { browser } from 'react-dom';
 
-function BrowserOnlyEditor() {
-  use(browser('The editor requires browser APIs.'));
-  return <label>Draft: <input /></label>;
+function SavedDraft() {
+  use(browser('The draft is stored in localStorage.'));
+  const [draft, setDraft] = useState(
+    () => localStorage.getItem('draft') ?? ''
+  );
+
+  function handleChange(event) {
+    const nextDraft = event.target.value;
+    setDraft(nextDraft);
+    localStorage.setItem('draft', nextDraft);
+  }
+
+  return (
+    <label>
+      Draft:
+      <textarea
+        value={draft}
+        onChange={handleChange}
+        rows={4}
+        cols={30}
+      />
+    </label>
+  );
 }
 
 export default function App() {
   return (
-    <Suspense fallback={<p>Loading editor...</p>}>
-      <BrowserOnlyEditor />
+    <Suspense fallback={<p>Loading draft...</p>}>
+      <SavedDraft />
     </Suspense>
   );
 }
@@ -2415,10 +2435,13 @@ export default function Document() {
   return (
     <html lang="en">
       <head>
-        <title>Article editor</title>
+        <title>Saved draft</title>
+        <style>{`
+          label, textarea { display: block; }
+          textarea { margin-top: 5px; }
+        `}</style>
       </head>
       <body>
-        <h1>Article editor</h1>
         <App />
       </body>
     </html>
@@ -2426,7 +2449,7 @@ export default function Document() {
 }
 ```
 
-```js src/index.js
+```js src/index.js hidden
 import { hydrateRoot } from 'react-dom/client';
 import { renderToReadableStream } from 'react-dom/server';
 import Document from './Document.js';
@@ -2468,7 +2491,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
 }
 ```
 
-```html public/index.html
+```html public/index.html hidden
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2486,8 +2509,8 @@ export async function flushReadableStreamToFrame(readable, frame) {
 ```css src/styles.css hidden
 iframe {
   width: 100%;
-  height: 180px;
-  border: 1px solid #aaa;
+  height: 120px;
+  border: 0;
 }
 ```
 
@@ -2509,7 +2532,7 @@ iframe {
 
 </Sandpack>
 
-During server rendering, React includes the Suspense boundary's fallback in the HTML. In the browser, React replaces the fallback with the editor.
+During server rendering, React includes the Suspense boundary's fallback in the HTML. In the browser, React replaces the fallback with the saved draft.
 
 ---
 

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2386,7 +2386,7 @@ The server HTML will include the loading indicator. It will be replaced by the `
 
 A Suspense boundary can provide a fallback for a browser-only component. Wrap the component in `<Suspense>` and call [`use(browser())`](/reference/react/use#use-browser) inside it.
 
-Press **Render the page** to see the loading fallback. React then displays a draft loaded from `localStorage`.
+Press **Load draft**. The initial HTML contains the loading fallback. After hydration, React displays the draft loaded from `localStorage`.
 
 <Sandpack>
 
@@ -2499,7 +2499,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
   <title>Browser-only rendering</title>
 </head>
 <body>
-  <button id="render">Render the page</button>
+  <button id="render">Load draft</button>
   <br /><br />
   <iframe id="preview" title="Rendered page"></iframe>
 </body>

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -1332,23 +1332,43 @@ async function getData(url) {
 
 Pass the value returned by [`browser`](/reference/react-dom/browser) to `use` inside a component that should only render in the browser.
 
-Press **Render the page**. The loading fallback appears first. After a short delay, React hydrates the page and displays the browser-only editor.
+Press **Render the page** to see the loading fallback. React then displays a draft loaded from `localStorage`.
 
 <Sandpack>
 
 ```js src/App.js active
-import { Suspense, use } from 'react';
+import { Suspense, use, useState } from 'react';
 import { browser } from 'react-dom';
 
-function BrowserOnlyEditor() {
-  use(browser('The editor requires browser APIs.'));
-  return <label>Draft: <input /></label>;
+function SavedDraft() {
+  use(browser('The draft is stored in localStorage.'));
+  const [draft, setDraft] = useState(
+    () => localStorage.getItem('draft') ?? ''
+  );
+
+  function handleChange(event) {
+    const nextDraft = event.target.value;
+    setDraft(nextDraft);
+    localStorage.setItem('draft', nextDraft);
+  }
+
+  return (
+    <label>
+      Draft:
+      <textarea
+        value={draft}
+        onChange={handleChange}
+        rows={4}
+        cols={30}
+      />
+    </label>
+  );
 }
 
 export default function App() {
   return (
-    <Suspense fallback={<p>Loading editor...</p>}>
-      <BrowserOnlyEditor />
+    <Suspense fallback={<p>Loading draft...</p>}>
+      <SavedDraft />
     </Suspense>
   );
 }
@@ -1361,10 +1381,13 @@ export default function Document() {
   return (
     <html lang="en">
       <head>
-        <title>Article editor</title>
+        <title>Saved draft</title>
+        <style>{`
+          label, textarea { display: block; }
+          textarea { margin-top: 5px; }
+        `}</style>
       </head>
       <body>
-        <h1>Article editor</h1>
         <App />
       </body>
     </html>
@@ -1372,7 +1395,7 @@ export default function Document() {
 }
 ```
 
-```js src/index.js
+```js src/index.js hidden
 import { hydrateRoot } from 'react-dom/client';
 import { renderToReadableStream } from 'react-dom/server';
 import Document from './Document.js';
@@ -1414,7 +1437,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
 }
 ```
 
-```html public/index.html
+```html public/index.html hidden
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1432,8 +1455,8 @@ export async function flushReadableStreamToFrame(readable, frame) {
 ```css src/styles.css hidden
 iframe {
   width: 100%;
-  height: 180px;
-  border: 1px solid #aaa;
+  height: 120px;
+  border: 0;
 }
 ```
 
@@ -1455,7 +1478,7 @@ iframe {
 
 </Sandpack>
 
-During server rendering, `use(browser())` suspends the component and React includes the closest Suspense boundary's fallback in the HTML. In the browser, `use(browser())` returns `undefined` and the editor renders normally.
+During server rendering, `use(browser())` suspends the component and React includes the closest Suspense boundary's fallback in the HTML. In the browser, `use(browser())` returns `undefined` and the saved draft renders normally.
 
 ---
 

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -1332,7 +1332,7 @@ async function getData(url) {
 
 Pass the value returned by [`browser`](/reference/react-dom/browser) to `use` inside a component that should only render in the browser.
 
-Press **Load draft**. The initial HTML contains the loading fallback. After hydration, React displays the draft loaded from `localStorage`.
+Click **Reload** to see the loading fallback in the initial HTML. After hydration, React displays the draft loaded from `localStorage`.
 
 <Sandpack>
 
@@ -1367,9 +1367,12 @@ function SavedDraft() {
 
 export default function App() {
   return (
-    <Suspense fallback={<p>Loading draft...</p>}>
-      <SavedDraft />
-    </Suspense>
+    <>
+      <h1>Saved draft</h1>
+      <Suspense fallback={<p>Loading draft...</p>}>
+        <SavedDraft />
+      </Suspense>
+    </>
   );
 }
 ```
@@ -1383,6 +1386,7 @@ export default function Document() {
       <head>
         <title>Saved draft</title>
         <style>{`
+          h1 { font-size: 24px; margin-top: 0; }
           label, textarea { display: block; }
           textarea { margin-top: 5px; }
         `}</style>
@@ -1411,11 +1415,7 @@ async function main(frame) {
   hydrateRoot(frame.contentDocument, <Document />);
 }
 
-const renderButton = document.getElementById('render');
-renderButton.addEventListener('click', () => {
-  renderButton.disabled = true;
-  main(document.getElementById('preview'));
-}, { once: true });
+main(document.getElementById('preview'));
 ```
 
 ```js src/demo-helpers.js hidden
@@ -1445,8 +1445,6 @@ export async function flushReadableStreamToFrame(readable, frame) {
   <title>Browser-only rendering</title>
 </head>
 <body>
-  <button id="render">Load draft</button>
-  <br /><br />
   <iframe id="preview" title="Rendered page"></iframe>
 </body>
 </html>
@@ -1455,7 +1453,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
 ```css src/styles.css hidden
 iframe {
   width: 100%;
-  height: 120px;
+  height: 160px;
   border: 0;
 }
 ```

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -1332,7 +1332,7 @@ async function getData(url) {
 
 Pass the value returned by [`browser`](/reference/react-dom/browser) to `use` inside a component that should only render in the browser.
 
-Press **Render the page** to see the loading fallback. React then displays a draft loaded from `localStorage`.
+Press **Load draft**. The initial HTML contains the loading fallback. After hydration, React displays the draft loaded from `localStorage`.
 
 <Sandpack>
 
@@ -1445,7 +1445,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
   <title>Browser-only rendering</title>
 </head>
 <body>
-  <button id="render">Render the page</button>
+  <button id="render">Load draft</button>
   <br /><br />
   <iframe id="preview" title="Rendered page"></iframe>
 </body>


### PR DESCRIPTION
## Summary

- replace the placeholder editor with a saved-draft example that uses `localStorage`
- reuse the example from the `browser`, `use`, and `Suspense` documentation entry points
- keep `Render the page` so the server-rendered fallback is visible
- hide the rendering and hydration plumbing and simplify the preview styling

## Verification

- `yarn eslint src/content/reference/react-dom/browser.md src/content/reference/react/use.md src/content/reference/react/Suspense.md`
- `yarn lint-heading-ids`
- `git diff --check`
- manually verified the fallback and hydrated draft on all three local documentation pages