### PR TITLE
Add a conditional browser query example

### DIFF
--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -258,6 +258,182 @@ function ProductDetails({ productId, initialData }) {
 
 On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
 
+This example renders one query with initial data and one without it.
+
+Click **Reload** to see the second product's loading fallback before its query resolves.
+
+<Sandpack>
+
+```js src/App.js active
+import { Suspense, use } from 'react';
+import { browser } from 'react-dom';
+import { useQuery } from './query.js';
+
+function useBrowserQuery(query, options) {
+  if (options.initialData === undefined) {
+    use(browser('useBrowserQuery: No initial data was provided.'));
+  }
+  return useQuery(query, options);
+}
+
+function ProductDetails({productId, initialData}) {
+  const product = useBrowserQuery(`/api/products/${productId}`, {
+    initialData,
+  });
+  return <strong>{product.name}</strong>;
+}
+
+export default function App() {
+  return (
+    <>
+      <h1>Featured products</h1>
+      <ul>
+        <li>
+          <ProductDetails
+            productId="react-mug"
+            initialData={{name: 'React mug'}}
+          />
+        </li>
+        <Suspense fallback={<li>Loading another product...</li>}>
+          <li>
+            <ProductDetails productId="react-shirt" />
+          </li>
+        </Suspense>
+      </ul>
+    </>
+  );
+}
+```
+
+```js src/query.js hidden
+import { use } from 'react';
+
+// This is a simplified implementation of a
+// Suspense-enabled query library.
+
+const products = {
+  '/api/products/react-shirt': {name: 'React shirt'},
+};
+
+const cache = new Map();
+
+function fetchProduct(query) {
+  if (!cache.has(query)) {
+    cache.set(
+      query,
+      new Promise(resolve => {
+        setTimeout(() => resolve(products[query]), 600);
+      })
+    );
+  }
+  return cache.get(query);
+}
+
+export function useQuery(query, options) {
+  if (options.initialData !== undefined) {
+    return options.initialData;
+  }
+  return use(fetchProduct(query));
+}
+```
+
+```js src/Document.js hidden
+import App from './App.js';
+
+export default function Document() {
+  return (
+    <html lang="en">
+      <head>
+        <title>Featured products</title>
+        <style>{`
+          h1 { font-size: 24px; margin-top: 0; }
+        `}</style>
+      </head>
+      <body>
+        <App />
+      </body>
+    </html>
+  );
+}
+```
+
+```js src/index.js hidden
+import { hydrateRoot } from 'react-dom/client';
+import { renderToReadableStream } from 'react-dom/server';
+import Document from './Document.js';
+import { flushReadableStreamToFrame } from './demo-helpers.js';
+import './styles.css';
+
+async function main(frame) {
+  const stream = await renderToReadableStream(<Document />);
+  await flushReadableStreamToFrame(stream, frame);
+
+  // Wait so both the fallback and hydrated content are visible.
+  await new Promise(resolve => setTimeout(resolve, 1200));
+  hydrateRoot(frame.contentDocument, <Document />);
+}
+
+main(document.getElementById('preview'));
+```
+
+```js src/demo-helpers.js hidden
+export async function flushReadableStreamToFrame(readable, frame) {
+  const doc = frame.contentWindow.document;
+  const decoder = new TextDecoder();
+  const reader = readable.getReader();
+
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) {
+      break;
+    }
+    doc.write(decoder.decode(value, {stream: true}));
+  }
+
+  doc.write(decoder.decode());
+  doc.close();
+}
+```
+
+```html public/index.html hidden
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Conditional browser rendering</title>
+</head>
+<body>
+  <iframe id="preview" title="Rendered page"></iframe>
+</body>
+</html>
+```
+
+```css src/styles.css hidden
+iframe {
+  width: 100%;
+  height: 170px;
+  border: 0;
+}
+```
+
+```json package.json hidden
+{
+  "dependencies": {
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814",
+    "react-scripts": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}
+```
+
+</Sandpack>
+
 ---
 
 ### Reporting browser-only rendering on the server {/*reporting-browser-only-rendering-on-the-server*/}

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -234,7 +234,7 @@ export default function SavedDraft() {
 
 ---
 
-### Conditionally rendering on the server {/*conditionally-rendering-in-the-browser*/}
+### Conditionally rendering on the server {/*conditionally-rendering-on-the-server*/}
 
 Unlike Hooks, [`use`](/reference/react/use) can be called inside a conditional statement or after an early return.
 
@@ -402,9 +402,9 @@ function ProductDetails({ productId, initialData }) {
 }
 ```
 
-When `initialData` is provided, `useBrowserQuery` calls `useQuery` during server rendering, and React includes the rendered content in the HTML.
+When `initialData` is provided, `useBrowserQuery` skips the call to `use(browser())` and passes the initial data to `useQuery`. This lets the Component render on the server.
 
-Without `initialData`, `useBrowserQuery` calls `use(browser())`, suspending the Component and leaving the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML.
+Without `initialData`, `useBrowserQuery` calls `use(browser())`. React leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the server-rendered HTML.
 
 In the browser, `useBrowserQuery` calls `useQuery` in both cases, allowing the query library to fetch the data or read it from its client cache as usual.
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -236,9 +236,9 @@ export default function SavedDraft() {
 
 ### Conditionally rendering on the server {/*conditionally-rendering-in-the-browser*/}
 
-Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally. This lets a Component or custom Hook opt out of server rendering based on a condition, such as the value of a prop passed to it.
+Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally. Unlike Hooks, `use` can be called after a conditional return or directly inside a conditional statement. This lets a Component or custom Hook opt out of server rendering based on a condition, such as the value of a prop passed to it.
 
-For example, this `useTimeZone` Hook accepts an optional default value. When provided, React renders the default value in the initial HTML and in the browser. When it is not provided, `use(browser())` suspends the Component during server rendering. In the browser, `use(browser())` does not suspend, so `useTimeZone` returns the device's local time zone.
+For example, this `useTimeZone` Hook accepts an optional default value. When provided, React renders the default value in the initial HTML and in the browser. When it is not provided, `use(browser())` suspends the Component during server rendering, but `useTimeZone` returns the device's local time zone when rendering in the browser.
 
 Click **Reload** to see the loading fallback before the user's time zone appears.
 
@@ -380,7 +380,7 @@ iframe {
 
 </Sandpack>
 
-You can apply the same pattern to a Suspense-enabled data-fetching library. For example, a wrapper can call `use(browser())` before the library's `useQuery` when initial data is missing:
+A wrapper around a Suspense-enabled data-fetching library can call `use(browser())` directly inside a condition before the library's `useQuery` when initial data is missing:
 
 ```js {3}
 function useBrowserQuery(query, options) {

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -238,7 +238,7 @@ export default function SavedDraft() {
 
 Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally. Unlike Hooks, `use` can be called after a conditional return or directly inside a conditional statement. This lets a Component or custom Hook opt out of server rendering based on a condition, such as the value of a prop passed to it.
 
-For example, this `useTimeZone` Hook accepts an optional default value. When provided, React renders the default value in the initial HTML and in the browser. When it is not provided, `use(browser())` suspends the Component during server rendering, but `useTimeZone` returns the device's local time zone when rendering in the browser.
+For example, this `useTimeZone` Hook accepts an optional default value. When provided, React renders the default value in the initial HTML and in the browser. Without a default value, the Component suspends during server rendering and shows the device's local time zone in the browser.
 
 Click **Reload** to see the loading fallback before the user's time zone appears.
 
@@ -400,7 +400,7 @@ function ProductDetails({ productId, initialData }) {
 }
 ```
 
-If `initialData` is not provided, `useBrowserQuery` skips server rendering and leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `use(browser())` does not suspend, so the query library can fetch the data or read it from its client cache as usual.
+If `initialData` is not provided, `useBrowserQuery` skips server rendering and leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `useBrowserQuery` calls `useQuery`, allowing the query library to fetch the data or read it from its client cache as usual.
 
 ---
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -265,16 +265,8 @@ Click **Reload** to see the second product's loading fallback before its query r
 <Sandpack>
 
 ```js src/App.js active
-import { Suspense, use } from 'react';
-import { browser } from 'react-dom';
-import { useQuery } from './query.js';
-
-function useBrowserQuery(query, options) {
-  if (options.initialData === undefined) {
-    use(browser('useBrowserQuery: No initial data was provided.'));
-  }
-  return useQuery(query, options);
-}
+import { Suspense } from 'react';
+import { useBrowserQuery } from './useBrowserQuery.js';
 
 function ProductDetails({productId, initialData}) {
   const product = useBrowserQuery(`/api/products/${productId}`, {
@@ -302,6 +294,19 @@ export default function App() {
       </ul>
     </>
   );
+}
+```
+
+```js src/useBrowserQuery.js
+import { use } from 'react';
+import { browser } from 'react-dom';
+import { useQuery } from './query.js';
+
+export function useBrowserQuery(query, options) {
+  if (options.initialData === undefined) {
+    use(browser('useBrowserQuery: No initial data was provided.'));
+  }
+  return useQuery(query, options);
 }
 ```
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -258,7 +258,7 @@ function ProductDetails({ productId, initialData }) {
 
 On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
 
-You can also call `use(browser())` only when initial data isn't available. In this example, the event time zone is provided as initial data, but the user's time zone is read from the browser. Click **Reload** to see the loading fallback for the user's time zone.
+The following example uses this pattern with time zones. The event time zone is provided as initial data, while the user's time zone is read from the browser. Click **Reload** to see the loading fallback for the user's time zone.
 
 <Sandpack>
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -236,9 +236,9 @@ export default function SavedDraft() {
 
 ### Conditionally rendering on the server {/*conditionally-rendering-in-the-browser*/}
 
-Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, a `useTimeZone` Hook can accept an initial time zone when one is available and read it from the device when it is not.
+Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally. This lets a Component or custom Hook opt out of server rendering based on a condition, such as the value of a prop passed to it.
 
-If an initial time zone is provided, `useTimeZone` includes it in the HTML. Otherwise, `use(browser())` leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `use(browser())` returns `undefined`, so `useTimeZone` reads the user's time zone from the device.
+For example, `useTimeZone` accepts an optional initial value. If provided, that value is included in the initial HTML and rendered in the browser. If not, `use(browser())` causes the Component calling `useTimeZone` to suspend during server rendering. In the browser, `useTimeZone` reads the device's local time zone.
 
 Click **Reload** to see the loading fallback before the user's time zone appears.
 
@@ -400,7 +400,7 @@ function ProductDetails({ productId, initialData }) {
 }
 ```
 
-During server rendering, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
+This way, if `initialData` is not provided, `useBrowserQuery` skips server rendering, leaving the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `use(browser())` does not suspend, so the query library can fetch the data or read it from its client cache as usual.
 
 ---
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -236,9 +236,7 @@ export default function SavedDraft() {
 
 ### Conditionally rendering on the server {/*conditionally-rendering-on-the-server*/}
 
-Unlike Hooks, [`use`](/reference/react/use) can be called inside a conditional statement or after an early return.
-
-You can use this behavior with `use(browser())` to conditionally opt a Component out of server rendering, including from inside a custom Hook. The condition might depend on the value of a prop.
+Like other calls to [`use`](/reference/react/use), `use(browser())` can be called inside a conditional statement or after an early return. This lets a Component or custom Hook opt out of server rendering based on a condition, such as the value of a prop.
 
 For example, this `useTimeZone` Hook accepts an optional default value. When provided, React renders the default value in the initial HTML and in the browser. Without a default value, the Component suspends during server rendering and shows the device's local time zone in the browser.
 
@@ -382,7 +380,7 @@ iframe {
 
 </Sandpack>
 
-You can apply a similar pattern to conditionally avoid server rendering when using a Suspense-enabled data-fetching library. For example, a wrapper can call `use(browser())` directly inside a condition before the library's `useQuery` when initial data is missing:
+You can apply a similar pattern to conditionally avoid server rendering when using a Suspense-enabled data-fetching library:
 
 ```js {3}
 function useBrowserQuery(query, options) {
@@ -402,11 +400,7 @@ function ProductDetails({ productId, initialData }) {
 }
 ```
 
-When `initialData` is provided, `useBrowserQuery` skips the call to `use(browser())` and passes the initial data to `useQuery`. This lets the Component render on the server.
-
-Without `initialData`, `useBrowserQuery` calls `use(browser())`. React leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the server-rendered HTML.
-
-In the browser, `useBrowserQuery` calls `useQuery` in both cases, allowing the query library to fetch the data or read it from its client cache as usual.
+With `initialData`, React renders the Component to HTML on the server. Without it, React leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `useQuery` can fetch the data or read it from its client cache as usual.
 
 ---
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -236,26 +236,33 @@ export default function SavedDraft() {
 
 ### Conditionally rendering in the browser {/*conditionally-rendering-in-the-browser*/}
 
-Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, a custom Hook can return an initial value when it is provided, and read it from IndexedDB in the browser when it isn't:
+Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, you can wrap a Suspense-enabled data-fetching library's `useQuery` and skip server rendering when initial data is missing:
 
-```js {6}
-function useSetting(settingId, initialValue) {
-  if (initialValue !== undefined) {
-    return initialValue;
+```js {3}
+function useBrowserQuery(query, options) {
+  if (options.initialData === undefined) {
+    use(browser('useBrowserQuery: No initial data was provided.'));
   }
 
-  use(browser('No initial setting was provided.'));
-  return use(readSetting(settingId));
+  return useQuery(query, options);
+}
+
+function ProductDetails({ productId, initialData }) {
+  const product = useBrowserQuery(`/api/products/${productId}`, {
+    initialData,
+  });
+
+  return <h1>{product.name}</h1>;
 }
 ```
 
-On the server, `useSetting` returns `initialValue` when it is provided. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the Hook continues and reads the setting from IndexedDB.
+On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
 
-In this example, the email notification setting is provided as initial data. The push notification setting is not, so click **Reload** to see its loading fallback while React reads it from IndexedDB.
+Here is a complete example using notification settings stored in IndexedDB. The email notification setting receives initial data, but the push notification setting does not. Click **Reload** to see the email setting in the initial HTML while the push setting shows a loading fallback.
 
 <Sandpack>
 
-```js src/App.js active
+```js src/App.js
 import { Suspense } from 'react';
 import { useSetting } from './useSetting.js';
 
@@ -290,7 +297,7 @@ export default function App() {
 }
 ```
 
-```js src/useSetting.js
+```js src/useSetting.js active
 import { use } from 'react';
 import { browser } from 'react-dom';
 import { readSetting } from './database.js';
@@ -306,6 +313,8 @@ export function useSetting(settingId, initialValue) {
 ```
 
 ```js src/database.js hidden
+// This is a simplified IndexedDB wrapper for this example.
+
 const cache = new Map();
 
 export function readSetting(settingId) {

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -234,31 +234,13 @@ export default function SavedDraft() {
 
 ---
 
-### Conditionally rendering in the browser {/*conditionally-rendering-in-the-browser*/}
+### Conditionally rendering on the server {/*conditionally-rendering-in-the-browser*/}
 
-Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, you can wrap a Suspense-enabled data-fetching library's `useQuery` and skip server rendering when initial data is missing:
+Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, a `useTimeZone` Hook can accept an initial time zone when one is available and read it from the device when it is not.
 
-```js {3}
-function useBrowserQuery(query, options) {
-  if (options.initialData === undefined) {
-    use(browser('useBrowserQuery: No initial data was provided.'));
-  }
+If an initial time zone is provided, `useTimeZone` includes it in the HTML. Otherwise, `use(browser())` leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `use(browser())` returns `undefined`, so `useTimeZone` reads the user's time zone from the device.
 
-  return useQuery(query, options);
-}
-
-function ProductDetails({ productId, initialData }) {
-  const product = useBrowserQuery(`/api/products/${productId}`, {
-    initialData,
-  });
-
-  return <h1>{product.name}</h1>;
-}
-```
-
-On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
-
-The following example uses this pattern with time zones. The event time zone is provided as initial data, while the user's time zone is read from the browser. Click **Reload** to see the loading fallback for the user's time zone.
+Click **Reload** to see the loading fallback before the user's time zone appears.
 
 <Sandpack>
 
@@ -397,6 +379,28 @@ iframe {
 ```
 
 </Sandpack>
+
+You can apply the same pattern to a Suspense-enabled data-fetching library. For example, a wrapper can call `use(browser())` before the library's `useQuery` when initial data is missing:
+
+```js {3}
+function useBrowserQuery(query, options) {
+  if (options.initialData === undefined) {
+    use(browser('useBrowserQuery: No initial data was provided.'));
+  }
+
+  return useQuery(query, options);
+}
+
+function ProductDetails({ productId, initialData }) {
+  const product = useBrowserQuery(`/api/products/${productId}`, {
+    initialData,
+  });
+
+  return <h1>{product.name}</h1>;
+}
+```
+
+During server rendering, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
 
 ---
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -258,91 +258,46 @@ function ProductDetails({ productId, initialData }) {
 
 On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
 
-You can also use this pattern to read from a browser-only data source when initial data isn't available. In this example, the email setting has initial data, but the push setting is read from IndexedDB. Click **Reload** to see the loading fallback for the push setting.
+You can also call `use(browser())` only when initial data isn't available. In this example, the event time zone is provided as initial data, but the user's time zone is read from the browser. Click **Reload** to see the loading fallback for the user's time zone.
 
 <Sandpack>
 
 ```js src/App.js
 import { Suspense } from 'react';
-import { useSetting } from './useSetting.js';
+import { useTimeZone } from './useTimeZone.js';
 
-function NotificationSetting({settingId, label, initialValue}) {
-  const enabled = useSetting(settingId, initialValue);
-  return (
-    <li>
-      {label}: <strong>{enabled ? 'On' : 'Off'}</strong>
-    </li>
-  );
+function TimeZone({label, initialTimeZone}) {
+  const timeZone = useTimeZone(initialTimeZone);
+  return <p>{label}: <strong>{timeZone}</strong></p>;
 }
 
 export default function App() {
   return (
     <>
-      <h1>Notification settings</h1>
-      <ul>
-        <NotificationSetting
-          settingId="email"
-          label="Email notifications"
-          initialValue={true}
-        />
-        <Suspense fallback={<li>Loading push notification setting...</li>}>
-          <NotificationSetting
-            settingId="push"
-            label="Push notifications"
-          />
-        </Suspense>
-      </ul>
+      <h1>Event details</h1>
+      <TimeZone
+        label="Event time zone"
+        initialTimeZone="America/New_York"
+      />
+      <Suspense fallback={<p>Loading your time zone...</p>}>
+        <TimeZone label="Your time zone" />
+      </Suspense>
     </>
   );
 }
 ```
 
-```js src/useSetting.js active
+```js src/useTimeZone.js active
 import { use } from 'react';
 import { browser } from 'react-dom';
-import { readSetting } from './database.js';
 
-export function useSetting(settingId, initialValue) {
-  if (initialValue !== undefined) {
-    return initialValue;
+export function useTimeZone(initialTimeZone) {
+  if (initialTimeZone !== undefined) {
+    return initialTimeZone;
   }
 
-  use(browser('No initial setting was provided.'));
-  return use(readSetting(settingId));
-}
-```
-
-```js src/database.js hidden
-// This is a simplified IndexedDB wrapper for this example.
-
-const cache = new Map();
-
-export function readSetting(settingId) {
-  if (!cache.has(settingId)) {
-    cache.set(settingId, readSettingFromIndexedDB(settingId));
-  }
-  return cache.get(settingId);
-}
-
-function readSettingFromIndexedDB(settingId) {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open('browser-notification-settings-example', 1);
-
-    request.onupgradeneeded = () => {
-      const store = request.result.createObjectStore('settings');
-      store.add(true, 'push');
-    };
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => {
-      const transaction = request.result.transaction('settings');
-      const settingRequest = transaction.objectStore('settings').get(settingId);
-      settingRequest.onerror = () => reject(settingRequest.error);
-      settingRequest.onsuccess = () => {
-        setTimeout(() => resolve(settingRequest.result), 600);
-      };
-    };
-  });
+  use(browser('No initial time zone was provided.'));
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 ```
 
@@ -353,7 +308,7 @@ export default function Document() {
   return (
     <html lang="en">
       <head>
-        <title>Notification settings</title>
+        <title>Event details</title>
         <style>{`
           h1 { font-size: 24px; margin-top: 0; }
         `}</style>

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -236,7 +236,9 @@ export default function SavedDraft() {
 
 ### Conditionally rendering on the server {/*conditionally-rendering-in-the-browser*/}
 
-Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally. Unlike Hooks, `use` can be called after a conditional return or directly inside a conditional statement. This lets a Component or custom Hook opt out of server rendering based on a condition, such as the value of a prop passed to it.
+Unlike Hooks, [`use`](/reference/react/use) can be called inside a conditional statement or after an early return.
+
+You can use this behavior with `use(browser())` to conditionally opt a Component out of server rendering, including from inside a custom Hook. The condition might depend on the value of a prop.
 
 For example, this `useTimeZone` Hook accepts an optional default value. When provided, React renders the default value in the initial HTML and in the browser. Without a default value, the Component suspends during server rendering and shows the device's local time zone in the browser.
 
@@ -400,7 +402,11 @@ function ProductDetails({ productId, initialData }) {
 }
 ```
 
-If `initialData` is not provided, `useBrowserQuery` skips server rendering and leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `useBrowserQuery` calls `useQuery`, allowing the query library to fetch the data or read it from its client cache as usual.
+When `initialData` is provided, `useBrowserQuery` calls `useQuery` during server rendering, and React includes the rendered content in the HTML.
+
+Without `initialData`, `useBrowserQuery` calls `use(browser())`, suspending the Component and leaving the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML.
+
+In the browser, `useBrowserQuery` calls `useQuery` in both cases, allowing the query library to fetch the data or read it from its client cache as usual.
 
 ---
 
@@ -419,19 +425,22 @@ function SavedDraft() {
   return <DraftEditor initialDraft={draft} />;
 }
 
-const { pipe } = renderToPipeableStream(
-  <Suspense fallback={<p>Loading saved draft...</p>}>
-    <SavedDraft />
-  </Suspense>,
-  {
-    onShellReady() {
-      pipe(response);
-    },
-    onBrowserBailout(error, errorInfo) {
-      logBrowserBailout(error, errorInfo);
-    }
+function App() {
+  return (
+    <Suspense fallback={<p>Loading saved draft...</p>}>
+      <SavedDraft />
+    </Suspense>
+  );
+}
+
+const { pipe } = renderToPipeableStream(<App />, {
+  onShellReady() {
+    pipe(response);
+  },
+  onBrowserBailout(error, errorInfo) {
+    logBrowserBailout(error, errorInfo);
   }
-);
+});
 ```
 
 `onBrowserBailout` receives two arguments:

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -258,7 +258,7 @@ function ProductDetails({ productId, initialData }) {
 
 On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
 
-Here is a complete example using notification settings stored in IndexedDB. The email notification setting receives initial data, but the push notification setting does not. Click **Reload** to see the email setting in the initial HTML while the push setting shows a loading fallback.
+Another way to use conditional `use(browser())` is to read from a browser-only data source when initial data is unavailable. In this example, `useSetting` receives an initial value for the email notification setting, so React can include it in the initial HTML. The push notification setting has no initial value, so `useSetting` calls `use(browser())` before reading it from IndexedDB. Click **Reload** to see both paths: the email setting appears immediately, while the push setting shows a loading fallback until `useSetting` reads it from IndexedDB in the browser.
 
 <Sandpack>
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -238,7 +238,7 @@ export default function SavedDraft() {
 
 Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally. This lets a Component or custom Hook opt out of server rendering based on a condition, such as the value of a prop passed to it.
 
-For example, `useTimeZone` accepts an optional initial value. If provided, that value is included in the initial HTML and rendered in the browser. If not, `use(browser())` causes the Component calling `useTimeZone` to suspend during server rendering. In the browser, `useTimeZone` reads the device's local time zone.
+For example, this `useTimeZone` Hook accepts an optional default value. When provided, React renders the default value in the initial HTML and in the browser. When it is not provided, `use(browser())` suspends the Component during server rendering. In the browser, `use(browser())` does not suspend, so `useTimeZone` returns the device's local time zone.
 
 Click **Reload** to see the loading fallback before the user's time zone appears.
 
@@ -248,8 +248,8 @@ Click **Reload** to see the loading fallback before the user's time zone appears
 import { Suspense } from 'react';
 import { useTimeZone } from './useTimeZone.js';
 
-function TimeZone({label, initialTimeZone}) {
-  const timeZone = useTimeZone(initialTimeZone);
+function TimeZone({label, defaultTimeZone}) {
+  const timeZone = useTimeZone(defaultTimeZone);
   return <p>{label}: <strong>{timeZone}</strong></p>;
 }
 
@@ -259,7 +259,7 @@ export default function App() {
       <h1>Event details</h1>
       <TimeZone
         label="Event time zone"
-        initialTimeZone="America/New_York"
+        defaultTimeZone="America/New_York"
       />
       <Suspense fallback={<p>Loading your time zone...</p>}>
         <TimeZone label="Your time zone" />
@@ -273,12 +273,12 @@ export default function App() {
 import { use } from 'react';
 import { browser } from 'react-dom';
 
-export function useTimeZone(initialTimeZone) {
-  if (initialTimeZone !== undefined) {
-    return initialTimeZone;
+export function useTimeZone(defaultTimeZone) {
+  if (defaultTimeZone !== undefined) {
+    return defaultTimeZone;
   }
 
-  use(browser('No initial time zone was provided.'));
+  use(browser('No default time zone was provided.'));
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 ```
@@ -400,7 +400,7 @@ function ProductDetails({ productId, initialData }) {
 }
 ```
 
-This way, if `initialData` is not provided, `useBrowserQuery` skips server rendering, leaving the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `use(browser())` does not suspend, so the query library can fetch the data or read it from its client cache as usual.
+If `initialData` is not provided, `useBrowserQuery` skips server rendering and leaves the closest [`<Suspense>`](/reference/react/Suspense) boundary's fallback in the HTML. In the browser, `use(browser())` does not suspend, so the query library can fetch the data or read it from its client cache as usual.
 
 ---
 

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -380,7 +380,7 @@ iframe {
 
 </Sandpack>
 
-A wrapper around a Suspense-enabled data-fetching library can call `use(browser())` directly inside a condition before the library's `useQuery` when initial data is missing:
+You can apply a similar pattern to conditionally avoid server rendering when using a Suspense-enabled data-fetching library. For example, a wrapper can call `use(browser())` directly inside a condition before the library's `useQuery` when initial data is missing:
 
 ```js {3}
 function useBrowserQuery(query, options) {

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -236,37 +236,34 @@ export default function SavedDraft() {
 
 ### Conditionally rendering in the browser {/*conditionally-rendering-in-the-browser*/}
 
-Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, a custom Hook can use initial data when it is available during server rendering, and read from IndexedDB in the browser when it isn't:
+Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, a custom Hook can return an initial value when it is provided, and read it from IndexedDB in the browser when it isn't:
 
-```js {3}
-function useDraft(draftId, initialDraft) {
-  if (initialDraft !== undefined) {
-    return initialDraft;
+```js {6}
+function useSetting(settingId, initialValue) {
+  if (initialValue !== undefined) {
+    return initialValue;
   }
 
-  use(browser('The draft is stored in IndexedDB.'));
-  return use(readDraft(draftId));
+  use(browser('No initial setting was provided.'));
+  return use(readSetting(settingId));
 }
 ```
 
-On the server, `useDraft` returns `initialDraft` when it is provided. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the Hook continues and reads the draft from IndexedDB.
+On the server, `useSetting` returns `initialValue` when it is provided. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the Hook continues and reads the setting from IndexedDB.
 
-This example renders one draft with initial data and one stored in IndexedDB.
-
-Click **Reload** to see the second draft's loading fallback while React reads it from IndexedDB.
+In this example, the email notification setting is provided as initial data. The push notification setting is not, so click **Reload** to see its loading fallback while React reads it from IndexedDB.
 
 <Sandpack>
 
 ```js src/App.js active
 import { Suspense } from 'react';
-import { useDraft } from './useDraft.js';
+import { useSetting } from './useSetting.js';
 
-function Draft({draftId, title, initialDraft}) {
-  const draft = useDraft(draftId, initialDraft);
+function NotificationSetting({settingId, label, initialValue}) {
+  const enabled = useSetting(settingId, initialValue);
   return (
     <li>
-      <strong>{title}</strong>
-      <p>{draft}</p>
+      {label}: <strong>{enabled ? 'On' : 'Off'}</strong>
     </li>
   );
 }
@@ -274,15 +271,18 @@ function Draft({draftId, title, initialDraft}) {
 export default function App() {
   return (
     <>
-      <h1>Saved drafts</h1>
+      <h1>Notification settings</h1>
       <ul>
-        <Draft
-          draftId="release-notes"
-          title="Release notes"
-          initialDraft="Announce the next release."
+        <NotificationSetting
+          settingId="email"
+          label="Email notifications"
+          initialValue={true}
         />
-        <Suspense fallback={<li>Loading saved draft...</li>}>
-          <Draft draftId="trip-notes" title="Trip notes" />
+        <Suspense fallback={<li>Loading push notification setting...</li>}>
+          <NotificationSetting
+            settingId="push"
+            label="Push notifications"
+          />
         </Suspense>
       </ul>
     </>
@@ -290,53 +290,47 @@ export default function App() {
 }
 ```
 
-```js src/useDraft.js
+```js src/useSetting.js
 import { use } from 'react';
 import { browser } from 'react-dom';
-import { readDraft } from './database.js';
+import { readSetting } from './database.js';
 
-export function useDraft(draftId, initialDraft) {
-  if (initialDraft !== undefined) {
-    return initialDraft;
+export function useSetting(settingId, initialValue) {
+  if (initialValue !== undefined) {
+    return initialValue;
   }
 
-  use(browser('The draft is stored in IndexedDB.'));
-  return use(readDraft(draftId));
+  use(browser('No initial setting was provided.'));
+  return use(readSetting(settingId));
 }
 ```
 
 ```js src/database.js hidden
-const drafts = {
-  'trip-notes': 'Remember to pack a charger.',
-};
-
 const cache = new Map();
 
-export function readDraft(draftId) {
-  if (!cache.has(draftId)) {
-    cache.set(draftId, readDraftFromIndexedDB(draftId));
+export function readSetting(settingId) {
+  if (!cache.has(settingId)) {
+    cache.set(settingId, readSettingFromIndexedDB(settingId));
   }
-  return cache.get(draftId);
+  return cache.get(settingId);
 }
 
-function readDraftFromIndexedDB(draftId) {
+function readSettingFromIndexedDB(settingId) {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open('browser-example', 1);
+    const request = indexedDB.open('browser-notification-settings-example', 1);
 
     request.onupgradeneeded = () => {
-      const store = request.result.createObjectStore('drafts');
-      for (const [key, value] of Object.entries(drafts)) {
-        store.add(value, key);
-      }
+      const store = request.result.createObjectStore('settings');
+      store.add(true, 'push');
     };
 
     request.onerror = () => reject(request.error);
     request.onsuccess = () => {
-      const transaction = request.result.transaction('drafts');
-      const draftRequest = transaction.objectStore('drafts').get(draftId);
-      draftRequest.onerror = () => reject(draftRequest.error);
-      draftRequest.onsuccess = () => {
-        setTimeout(() => resolve(draftRequest.result), 600);
+      const transaction = request.result.transaction('settings');
+      const settingRequest = transaction.objectStore('settings').get(settingId);
+      settingRequest.onerror = () => reject(settingRequest.error);
+      settingRequest.onsuccess = () => {
+        setTimeout(() => resolve(settingRequest.result), 600);
       };
     };
   });
@@ -350,7 +344,7 @@ export default function Document() {
   return (
     <html lang="en">
       <head>
-        <title>Saved drafts</title>
+        <title>Notification settings</title>
         <style>{`
           h1 { font-size: 24px; margin-top: 0; }
         `}</style>
@@ -417,7 +411,7 @@ export async function flushReadableStreamToFrame(readable, frame) {
 ```css src/styles.css hidden
 iframe {
   width: 100%;
-  height: 170px;
+  height: 240px;
   border: 0;
 }
 ```

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -236,60 +236,53 @@ export default function SavedDraft() {
 
 ### Conditionally rendering in the browser {/*conditionally-rendering-in-the-browser*/}
 
-Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, you can wrap a Suspense-enabled data-fetching library's `useQuery` and skip server rendering when initial data is missing:
+Like other calls to [`use`](/reference/react/use), you can call `use(browser())` conditionally or inside a custom Hook. For example, a custom Hook can use initial data when it is available during server rendering, and read from IndexedDB in the browser when it isn't:
 
 ```js {3}
-function useBrowserQuery(query, options) {
-  if (options.initialData === undefined) {
-    use(browser('useBrowserQuery: No initial data was provided.'));
+function useDraft(draftId, initialDraft) {
+  if (initialDraft !== undefined) {
+    return initialDraft;
   }
 
-  return useQuery(query, options);
-}
-
-function ProductDetails({ productId, initialData }) {
-  const product = useBrowserQuery(`/api/products/${productId}`, {
-    initialData,
-  });
-
-  return <h1>{product.name}</h1>;
+  use(browser('The draft is stored in IndexedDB.'));
+  return use(readDraft(draftId));
 }
 ```
 
-On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
+On the server, `useDraft` returns `initialDraft` when it is provided. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the Hook continues and reads the draft from IndexedDB.
 
-This example renders one query with initial data and one without it.
+This example renders one draft with initial data and one stored in IndexedDB.
 
-Click **Reload** to see the second product's loading fallback before its query resolves.
+Click **Reload** to see the second draft's loading fallback while React reads it from IndexedDB.
 
 <Sandpack>
 
 ```js src/App.js active
 import { Suspense } from 'react';
-import { useBrowserQuery } from './useBrowserQuery.js';
+import { useDraft } from './useDraft.js';
 
-function ProductDetails({productId, initialData}) {
-  const product = useBrowserQuery(`/api/products/${productId}`, {
-    initialData,
-  });
-  return <strong>{product.name}</strong>;
+function Draft({draftId, title, initialDraft}) {
+  const draft = useDraft(draftId, initialDraft);
+  return (
+    <li>
+      <strong>{title}</strong>
+      <p>{draft}</p>
+    </li>
+  );
 }
 
 export default function App() {
   return (
     <>
-      <h1>Featured products</h1>
+      <h1>Saved drafts</h1>
       <ul>
-        <li>
-          <ProductDetails
-            productId="react-mug"
-            initialData={{name: 'React mug'}}
-          />
-        </li>
-        <Suspense fallback={<li>Loading another product...</li>}>
-          <li>
-            <ProductDetails productId="react-shirt" />
-          </li>
+        <Draft
+          draftId="release-notes"
+          title="Release notes"
+          initialDraft="Announce the next release."
+        />
+        <Suspense fallback={<li>Loading saved draft...</li>}>
+          <Draft draftId="trip-notes" title="Trip notes" />
         </Suspense>
       </ul>
     </>
@@ -297,48 +290,56 @@ export default function App() {
 }
 ```
 
-```js src/useBrowserQuery.js
+```js src/useDraft.js
 import { use } from 'react';
 import { browser } from 'react-dom';
-import { useQuery } from './query.js';
+import { readDraft } from './database.js';
 
-export function useBrowserQuery(query, options) {
-  if (options.initialData === undefined) {
-    use(browser('useBrowserQuery: No initial data was provided.'));
+export function useDraft(draftId, initialDraft) {
+  if (initialDraft !== undefined) {
+    return initialDraft;
   }
-  return useQuery(query, options);
+
+  use(browser('The draft is stored in IndexedDB.'));
+  return use(readDraft(draftId));
 }
 ```
 
-```js src/query.js hidden
-import { use } from 'react';
-
-// This is a simplified implementation of a
-// Suspense-enabled query library.
-
-const products = {
-  '/api/products/react-shirt': {name: 'React shirt'},
+```js src/database.js hidden
+const drafts = {
+  'trip-notes': 'Remember to pack a charger.',
 };
 
 const cache = new Map();
 
-function fetchProduct(query) {
-  if (!cache.has(query)) {
-    cache.set(
-      query,
-      new Promise(resolve => {
-        setTimeout(() => resolve(products[query]), 600);
-      })
-    );
+export function readDraft(draftId) {
+  if (!cache.has(draftId)) {
+    cache.set(draftId, readDraftFromIndexedDB(draftId));
   }
-  return cache.get(query);
+  return cache.get(draftId);
 }
 
-export function useQuery(query, options) {
-  if (options.initialData !== undefined) {
-    return options.initialData;
-  }
-  return use(fetchProduct(query));
+function readDraftFromIndexedDB(draftId) {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('browser-example', 1);
+
+    request.onupgradeneeded = () => {
+      const store = request.result.createObjectStore('drafts');
+      for (const [key, value] of Object.entries(drafts)) {
+        store.add(value, key);
+      }
+    };
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const transaction = request.result.transaction('drafts');
+      const draftRequest = transaction.objectStore('drafts').get(draftId);
+      draftRequest.onerror = () => reject(draftRequest.error);
+      draftRequest.onsuccess = () => {
+        setTimeout(() => resolve(draftRequest.result), 600);
+      };
+    };
+  });
 }
 ```
 
@@ -349,7 +350,7 @@ export default function Document() {
   return (
     <html lang="en">
       <head>
-        <title>Featured products</title>
+        <title>Saved drafts</title>
         <style>{`
           h1 { font-size: 24px; margin-top: 0; }
         `}</style>

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -258,7 +258,7 @@ function ProductDetails({ productId, initialData }) {
 
 On the server, `useBrowserQuery` calls `useQuery` only when `initialData` is available. Otherwise, the closest Suspense boundary's fallback remains in the HTML. In the browser, `use(browser())` returns `undefined`, so the query library can fetch the data or read it from its client cache.
 
-Another way to use conditional `use(browser())` is to read from a browser-only data source when initial data is unavailable. In this example, `useSetting` receives an initial value for the email notification setting, so React can include it in the initial HTML. The push notification setting has no initial value, so `useSetting` calls `use(browser())` before reading it from IndexedDB. Click **Reload** to see both paths: the email setting appears immediately, while the push setting shows a loading fallback until `useSetting` reads it from IndexedDB in the browser.
+You can also use this pattern to read from a browser-only data source when initial data isn't available. In this example, the email setting has initial data, but the push setting is read from IndexedDB. Click **Reload** to see the loading fallback for the push setting.
 
 <Sandpack>
 


### PR DESCRIPTION
## Summary

https://react-ch7zfadp5-react-foundation.vercel.app/reference/react-dom/browser#conditionally-rendering-in-the-browser

- add a runnable example for conditionally calling `use(browser())` from a Suspense-enabled query wrapper
- show how initial data renders immediately while a query without initial data waits for the browser
- keep the query implementation and server-rendering harness hidden so the visible example stays focused

## Validation

- `npx prettier --config .prettierrc --check src/content/reference/react-dom/browser.md`
- `npx eslint src/content/reference/react-dom/browser.md`
- `yarn lint-heading-ids`
- verified locally that Reload first shows React mug with the loading fallback, then resolves React shirt