### PR TITLE
docs: capitalize Actions (React 19 concept) in reference docs

### DIFF
--- a/src/content/reference/react/hooks.md
+++ b/src/content/reference/react/hooks.md
@@ -116,7 +116,7 @@ These Hooks are mostly useful to library authors and aren't commonly used in the
 - [`useDebugValue`](/reference/react/useDebugValue) lets you customize the label React DevTools displays for your custom Hook.
 - [`useId`](/reference/react/useId) lets a component associate a unique ID with itself. Typically used with accessibility APIs.
 - [`useSyncExternalStore`](/reference/react/useSyncExternalStore) lets a component subscribe to an external store.
-* [`useActionState`](/reference/react/useActionState) allows you to manage state of actions.
+* [`useActionState`](/reference/react/useActionState) allows you to manage state of Actions.
 
 ---
 

--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -269,7 +269,7 @@ Try clicking "Add Ticket" multiple times. Every time you click, a new `addToCart
 
 We have to wait for the previous result of `addToCartAction` in order to pass the `prevCount` to the next call to `addToCartAction`. That means React has to wait for the previous Action to finish before calling the next Action.
 
-You can typically solve this by [using with useOptimistic](/reference/react/useActionState#using-with-useoptimistic) but for more complex cases you may want to consider [cancelling queued actions](#cancelling-queued-actions) or not using `useActionState`.
+You can typically solve this by [using with useOptimistic](/reference/react/useActionState#using-with-useoptimistic) but for more complex cases you may want to consider [cancelling queued Actions](#cancelling-queued-actions) or not using `useActionState`.
 
 </DeepDive>
 
@@ -1423,7 +1423,7 @@ function action(prevState, formData) {
 
 ---
 
-### My actions are being skipped {/*actions-skipped*/}
+### My Actions are being skipped {/*actions-skipped*/}
 
 If you call `dispatchAction` multiple times and some of them don't run, it may be because an earlier `dispatchAction` call threw an error.
 

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -309,7 +309,7 @@ This is a basic example to demonstrate how Actions work, but this example does n
 
 For common use cases, React provides built-in abstractions such as:
 - [`useActionState`](/reference/react/useActionState)
-- [`<form>` actions](/reference/react-dom/components/form)
+- [`<form>` Actions](/reference/react-dom/components/form)
 - [Server Functions](/reference/rsc/server-functions)
 
 These solutions handle request ordering for you. When using Transitions to build your own custom hooks or libraries that manage async state transitions, you have greater control over the request ordering, but you must handle it yourself.
@@ -1256,7 +1256,7 @@ This is recommended for three reasons:
 
 - [Transitions are interruptible,](#perform-non-blocking-updates-with-actions) which lets the user click away without waiting for the re-render to complete.
 - [Transitions prevent unwanted loading indicators,](#preventing-unwanted-loading-indicators) which lets the user avoid jarring jumps on navigation.
-- [Transitions wait for all pending actions](#perform-non-blocking-updates-with-actions) which lets the user wait for side effects to complete before the new page is shown.
+- [Transitions wait for all pending Actions](#perform-non-blocking-updates-with-actions) which lets the user wait for side effects to complete before the new page is shown.
 
 Here is a simplified router example using Transitions for navigations.
 
@@ -1953,7 +1953,7 @@ export async function updateQuantity(newName) {
 
 When clicking multiple times, it's possible for previous requests to finish after later requests. When this happens, React currently has no way to know the intended order. This is because the updates are scheduled asynchronously, and React loses context of the order across the async boundary.
 
-This is expected, because Actions within a Transition do not guarantee execution order. For common use cases, React provides higher-level abstractions like [`useActionState`](/reference/react/useActionState) and [`<form>` actions](/reference/react-dom/components/form) that handle ordering for you. For advanced use cases, you'll need to implement your own queuing and abort logic to handle this.
+This is expected, because Actions within a Transition do not guarantee execution order. For common use cases, React provides higher-level abstractions like [`useActionState`](/reference/react/useActionState) and [`<form>` Actions](/reference/react-dom/components/form) that handle ordering for you. For advanced use cases, you'll need to implement your own queuing and abort logic to handle this.
 
 
 Example of `useActionState` handling execution order:


### PR DESCRIPTION
Part of #6713

Capitalizes 'Actions' when referring to the React 19 Actions feature (functions passed to startTransition) in the reference docs.

## Files changed
- `hooks.md`: manage state of Actions
- `useActionState.md`: cancelling queued Actions, My Actions are being skipped
- `useTransition.md`: `<form>` Actions (x2), pending Actions

## Not changed
Left lowercase 'actions' where it refers to general programming concepts: reducer actions, user actions, DOM actions, and actions.js filenames — these are not the React 19 Actions feature.