### PR TITLE
fix: make sidebar dropdown arrow togglable

### DIFF
--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -132,9 +132,8 @@ export function SidebarLink({
               onToggle();
             }
           }}
-          aria-label={isExpanded ? "Collapse" : "Expand"}
-          aria-expanded={isExpanded}
-        >
+          aria-label={isExpanded ? 'Collapse' : 'Expand'}
+          aria-expanded={isExpanded}>
           <IconNavArrow displayDirection={isExpanded ? 'down' : 'end'} />
         </span>
       )}

--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -29,6 +29,7 @@ interface SidebarLinkProps {
   isExpanded?: boolean;
   hideArrow?: boolean;
   isPending: boolean;
+  onToggle?: () => void;
 }
 
 export function SidebarLink({
@@ -40,6 +41,7 @@ export function SidebarLink({
   isExpanded,
   hideArrow,
   isPending,
+  onToggle,
 }: SidebarLinkProps) {
   const ref = useRef<HTMLAnchorElement>(null);
 
@@ -115,7 +117,24 @@ export function SidebarLink({
           className={cn('pe-1', {
             'text-link dark:text-link-dark': isExpanded,
             'text-tertiary dark:text-tertiary-dark': !isExpanded,
-          })}>
+          })}
+          role="button"
+          tabIndex={0}
+          onClick={(e) => {
+            if (onToggle) {
+              e.preventDefault();
+              onToggle();
+            }
+          }}
+          onKeyDown={(e) => {
+            if (onToggle && (e.key === 'Enter' || e.key === ' ')) {
+              e.preventDefault();
+              onToggle();
+            }
+          }}
+          aria-label={isExpanded ? "Collapse" : "Expand"}
+          aria-expanded={isExpanded}
+        >
           <IconNavArrow displayDirection={isExpanded ? 'down' : 'end'} />
         </span>
       )}

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -120,7 +120,9 @@ function ExpandableSidebarItem({
         hideArrow={isForceExpanded}
         onToggle={onToggle}
       />
-      <CollapseWrapper duration={250} isExpanded={isForceExpanded || isExpanded}>
+      <CollapseWrapper
+        duration={250}
+        isExpanded={isForceExpanded || isExpanded}>
         <SidebarRouteTree
           isForceExpanded={isForceExpanded}
           routeTree={{title, routes}}
@@ -142,13 +144,14 @@ export function SidebarRouteTree({
   const pendingRoute = usePendingRoute();
   const currentRoutes = routeTree.routes as RouteItem[];
 
-  const defaultExpandedPath = currentRoutes.find(({path}) => {
-    const isBreadcrumb =
-      breadcrumbs.length > 1 &&
-      breadcrumbs[breadcrumbs.length - 1].path === path;
-    const selected = slug === path;
-    return isBreadcrumb || selected;
-  })?.path || null;
+  const defaultExpandedPath =
+    currentRoutes.find(({path}) => {
+      const isBreadcrumb =
+        breadcrumbs.length > 1 &&
+        breadcrumbs[breadcrumbs.length - 1].path === path;
+      const selected = slug === path;
+      return isBreadcrumb || selected;
+    })?.path || null;
 
   const [expandedPath, setExpandedPath] = useState<string | null>(
     defaultExpandedPath
@@ -203,7 +206,7 @@ export function SidebarRouteTree({
                 pendingRoute={pendingRoute}
                 isExpanded={expandedPath === path}
                 onToggle={() =>
-                  setExpandedPath(expandedPath === path ? null : (path || null))
+                  setExpandedPath(expandedPath === path ? null : path || null)
                 }
               />
             );

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -9,7 +9,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {useRef, useLayoutEffect, Fragment} from 'react';
+import {useRef, useLayoutEffect, Fragment, useState, useEffect} from 'react';
 
 import cn from 'classnames';
 import {useRouter} from 'next/router';
@@ -78,6 +78,67 @@ function CollapseWrapper({
   );
 }
 
+interface ExpandableSidebarItemProps {
+  title: string;
+  path: string;
+  level: number;
+  routes?: RouteItem[];
+  version?: 'canary' | 'major' | 'experimental' | 'rc';
+  isForceExpanded: boolean;
+  breadcrumbs: RouteItem[];
+  selected: boolean;
+  pendingRoute: string | null;
+}
+
+function ExpandableSidebarItem({
+  title,
+  path,
+  level,
+  routes,
+  version,
+  isForceExpanded,
+  breadcrumbs,
+  selected,
+  pendingRoute,
+}: ExpandableSidebarItemProps) {
+  const isBreadcrumb =
+    breadcrumbs.length > 1 &&
+    breadcrumbs[breadcrumbs.length - 1].path === path;
+  const defaultExpanded = isForceExpanded || isBreadcrumb || selected;
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  useEffect(() => {
+    if (defaultExpanded) {
+      setIsExpanded(true);
+    }
+  }, [defaultExpanded]);
+
+  return (
+    <li key={`${title}-${path}-${level}-heading`}>
+      <SidebarLink
+        key={`${title}-${path}-${level}-link`}
+        href={path}
+        isPending={pendingRoute === path}
+        selected={selected}
+        level={level}
+        title={title}
+        version={version}
+        isExpanded={isExpanded}
+        hideArrow={isForceExpanded}
+        onToggle={() => setIsExpanded(!isExpanded)}
+      />
+      <CollapseWrapper duration={250} isExpanded={isExpanded}>
+        <SidebarRouteTree
+          isForceExpanded={isForceExpanded}
+          routeTree={{title, routes}}
+          breadcrumbs={breadcrumbs}
+          level={level + 1}
+        />
+      </CollapseWrapper>
+    </li>
+  );
+}
+
 export function SidebarRouteTree({
   isForceExpanded,
   breadcrumbs,
@@ -116,32 +177,19 @@ export function SidebarRouteTree({
             );
           } else if (routes) {
             // if route has a path and child routes, treat it as an expandable sidebar item
-            const isBreadcrumb =
-              breadcrumbs.length > 1 &&
-              breadcrumbs[breadcrumbs.length - 1].path === path;
-            const isExpanded = isForceExpanded || isBreadcrumb || selected;
             listItem = (
-              <li key={`${title}-${path}-${level}-heading`}>
-                <SidebarLink
-                  key={`${title}-${path}-${level}-link`}
-                  href={path}
-                  isPending={pendingRoute === path}
-                  selected={selected}
-                  level={level}
-                  title={title}
-                  version={version}
-                  isExpanded={isExpanded}
-                  hideArrow={isForceExpanded}
-                />
-                <CollapseWrapper duration={250} isExpanded={isExpanded}>
-                  <SidebarRouteTree
-                    isForceExpanded={isForceExpanded}
-                    routeTree={{title, routes}}
-                    breadcrumbs={breadcrumbs}
-                    level={level + 1}
-                  />
-                </CollapseWrapper>
-              </li>
+              <ExpandableSidebarItem
+                key={`${title}-${path}-${level}-heading`}
+                title={title}
+                path={path}
+                level={level}
+                routes={routes}
+                version={version}
+                isForceExpanded={isForceExpanded}
+                breadcrumbs={breadcrumbs}
+                selected={selected}
+                pendingRoute={pendingRoute}
+              />
             );
           } else {
             // if route has a path and no child routes, treat it as a sidebar link

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -100,19 +100,12 @@ function ExpandableSidebarItem({
   breadcrumbs,
   selected,
   pendingRoute,
-}: ExpandableSidebarItemProps) {
-  const isBreadcrumb =
-    breadcrumbs.length > 1 &&
-    breadcrumbs[breadcrumbs.length - 1].path === path;
-  const defaultExpanded = isForceExpanded || isBreadcrumb || selected;
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-
-  useEffect(() => {
-    if (defaultExpanded) {
-      setIsExpanded(true);
-    }
-  }, [defaultExpanded]);
-
+  isExpanded,
+  onToggle,
+}: ExpandableSidebarItemProps & {
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
   return (
     <li key={`${title}-${path}-${level}-heading`}>
       <SidebarLink
@@ -123,11 +116,11 @@ function ExpandableSidebarItem({
         level={level}
         title={title}
         version={version}
-        isExpanded={isExpanded}
+        isExpanded={isForceExpanded || isExpanded}
         hideArrow={isForceExpanded}
-        onToggle={() => setIsExpanded(!isExpanded)}
+        onToggle={onToggle}
       />
-      <CollapseWrapper duration={250} isExpanded={isExpanded}>
+      <CollapseWrapper duration={250} isExpanded={isForceExpanded || isExpanded}>
         <SidebarRouteTree
           isForceExpanded={isForceExpanded}
           routeTree={{title, routes}}
@@ -148,6 +141,25 @@ export function SidebarRouteTree({
   const slug = useRouter().asPath.split(/[\?\#]/)[0];
   const pendingRoute = usePendingRoute();
   const currentRoutes = routeTree.routes as RouteItem[];
+
+  const defaultExpandedPath = currentRoutes.find(({path}) => {
+    const isBreadcrumb =
+      breadcrumbs.length > 1 &&
+      breadcrumbs[breadcrumbs.length - 1].path === path;
+    const selected = slug === path;
+    return isBreadcrumb || selected;
+  })?.path || null;
+
+  const [expandedPath, setExpandedPath] = useState<string | null>(
+    defaultExpandedPath
+  );
+
+  useEffect(() => {
+    if (defaultExpandedPath) {
+      setExpandedPath(defaultExpandedPath);
+    }
+  }, [defaultExpandedPath]);
+
   return (
     <ul>
       {currentRoutes.map(
@@ -189,6 +201,10 @@ export function SidebarRouteTree({
                 breadcrumbs={breadcrumbs}
                 selected={selected}
                 pendingRoute={pendingRoute}
+                isExpanded={expandedPath === path}
+                onToggle={() =>
+                  setExpandedPath(expandedPath === path ? null : (path || null))
+                }
               />
             );
           } else {


### PR DESCRIPTION

## Description
Closes #8618 
This PR fixes a UX issue in the left sidebar navigation where the downward-facing arrow of an active/expanded section could not be clicked to collapse the section. 

Previously, when a section (e.g., "Installation" or "[Components](https://react.dev/reference/react-dom/components)") was expanded, its dropdown arrow was unresponsive. As a result, users had to explicitly and unnecessarily scroll down past all of its sub-items just to view the next main component in the list. By allowing these sections to collapse via the dropdown arrow, the sidebar navigation will no longer unnecessarily consume vertical space, making it much easier for users to navigate the documentation.

### Changes made:
- The dropdown arrow is now independently clickable and toggles the section's expanded/collapsed state without triggering navigation.
- The active page's section still expands automatically by default, but can be freely collapsed or re-expanded afterward.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (UI/UX enhancement in docs)

## How Has This Been Tested?
- [x] Tested locally using the development server (`yarn dev`). Verified that the dropdown arrows accurately collapse and expand their respective sections.
- [x] Keyboard accessibility tested (users can focus the arrow and trigger the toggle using `Enter` or `Space`).

https://github.com/user-attachments/assets/0adbade6-e519-4fe1-90c6-d75a50ec8e86

