### PR TITLE
docs: fix typo in useActionState and remove redundant async in useTransition

### DIFF
--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -257,7 +257,7 @@ button {
 
 </Sandpack>
 
-Every time you click "Add Ticket," React queues a call to `addToCartAction`. React shows the pending state until all the tickets are added, and then re-renders with the final state.
+Every time you click "Add Ticket", React queues a call to `addToCartAction`. React shows the pending state until all the tickets are added, and then re-renders with the final state.
 
 <DeepDive>
 

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -661,7 +661,7 @@ export default function TabButton({ action, children, isActive }) {
     return <b className="pending">{children}</b>;
   }
   return (
-    <button onClick={async () => {
+    <button onClick={() => {
       startTransition(async () => {
         // await the action that's passed in.
         // This allows it to be either sync or async.


### PR DESCRIPTION
1. Fixes a typo in the `useActionState` documentation.

Moves the comma outside the quotation marks:

`Every time you click "Add Ticket," React queues`

becomes

`Every time you click "Add Ticket", React queues`

I know that Chicago style places commas before the closing quotation mark, but based on the style used in other parts of the React documentation for quoted UI labels, I believe this is a typo.


Before fix:
<img width="885" height="82" alt="1" src="https://github.com/user-attachments/assets/2056a22c-a27f-4cff-b9e8-364c7dcb8bfd" />

After fix:
<img width="885" height="82" alt="2" src="https://github.com/user-attachments/assets/dbbf2b33-8fd1-4423-bb54-f78dfdcdf71d" />

2. Removes a redundant `async` from a `useTransition` example.

Changes

`onClick={async () => {`

to

`onClick={() => {`

The outer event handler does not contain an `await`, so marking it as `async` is unnecessary.

Before fix:
<img width="1143" height="508" alt="3" src="https://github.com/user-attachments/assets/ec181915-5ebd-4867-97b9-3aa6c8567866" />

After fix:
<img width="1143" height="508" alt="4" src="https://github.com/user-attachments/assets/07e033a7-9303-405e-a05a-cd10447b167c" />
