### PR TITLE
Fix mobile in-app browser navigation

### DIFF
--- a/src/components/Layout/TopNav/TopNav.tsx
+++ b/src/components/Layout/TopNav/TopNav.tsx
@@ -247,7 +247,7 @@ export default function TopNav({
       <div
         className={cn(
           isMenuOpen
-            ? 'h-screen sticky top-0 lg:bottom-0 lg:h-screen flex flex-col shadow-nav dark:shadow-nav-dark z-20'
+            ? 'h-[100dvh] fixed inset-x-0 top-0 lg:bottom-0 lg:h-[100dvh] flex flex-col shadow-nav dark:shadow-nav-dark z-20'
             : 'z-40 sticky top-0'
         )}>
         <nav
@@ -402,7 +402,7 @@ export default function TopNav({
         {isMenuOpen && (
           <div
             ref={scrollParentRef}
-            className="overflow-y-scroll isolate no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark">
+            className="overflow-y-scroll overscroll-contain isolate no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark">
             <aside
               className={cn(
                 `lg:grow lg:flex flex-col w-full pb-8 lg:pb-0 lg:max-w-custom-xs z-40`,


### PR DESCRIPTION

## Description

Fixes mobile in-app browser navigation positioning and scroll behavior.

## Changes

- Use `100dvh` for the mobile navigation height.
- Use `fixed` positioning for the open mobile navigation.
- Keep the navigation positioned at the top of the viewport.

## Testing

- Tested mobile navigation using Chrome DevTools with Pixel 7 emulation.
- Confirmed the navigation scrolls correctly.
- Confirmed the page behind the navigation does not scroll when reaching the navigation boundary.
- Confirmed the navigation opens from the top of the viewport.
- `yarn lint` passes.
- `yarn tsc` passes.

Fixes #656
