### PR TITLE
Fix isExpanded check in SidebarButton

### DIFF
--- a/src/components/Layout/Sidebar/SidebarButton.tsx
+++ b/src/components/Layout/Sidebar/SidebarButton.tsx
@@ -53,7 +53,7 @@ export function SidebarButton({
         )}
         onClick={onClick}>
         {title}
-        {typeof isExpanded && !heading && (
+        {isExpanded != null && !heading && (
           <span className="pe-2 text-gray-30">
             <IconNavArrow displayDirection={isExpanded ? 'down' : 'end'} />
           </span>


### PR DESCRIPTION
## Description
In `SidebarButton.tsx`, the expansion chevron arrow condition was checking:
`{typeof isExpanded && !heading && (`

In JavaScript, `typeof isExpanded` evaluates to `'boolean'` or `'undefined'`. Since non-empty strings are truthy in JS (`Boolean("undefined") === true`), the arrow was rendered even when `isExpanded` was undefined / not provided.

This PR updates the condition to `{isExpanded != null && !heading && (`, matching the pattern used in `SidebarLink.tsx`.

## Verification
- `yarn tsc` passed (0 errors)
- `yarn prettier:diff` passed
- `npx next lint` passed
- `yarn test:eslint-local-rules` passed
