### PR TITLE
a11y: normalize TeamMember social link labels and mark icons aria-hid…

### DIFF
--- a/src/components/MDX/TeamMember.tsx
+++ b/src/components/MDX/TeamMember.tsx
@@ -113,7 +113,7 @@ export function TeamMember({
                   aria-label={`${name} on Twitter`}
                   href={`https://twitter.com/${twitter}`}
                   className="hover:text-primary hover:underline dark:text-primary-dark flex flex-row items-center">
-                  <IconTwitter className="pe-1" />
+                  <IconTwitter aria-hidden="true" className="pe-1" />
                   {twitter}
                 </ExternalLink>
               </div>
@@ -124,7 +124,7 @@ export function TeamMember({
                   aria-label={`${name} on Threads`}
                   href={`https://threads.net/${threads}`}
                   className="hover:text-primary hover:underline dark:text-primary-dark flex flex-row items-center">
-                  <IconThreads className="pe-1" />
+                  <IconThreads aria-hidden="true" className="pe-1" />
                   {threads}
                 </ExternalLink>
               </div>
@@ -135,7 +135,7 @@ export function TeamMember({
                   aria-label={`${name} on Bluesky`}
                   href={`https://bsky.app/profile/${bsky}`}
                   className="hover:text-primary hover:underline dark:text-primary-dark flex flex-row items-center">
-                  <IconBsky className="pe-1" />
+                  <IconBsky aria-hidden="true" className="pe-1" />
                   {bsky}
                 </ExternalLink>
               </div>
@@ -143,19 +143,19 @@ export function TeamMember({
             {github && (
               <div className="me-4">
                 <ExternalLink
-                  aria-label="GitHub Profile"
+                  aria-label={`${name} on GitHub`}
                   href={`https://github.com/${github}`}
                   className="hover:text-primary hover:underline dark:text-primary-dark flex flex-row items-center">
-                  <IconGitHub className="pe-1" /> {github}
+                  <IconGitHub aria-hidden="true" className="pe-1" /> {github}
                 </ExternalLink>
               </div>
             )}
             {personal && (
               <ExternalLink
-                aria-label="Personal Site"
+                aria-label={`${name}'s Personal Site`}
                 href={`https://${personal}`}
                 className="hover:text-primary hover:underline dark:text-primary-dark flex flex-row items-center">
-                <IconLink className="pe-1" /> {personal}
+                <IconLink aria-hidden="true" className="pe-1" /> {personal}
               </ExternalLink>
             )}
           </div>


### PR DESCRIPTION
## Description
Fixes #8552

On the Team page (`/community/team`), the social links for GitHub and Personal Site previously used generic accessible labels (`"GitHub Profile"` and `"Personal Site"`). On a page listing dozens of members, screen reader users navigating links or rotor menus encountered identical, ambiguous links without knowing whose profile was referenced (WCAG 2.4.4 Link Purpose in Context).

This PR:
- Normalizes GitHub links to use `aria-label={`${name} on GitHub`}`.
- Normalizes Personal site links to use `aria-label={`${name}'s Personal Site`}`.
- Adds `aria-hidden="true"` to decorative icons (`IconTwitter`, `IconThreads`, `IconBsky`, `IconGitHub`, `IconLink`) to ensure clean accessible names without conflicting nested SVG labels.

## Verification
- `yarn tsc` passed (0 errors)
- `yarn prettier:diff` passed
- `next lint` passed
## Description
Fixes #8552

On the Team page (`/community/team`), the social links for GitHub and Personal Site previously used generic accessible labels (`"GitHub Profile"` and `"Personal Site"`). On a page listing dozens of members, screen reader users navigating links or rotor menus encountered identical, ambiguous links without knowing whose profile was referenced (WCAG 2.4.4 Link Purpose in Context).

This PR:
- Normalizes GitHub links to use `aria-label={`${name} on GitHub`}`.
- Normalizes Personal site links to use `aria-label={`${name}'s Personal Site`}`.
- Adds `aria-hidden="true"` to decorative icons (`IconTwitter`, `IconThreads`, `IconBsky`, `IconGitHub`, `IconLink`) to ensure clean accessible names without conflicting nested SVG labels.

## Verification
- `yarn tsc` passed (0 errors)
- `yarn prettier:diff` passed
- `next lint` passed
