### PR TITLE
Fix a/an grammar errors in reference docs

### DIFF
--- a/src/content/reference/react-dom/components/index.md
+++ b/src/content/reference/react-dom/components/index.md
@@ -186,7 +186,7 @@ Non-string JavaScript values passed to custom elements will be serialized by def
 <my-element value={[1,2,3]}></my-element>
 ```
 
-React will, however, recognize an custom element's property as one that it may pass arbitrary values to if the property name shows up on the class during construction:
+React will, however, recognize a custom element's property as one that it may pass arbitrary values to if the property name shows up on the class during construction:
 
 <Sandpack>
 

--- a/src/content/reference/react/experimental_taintUniqueValue.md
+++ b/src/content/reference/react/experimental_taintUniqueValue.md
@@ -91,7 +91,7 @@ experimental_taintUniqueValue(
 );
 ```
 
-If the tainted value's lifespan is tied to a object, the `lifetime` should be the object that encapsulates the value. This ensures the tainted value remains protected for the lifetime of the encapsulating object.
+If the tainted value's lifespan is tied to an object, the `lifetime` should be the object that encapsulates the value. This ensures the tainted value remains protected for the lifetime of the encapsulating object.
 
 ```js
 import {experimental_taintUniqueValue} from 'react';


### PR DESCRIPTION
## Summary

Fixes two accidental `a`/`an` grammar errors in the reference documentation.

| File | Before | After |
| --- | --- | --- |
| `reference/react-dom/components/index.md` | "recognize **an custom** element's property" | "recognize **a custom** element's property" |
| `reference/react/experimental_taintUniqueValue.md` | "tied to **a object**" | "tied to **an object**" |

Text-only corrections. No change to meaning or code samples.