### PR TITLE
docs: add note about use(Context) support in React 19 to useContext r…

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -12,6 +12,12 @@ const value = useContext(SomeContext)
 
 </Intro>
 
+<Note>
+
+Starting in React 19, you can use [`use(Context)`](/reference/react/use) instead of `useContext(Context)`, which allows you to read context in conditionals and loops.
+
+</Note>
+
 <InlineToc />
 
 ---


### PR DESCRIPTION
…eference

Informs developers that starting in React 19, use(Context) can be used instead of useContext(Context) to read context inside conditionals and loops.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
