### PR TITLE
a11y: add skip to main content navigation link (WCAG 2.4.1)

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -154,6 +154,11 @@ export function Page({
         </Head>
       )}
       {/* <SocialBanner /> */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2.5 focus:start-2.5 focus:z-50 focus:px-4 focus:py-2 focus:bg-card focus:dark:bg-card-dark focus:text-link focus:dark:text-link-dark focus:rounded-lg focus:shadow-md focus:outline-none focus:ring-2 focus:ring-link">
+        Skip to main content
+      </a>
       <TopNav
         section={section}
         routeTree={routeTree}
@@ -177,7 +182,7 @@ export function Page({
         )}
         {/* No fallback UI so need to be careful not to suspend directly inside. */}
         <Suspense fallback={null}>
-          <main className="min-w-0 isolate">
+          <main id="main-content" className="min-w-0 isolate">
             <article
               className="font-normal break-words text-primary dark:text-primary-dark"
               key={asPath}>


### PR DESCRIPTION
## Description
This PR implements a "Skip to main content" link to satisfy WCAG 2.4.1 (Bypass Blocks, Level A).

Currently, keyboard and assistive technology users navigating `react.dev` must tab through all header links, search, and sidebar navigation items on every page before reaching the main article.

### Changes:
- Added an accessible skip link at the top of `Page.tsx` using `sr-only focus:not-sr-only`, styled with the site's design tokens. When focused via keyboard `Tab`, the skip button appears at the top-left corner.
- Added `id="main-content"` to the `<main>` landmark element in `Page.tsx`.

## Verification
- `yarn tsc` passed (0 errors)
- `yarn prettier:diff` passed
- `npx next lint` passed
- `yarn test:eslint-local-rules` passed
