### PR TITLE
docs: clarify repetitive phrasing in Preserving and Resetting State

### DIFF
--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -478,7 +478,7 @@ label {
 
 You might expect the state to reset when you tick checkbox, but it doesn't! This is because **both of these `<Counter />` tags are rendered at the same position.** React doesn't know where you place the conditions in your function. All it "sees" is the tree you return.
 
-In both cases, the `App` component returns a `<div>` with `<Counter />` as a first child. To React, these two counters have the same "address": the first child of the first child of the root. This is how React matches them up between the previous and next renders, regardless of how you structure your logic.
+In both cases, the `App` component returns a `<div>` with `<Counter />` as a first child. To React, these two counters have the same "address": they're both the first child of the `<div>` that `App` returns. This is how React matches them up between the previous and next renders, regardless of how you structure your logic.
 
 </Pitfall>
 


### PR DESCRIPTION
## Summary

The Pitfall in [Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state) described both `<Counter />` positions as:

> the first child of the first child of the root

Chaining two "first child of" hops reads like an accidental duplicate phrase (see #8622), even though it's technically describing two levels of nesting (`App`'s returned `<div>`, then `<Counter />` inside it). Rephrased to name the anchor directly instead of chaining the hops:

> they're both the first child of the `<div>` that `App` returns

Fixes #8622