### PR TITLE
docs(warnings): update special-props warning for React 19 ref prop fo…

### DIFF
--- a/src/content/warnings/special-props.md
+++ b/src/content/warnings/special-props.md
@@ -2,6 +2,8 @@
 title: Special Props Warning
 ---
 
-Most props on a JSX element are passed on to the component, however, there are two special props (`ref` and `key`) which are used by React, and are thus not forwarded to the component.
+Most props on a JSX element are passed on to the component. In earlier versions of React, `key` and `ref` were two special props used internally by React that were not forwarded to components.
 
-For instance, you can't read `props.key` from a component. If you need to access the same value within the child component, you should pass it as a different prop (ex: `<ListItemWrapper key={result.id} id={result.id} />` and read `props.id`). While this may seem redundant, it's important to separate app logic from hints to React.
+Starting in React 19, `ref` is available as a prop for function components, making `key` the only prop that React does not forward to the component.
+
+For instance, you cannot read `props.key` from a component. If you need to access the same value within the child component, you should pass it as a different prop (e.g. `<ListItemWrapper key={result.id} id={result.id} />` and read `props.id`). While this may seem redundant, it's important to separate app logic from hints to React.


### PR DESCRIPTION
## Description
Fixes #8323

The warning documentation page at `/warnings/special-props` (linked directly from React engine runtime warnings via `/link/special-props`) stated that both `ref` and `key` are not forwarded to components.

In React 19, `ref` is available as a prop for function components. This PR updates the copy to clarify that `key` is the only prop that React reserves and does not forward to child components.

## Verification
- `yarn tsc` passed (0 errors)
- `yarn prettier:diff` passed
- `node scripts/deadLinkChecker.js` passed
