### PR TITLE
Rewrite the Activity API reference

### DIFF
--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -513,107 +513,7 @@ An Activity boundary can also prepare content before the user sees it. Content i
 
 If `Posts` suspends while reading code or data, React continues rendering the rest of the page while the hidden work proceeds.
 
-The following examples compare rendering the Posts tab on demand with pre-rendering it in a hidden Activity boundary. Both versions read the same cached Promise with [`use`](/reference/react/use).
-
-<Recipes titleText="The difference between rendering and pre-rendering a tab" titleId="examples-pre-rendering">
-
-#### Rendering the tab on demand shows a fallback {/*rendering-the-tab-on-demand-shows-a-fallback*/}
-
-This version does not mount `<Posts>` until its tab is active. Select **Posts** to see the Suspense fallback while the data loads.
-
-<Sandpack>
-
-```js src/App.js active
-import { Suspense, useState } from 'react';
-import Home from './Home.js';
-import Posts from './Posts.js';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('home');
-
-  return (
-    <>
-      <div aria-label="Profile sections" role="group">
-        <button
-          aria-pressed={activeTab === 'home'}
-          onClick={() => setActiveTab('home')}
-        >
-          Home
-        </button>
-        <button
-          aria-pressed={activeTab === 'posts'}
-          onClick={() => setActiveTab('posts')}
-        >
-          Posts
-        </button>
-      </div>
-
-      <Suspense fallback={<h1>Loading posts...</h1>}>
-        {activeTab === 'home' && <Home />}
-        {activeTab === 'posts' && <Posts />}
-      </Suspense>
-    </>
-  );
-}
-```
-
-```js src/Posts.js
-import { use } from 'react';
-import { getPosts } from './data.js';
-
-export default function Posts() {
-  const posts = use(getPosts());
-
-  return (
-    <ul>
-      {posts.map(post => (
-        <li key={post.id}>{post.title}</li>
-      ))}
-    </ul>
-  );
-}
-```
-
-```js src/Home.js hidden
-export default function Home() {
-  return <p>Welcome to my profile!</p>;
-}
-```
-
-```js src/data.js hidden
-let postsPromise;
-
-export function getPosts() {
-  if (!postsPromise) {
-    postsPromise = loadPosts();
-  }
-  return postsPromise;
-}
-
-async function loadPosts() {
-  // Add a delay so that loading is easier to observe.
-  await new Promise(resolve => setTimeout(resolve, 1500));
-
-  return Array.from({ length: 5 }, (_, index) => ({
-    id: index,
-    title: 'Post #' + (index + 1),
-  }));
-}
-```
-
-```css
-button {
-  margin-right: 8px;
-}
-```
-
-</Sandpack>
-
-<Solution />
-
-#### Pre-rendering the tab can avoid the fallback {/*pre-rendering-the-tab-can-avoid-the-fallback*/}
-
-This version renders both tabs inside Activity boundaries. React begins rendering `<Posts>` while its boundary is hidden. Wait briefly before selecting **Posts**. The list appears immediately because the hidden render started loading it in the background.
+The following example renders both tabs inside Activity boundaries. `<Posts>` reads a cached Promise with [`use`](/reference/react/use), so React begins loading the posts while its boundary is hidden. Wait briefly before selecting **Posts**. If the hidden render has finished, the list appears immediately.
 
 <Sandpack>
 
@@ -706,10 +606,6 @@ button {
 ```
 
 </Sandpack>
-
-<Solution />
-
-</Recipes>
 
 If the user selects Posts before the hidden render finishes, the Suspense fallback appears until the data is ready. Pre-rendering can reduce the loading time, but it does not guarantee that the content will always be ready.
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -4,10 +4,10 @@ title: <Activity>
 
 <Intro>
 
-`<Activity>` lets you hide and restore the UI and internal state of its children.
+`<Activity>` lets you hide and reveal part of the UI while preserving its state.
 
 ```js
-<Activity mode={visibility}>
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
   <Sidebar />
 </Activity>
 ```
@@ -22,215 +22,148 @@ title: <Activity>
 
 ### `<Activity>` {/*activity*/}
 
-You can use Activity to hide part of your application:
+Wrap part of the component tree in `<Activity>` to control whether it is visible:
 
-```js [[1, 1, "\\"hidden\\""], [2, 2, "<Sidebar />"], [3, 1, "\\"visible\\""]]
-<Activity mode={isShowingSidebar ? "visible" : "hidden"}>
+```js
+import { Activity } from 'react';
+
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
   <Sidebar />
 </Activity>
 ```
 
-When an Activity boundary is <CodeStep step={1}>hidden</CodeStep>, React will visually hide <CodeStep step={2}>its children</CodeStep> using the `display: "none"` CSS property. It will also destroy their Effects, cleaning up any active subscriptions.
-
-While hidden, children still re-render in response to new props, albeit at a lower priority than the rest of the content.
-
-When the boundary becomes <CodeStep step={3}>visible</CodeStep> again, React will reveal the children with their previous state restored, and re-create their Effects.
-
-In this way, Activity can be thought of as a mechanism for rendering "background activity". Rather than completely discarding content that's likely to become visible again, you can use Activity to maintain and restore that content's UI and internal state, while ensuring that your hidden content has no unwanted side effects.
-
 [See more examples below.](#usage)
+
+#### Modes {/*modes*/}
+
+An Activity boundary supports two modes:
+
+- In `visible` mode, React renders the children and runs the setup functions for
+  their `useEffect` and `useLayoutEffect` calls.
+- In `hidden` mode, React hides the children and runs the cleanup functions for
+  their `useEffect` and `useLayoutEffect` calls. React preserves their state and
+  renders updates at a lower priority than updates to visible content.
+
+When a hidden Activity boundary becomes visible, React reveals its children with
+their previous state and runs their Effect setup functions again.
+
+In React DOM, hiding an Activity boundary applies `display: none` to the nearest
+DOM elements inside the boundary. React preserves those elements while the
+boundary remains mounted.
 
 #### Props {/*props*/}
 
-* `children`: The UI you intend to show and hide.
-* `mode`: A string value of either `'visible'` or `'hidden'`. If omitted, defaults to `'visible'`.
+* `children`: The UI rendered by the Activity boundary. `children` can be any
+  [React node](/reference/react/isValidElement#react-elements-vs-react-nodes).
+* **optional** `mode`: Either `'visible'` or `'hidden'`. Defaults to `'visible'`.
+  See [Modes](#modes) for the behavior of each value.
+* **optional** `name`: A string that identifies the Activity boundary in React
+  Developer Tools.
 
 #### Caveats {/*caveats*/}
 
-- If an Activity is rendered inside of a [ViewTransition](/reference/react/ViewTransition), and it becomes visible as a result of an update caused by [startTransition](/reference/react/startTransition), it will activate the ViewTransition's `enter` animation. If it becomes hidden, it will activate its `exit` animation.
-- A *hidden* Activity that just renders text will not render anything rather than rendering hidden text, because there’s no corresponding DOM element to apply visibility changes to. For example, `<Activity mode="hidden"><ComponentThatJustReturnsText /></Activity>` will not produce any output in the DOM for `const ComponentThatJustReturnsText = () => "Hello, World!"`. `<Activity mode="visible"><ComponentThatJustReturnsText /></Activity>` will render visible text.
+- Hiding an Activity boundary retains its state and DOM nodes, so React does not
+  reclaim all memory associated with the hidden subtree.
+- Browser behavior associated with preserved DOM nodes can continue while the
+  boundary is hidden. For example, audio and video can continue playing. Use an
+  Effect cleanup function to stop this behavior.
+  [See an example below.](#my-hidden-components-have-unwanted-side-effects)
+- React runs cleanup functions for Effects created with `useEffect` and
+  `useLayoutEffect` when an Activity boundary becomes hidden. Insertion Effects
+  created with
+  [`useInsertionEffect`](/reference/react/useInsertionEffect)
+  remain connected because styles may still be needed by the preserved DOM.
+- React detaches refs in a hidden Activity boundary and reattaches them when the
+  boundary becomes visible.
+- Content initially rendered inside `<Activity mode="hidden">` is not included in
+  server-rendered HTML. React renders it on the client at a lower priority after
+  hydrating visible content.
+- React omits text-only output while an Activity boundary is hidden because a text
+  node cannot receive `display: none`. The text appears when the boundary becomes
+  visible.
+- If an Activity boundary is inside
+  [`<ViewTransition>`](/reference/react/ViewTransition),
+  changing it from hidden to visible as part of an update started with
+  [`startTransition`](/reference/react/startTransition) activates the `enter`
+  animation. Changing it from visible to hidden as part of that update activates
+  the `exit` animation.
 
 ---
 
 ## Usage {/*usage*/}
 
-### Restoring the state of hidden components {/*restoring-the-state-of-hidden-components*/}
+### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
-In React, when you want to conditionally show or hide a component, you typically mount or unmount it based on that condition:
+When this condition becomes false, React removes `<Sidebar>` from the tree and
+discards its state:
 
-```jsx
-{isShowingSidebar && (
-  <Sidebar />
-)}
+```js
+{isShowingSidebar && <Sidebar />}
 ```
 
-But unmounting a component destroys its internal state, which is not always what you want.
+Render the component inside an Activity boundary to preserve its state while it is
+hidden:
 
-When you hide a component using an Activity boundary instead, React will "save" its state for later:
-
-```jsx
-<Activity mode={isShowingSidebar ? "visible" : "hidden"}>
-  <Sidebar />
-</Activity>
-```
-
-This makes it possible to hide and then later restore components in the state they were previously in.
-
-The following example has a sidebar with an expandable section. You can press "Overview" to reveal the three subitems below it. The main app area also has a button that hides and shows the sidebar.
-
-Try expanding the Overview section, and then toggling the sidebar closed then open:
-
-<Sandpack>
-
-```js src/App.js active
-import { useState } from 'react';
-import Sidebar from './Sidebar.js';
-
-export default function App() {
-  const [isShowingSidebar, setIsShowingSidebar] = useState(true);
-
-  return (
-    <>
-      {isShowingSidebar && (
-        <Sidebar />
-      )}
-
-      <main>
-        <button onClick={() => setIsShowingSidebar(!isShowingSidebar)}>
-          Toggle sidebar
-        </button>
-        <h1>Main content</h1>
-      </main>
-    </>
-  );
-}
-```
-
-```js src/Sidebar.js
-import { useState } from 'react';
-
-export default function Sidebar() {
-  const [isExpanded, setIsExpanded] = useState(false)
-
-  return (
-    <nav>
-      <button onClick={() => setIsExpanded(!isExpanded)}>
-        Overview
-        <span className={`indicator ${isExpanded ? 'down' : 'right'}`}>
-          &#9650;
-        </span>
-      </button>
-
-      {isExpanded && (
-        <ul>
-          <li>Section 1</li>
-          <li>Section 2</li>
-          <li>Section 3</li>
-        </ul>
-      )}
-    </nav>
-  );
-}
-```
-
-```css
-body { height: 275px; margin: 0; }
-#root {
-  display: flex;
-  gap: 10px;
-  height: 100%;
-}
-nav {
-  padding: 10px;
-  background: #eee;
-  font-size: 14px;
-  height: 100%;
-}
-main {
-  padding: 10px;
-}
-p {
-  margin: 0;
-}
-h1 {
-  margin-top: 10px;
-}
-.indicator {
-  margin-left: 4px;
-  display: inline-block;
-  rotate: 90deg;
-}
-.indicator.down {
-  rotate: 180deg;
-}
-```
-
-</Sandpack>
-
-The Overview section always starts out collapsed. Because we unmount the sidebar when `isShowingSidebar` flips to `false`, all its internal state is lost.
-
-This is a perfect use case for Activity. We can preserve the internal state of our sidebar, even when visually hiding it.
-
-Let's replace the conditional rendering of our sidebar with an Activity boundary:
-
-```jsx {7,9}
-// Before
-{isShowingSidebar && (
-  <Sidebar />
-)}
-
-// After
+```js
 <Activity mode={isShowingSidebar ? 'visible' : 'hidden'}>
   <Sidebar />
 </Activity>
 ```
 
-and check out the new behavior:
+In this example, expand the sidebar, hide it, and show it again. The expanded state
+is preserved.
 
 <Sandpack>
 
-```js src/App.js active
+```js
 import { Activity, useState } from 'react';
-
-import Sidebar from './Sidebar.js';
 
 export default function App() {
   const [isShowingSidebar, setIsShowingSidebar] = useState(true);
 
   return (
-    <>
-      <Activity mode={isShowingSidebar ? 'visible' : 'hidden'}>
+    <div className='layout'>
+      <Activity
+        mode={isShowingSidebar ? 'visible' : 'hidden'}
+      >
         <Sidebar />
       </Activity>
 
       <main>
-        <button onClick={() => setIsShowingSidebar(!isShowingSidebar)}>
-          Toggle sidebar
+        <button
+          aria-controls='documentation-sidebar'
+          aria-expanded={isShowingSidebar}
+          onClick={() => setIsShowingSidebar(s => !s)}
+        >
+          {isShowingSidebar ? 'Hide' : 'Show'} sidebar
         </button>
         <h1>Main content</h1>
       </main>
-    </>
+    </div>
   );
 }
-```
 
-```js src/Sidebar.js
-import { useState } from 'react';
-
-export default function Sidebar() {
-  const [isExpanded, setIsExpanded] = useState(false)
+function Sidebar() {
+  const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <nav>
-      <button onClick={() => setIsExpanded(!isExpanded)}>
+    <nav
+      aria-label='Documentation'
+      id='documentation-sidebar'
+    >
+      <button
+        aria-controls='overview-sections'
+        aria-expanded={isExpanded}
+        onClick={() => setIsExpanded(e => !e)}
+      >
         Overview
-        <span className={`indicator ${isExpanded ? 'down' : 'right'}`}>
-          &#9650;
+        <span aria-hidden='true' className='indicator'>
+          {isExpanded ? '−' : '+'}
         </span>
       </button>
 
       {isExpanded && (
-        <ul>
+        <ul id='overview-sections'>
           <li>Section 1</li>
           <li>Section 2</li>
           <li>Section 3</li>
@@ -242,652 +175,182 @@ export default function Sidebar() {
 ```
 
 ```css
-body { height: 275px; margin: 0; }
-#root {
-  display: flex;
-  gap: 10px;
-  height: 100%;
-}
-nav {
-  padding: 10px;
-  background: #eee;
-  font-size: 14px;
-  height: 100%;
-}
-main {
-  padding: 10px;
-}
-p {
+body {
   margin: 0;
 }
-h1 {
-  margin-top: 10px;
+.layout {
+  display: flex;
+  min-height: 275px;
+}
+nav {
+  padding: 12px;
+  background: #eee;
+}
+main {
+  padding: 12px;
 }
 .indicator {
-  margin-left: 4px;
-  display: inline-block;
-  rotate: 90deg;
-}
-.indicator.down {
-  rotate: 180deg;
+  margin-left: 6px;
 }
 ```
 
 </Sandpack>
 
-Our sidebar's internal state is now restored, without any changes to its implementation.
+Changing `mode` preserves the state of the children. Removing the boundary or
+changing a child's type, key, or position can
+[reset its state](/learn/preserving-and-resetting-state).
 
 ---
 
-### Restoring the DOM of hidden components {/*restoring-the-dom-of-hidden-components*/}
+### Preserving DOM state while content is hidden {/*restoring-the-dom-of-hidden-components*/}
 
-Since Activity boundaries hide their children using `display: none`, their children's DOM is also preserved when hidden. This makes them great for maintaining ephemeral state in parts of the UI that the user is likely to interact with again.
+An Activity boundary also preserves state held by the browser in DOM nodes. This
+includes an uncontrolled input's current value, scroll position, and media
+playback position.
 
-In this example, the Contact tab has a `<textarea>` where the user can enter a message. If you enter some text, change to the Home tab, then change back to the Contact tab, the draft message is lost:
-
-<Sandpack>
-
-```js src/App.js
-import { useState } from 'react';
-import TabButton from './TabButton.js';
-import Home from './Home.js';
-import Contact from './Contact.js';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('contact');
-
-  return (
-    <>
-      <TabButton
-        isActive={activeTab === 'home'}
-        onClick={() => setActiveTab('home')}
-      >
-        Home
-      </TabButton>
-      <TabButton
-        isActive={activeTab === 'contact'}
-        onClick={() => setActiveTab('contact')}
-      >
-        Contact
-      </TabButton>
-
-      <hr />
-
-      {activeTab === 'home' && <Home />}
-      {activeTab === 'contact' && <Contact />}
-    </>
-  );
-}
-```
-
-```js src/TabButton.js
-export default function TabButton({ onClick, children, isActive }) {
-  if (isActive) {
-    return <b>{children}</b>
-  }
-
-  return (
-    <button onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-```
-
-```js src/Home.js
-export default function Home() {
-  return (
-    <p>Welcome to my profile!</p>
-  );
-}
-```
-
-```js src/Contact.js active
-export default function Contact() {
-  return (
-    <div>
-      <p>Send me a message!</p>
-
-      <textarea />
-
-      <p>You can find me online here:</p>
-      <ul>
-        <li>admin@mysite.com</li>
-        <li>+123456789</li>
-      </ul>
-    </div>
-  );
-}
-```
-
-```css
-body { height: 275px; }
-button { margin-right: 10px }
-b { display: inline-block; margin-right: 10px; }
-.pending { color: #777; }
-```
-
-</Sandpack>
-
-This is because we're fully unmounting `Contact` in `App`. When the Contact tab unmounts, the `<textarea>` element's internal DOM state is lost.
-
-If we switch to using an Activity boundary to show and hide the active tab, we can preserve the state of each tab's DOM. Try entering text and switching tabs again, and you'll see the draft message is no longer reset:
+In this example, enter a draft in the Contact section, switch sections, and then
+return to Contact. The `<textarea>` value remains because its DOM node was hidden
+rather than removed.
 
 <Sandpack>
 
-```js src/App.js active
+```js
 import { Activity, useState } from 'react';
-import TabButton from './TabButton.js';
-import Home from './Home.js';
-import Contact from './Contact.js';
 
 export default function App() {
-  const [activeTab, setActiveTab] = useState('contact');
+  const [activeSection, setActiveSection] = useState('contact');
 
   return (
     <>
-      <TabButton
-        isActive={activeTab === 'home'}
-        onClick={() => setActiveTab('home')}
+      <div
+        aria-label='Profile sections'
+        className='section-buttons'
+        role='group'
       >
-        Home
-      </TabButton>
-      <TabButton
-        isActive={activeTab === 'contact'}
-        onClick={() => setActiveTab('contact')}
+        <SectionButton
+          isActive={activeSection === 'home'}
+          onClick={() => setActiveSection('home')}
+        >
+          Home
+        </SectionButton>
+        <SectionButton
+          isActive={activeSection === 'contact'}
+          onClick={() => setActiveSection('contact')}
+        >
+          Contact
+        </SectionButton>
+      </div>
+
+      <Activity
+        mode={activeSection === 'home' ? 'visible' : 'hidden'}
       >
-        Contact
-      </TabButton>
-
-      <hr />
-
-      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
         <Home />
       </Activity>
-      <Activity mode={activeTab === 'contact' ? 'visible' : 'hidden'}>
+      <Activity
+        mode={activeSection === 'contact' ? 'visible' : 'hidden'}
+      >
         <Contact />
       </Activity>
     </>
   );
 }
-```
 
-```js src/TabButton.js
-export default function TabButton({ onClick, children, isActive }) {
-  if (isActive) {
-    return <b>{children}</b>
-  }
-
+function SectionButton({ isActive, onClick, children }) {
   return (
-    <button onClick={onClick}>
+    <button aria-pressed={isActive} onClick={onClick}>
       {children}
     </button>
   );
 }
-```
 
-```js src/Home.js
-export default function Home() {
-  return (
-    <p>Welcome to my profile!</p>
-  );
+function Home() {
+  return <p>Welcome to my profile!</p>;
 }
-```
 
-```js src/Contact.js
-export default function Contact() {
+function Contact() {
   return (
-    <div>
-      <p>Send me a message!</p>
-
-      <textarea />
-
-      <p>You can find me online here:</p>
-      <ul>
-        <li>admin@mysite.com</li>
-        <li>+123456789</li>
-      </ul>
-    </div>
+    <p>
+      <label htmlFor='message'>Message</label>
+      <textarea id='message' />
+    </p>
   );
 }
 ```
 
 ```css
-body { height: 275px; }
-button { margin-right: 10px }
-b { display: inline-block; margin-right: 10px; }
-.pending { color: #777; }
+.section-buttons {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+label,
+textarea {
+  display: block;
+}
+textarea {
+  margin-top: 4px;
+}
 ```
 
 </Sandpack>
 
-Again, the Activity boundary let us preserve the Contact tab's internal state without changing its implementation.
+Preserving DOM state also means that DOM behavior can continue while content is
+hidden. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects)
+for DOM behavior that requires explicit cleanup.
 
 ---
 
-### Pre-rendering content that's likely to become visible {/*pre-rendering-content-thats-likely-to-become-visible*/}
+### Pre-rendering content that is likely to become visible {/*pre-rendering-content-thats-likely-to-become-visible*/}
 
-So far, we've seen how Activity can hide some content that the user has interacted with, without discarding that content's ephemeral state.
+Content inside a hidden Activity boundary renders at a lower priority without
+running Effects created with `useEffect` or `useLayoutEffect`. This allows the
+content to begin loading code and render-time data before it becomes visible:
 
-But Activity boundaries can also be used to _prepare_ content that the user has yet to see for the first time:
-
-```jsx [[1, 1, "\\"hidden\\""]]
-<Activity mode="hidden">
-  <SlowComponent />
-</Activity>
+```js
+<Suspense fallback={<Loading />}>
+  <Activity mode={activeTab === 'posts' ? 'visible' : 'hidden'}>
+    <Posts />
+  </Activity>
+</Suspense>
 ```
 
-When an Activity boundary is <CodeStep step={1}>hidden</CodeStep> during its initial render, its children won't be visible on the page — but they will _still be rendered_, albeit at a lower priority than the visible content, and without mounting their Effects.
-
-This _pre-rendering_ allows the children to load any code or data they need ahead of time, so that later, when the Activity boundary becomes visible, the children can appear faster with reduced loading times.
-
-Let's look at an example.
-
-In this demo, the Posts tab loads some data. If you press it, you'll see a Suspense fallback displayed while the data is being fetched:
-
-<Sandpack>
-
-```js src/App.js
-import { useState, Suspense } from 'react';
-import TabButton from './TabButton.js';
-import Home from './Home.js';
-import Posts from './Posts.js';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('home');
-
-  return (
-    <>
-      <TabButton
-        isActive={activeTab === 'home'}
-        onClick={() => setActiveTab('home')}
-      >
-        Home
-      </TabButton>
-      <TabButton
-        isActive={activeTab === 'posts'}
-        onClick={() => setActiveTab('posts')}
-      >
-        Posts
-      </TabButton>
-
-      <hr />
-
-      <Suspense fallback={<h1>🌀 Loading...</h1>}>
-        {activeTab === 'home' && <Home />}
-        {activeTab === 'posts' && <Posts />}
-      </Suspense>
-    </>
-  );
-}
-```
-
-```js src/TabButton.js hidden
-export default function TabButton({ onClick, children, isActive }) {
-  if (isActive) {
-    return <b>{children}</b>
-  }
-
-  return (
-    <button onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-```
-
-```js src/Home.js
-export default function Home() {
-  return (
-    <p>Welcome to my profile!</p>
-  );
-}
-```
-
-```js src/Posts.js
-import { use } from 'react';
-import { fetchData } from './data.js';
-
-export default function Posts() {
-  const posts = use(fetchData('/posts'));
-
-  return (
-    <ul className="items">
-      {posts.map(post =>
-        <li className="item" key={post.id}>
-          {post.title}
-        </li>
-      )}
-    </ul>
-  );
-}
-```
-
-```js src/data.js hidden
-// Note: the way you would do data fetching depends on
-// the framework that you use together with Suspense.
-// Normally, the caching logic would be inside a framework.
-
-let cache = new Map();
-
-export function fetchData(url) {
-  if (!cache.has(url)) {
-    cache.set(url, getData(url));
-  }
-  return cache.get(url);
-}
-
-async function getData(url) {
-  if (url.startsWith('/posts')) {
-    return await getPosts();
-  } else {
-    throw Error('Not implemented');
-  }
-}
-
-async function getPosts() {
-  // Add a fake delay to make waiting noticeable.
-  await new Promise(resolve => {
-    setTimeout(resolve, 1000);
-  });
-  let posts = [];
-  for (let i = 0; i < 10; i++) {
-    posts.push({
-      id: i,
-      title: 'Post #' + (i + 1)
-    });
-  }
-  return posts;
-}
-```
-
-```css
-body { height: 275px; }
-button { margin-right: 10px }
-b { display: inline-block; margin-right: 10px; }
-.pending { color: #777; }
-video { width: 300px; margin-top: 10px; aspect-ratio: 16/9; }
-```
-
-</Sandpack>
-
-This is because `App` doesn't mount `Posts` until its tab is active.
-
-If we update `App` to use an Activity boundary to show and hide the active tab, `Posts` will be pre-rendered when the app first loads, allowing it to fetch its data before it becomes visible.
-
-Try clicking the Posts tab now:
-
-<Sandpack>
-
-```js src/App.js
-import { Activity, useState, Suspense } from 'react';
-import TabButton from './TabButton.js';
-import Home from './Home.js';
-import Posts from './Posts.js';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('home');
-
-  return (
-    <>
-      <TabButton
-        isActive={activeTab === 'home'}
-        onClick={() => setActiveTab('home')}
-      >
-        Home
-      </TabButton>
-      <TabButton
-        isActive={activeTab === 'posts'}
-        onClick={() => setActiveTab('posts')}
-      >
-        Posts
-      </TabButton>
-
-      <hr />
-
-      <Suspense fallback={<h1>🌀 Loading...</h1>}>
-        <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
-          <Home />
-        </Activity>
-        <Activity mode={activeTab === 'posts' ? 'visible' : 'hidden'}>
-          <Posts />
-        </Activity>
-      </Suspense>
-    </>
-  );
-}
-```
-
-```js src/TabButton.js hidden
-export default function TabButton({ onClick, children, isActive }) {
-  if (isActive) {
-    return <b>{children}</b>
-  }
-
-  return (
-    <button onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-```
-
-```js src/Home.js
-export default function Home() {
-  return (
-    <p>Welcome to my profile!</p>
-  );
-}
-```
-
-```js src/Posts.js
-import { use } from 'react';
-import { fetchData } from './data.js';
-
-export default function Posts() {
-  const posts = use(fetchData('/posts'));
-
-  return (
-    <ul className="items">
-      {posts.map(post =>
-        <li className="item" key={post.id}>
-          {post.title}
-        </li>
-      )}
-    </ul>
-  );
-}
-```
-
-```js src/data.js hidden
-// Note: the way you would do data fetching depends on
-// the framework that you use together with Suspense.
-// Normally, the caching logic would be inside a framework.
-
-let cache = new Map();
-
-export function fetchData(url) {
-  if (!cache.has(url)) {
-    cache.set(url, getData(url));
-  }
-  return cache.get(url);
-}
-
-async function getData(url) {
-  if (url.startsWith('/posts')) {
-    return await getPosts();
-  } else {
-    throw Error('Not implemented');
-  }
-}
-
-async function getPosts() {
-  // Add a fake delay to make waiting noticeable.
-  await new Promise(resolve => {
-    setTimeout(resolve, 1000);
-  });
-  let posts = [];
-  for (let i = 0; i < 10; i++) {
-    posts.push({
-      id: i,
-      title: 'Post #' + (i + 1)
-    });
-  }
-  return posts;
-}
-```
-
-```css
-body { height: 275px; }
-button { margin-right: 10px }
-b { display: inline-block; margin-right: 10px; }
-.pending { color: #777; }
-video { width: 300px; margin-top: 10px; aspect-ratio: 16/9; }
-```
-
-</Sandpack>
-
-`Posts` was able to prepare itself for a faster render, thanks to the hidden Activity boundary.
-
----
-
-Pre-rendering components with hidden Activity boundaries is a powerful way to reduce loading times for parts of the UI that the user is likely to interact with next.
+If `Posts` suspends while reading code or data, React continues rendering the rest
+of the page. If that hidden work completes, switching to the Posts tab can reveal
+the content without waiting for the same work again.
 
 <Note>
 
-Only data read from a source that [activates a Suspense boundary](/reference/react/Suspense#what-activates-a-suspense-boundary), such as a Promise read with [`use`](/reference/react/use), is fetched during pre-rendering. Activity does not detect data fetched inside an Effect.
+Only code and data read during rendering can load during pre-rendering. Activity
+does not run Effects in hidden content, so data fetched inside an Effect does not
+load until the boundary becomes visible.
+
+The data source must integrate with Suspense. For example, the component can read a
+cached Promise with [`use`](/reference/react/use). See
+[what activates a Suspense boundary](/reference/react/Suspense#what-activates-a-suspense-boundary).
 
 </Note>
 
----
+<DeepDive>
 
+#### How does `<Activity>` affect server rendering and hydration? {/*speeding-up-interactions-during-page-load*/}
 
-### Speeding up interactions during page load {/*speeding-up-interactions-during-page-load*/}
+React does not include initially hidden `<Activity>` content in server-rendered HTML.
+On the client, React hydrates the visible content first and renders the hidden
+content later at a lower priority.
 
-React includes an under-the-hood performance optimization called Selective Hydration. It works by hydrating your app's initial HTML _in chunks_, enabling some components to become interactive even if other components on the page haven't loaded their code or data yet.
+For initially visible `<Activity>` boundaries, React includes the content in the
+server-rendered HTML but can hydrate the boundary independently from surrounding
+content. If the user interacts with the boundary before hydration reaches it,
+React prioritizes hydrating that boundary.
 
-Suspense boundaries participate in Selective Hydration, because they naturally divide your component tree into units that are independent from one another:
+An always-visible `<Activity>` boundary lets React hydrate that subtree
+independently:
 
-```jsx
-function Page() {
-  return (
-    <>
-      <MessageComposer />
-
-      <Suspense fallback="Loading chats...">
-        <Chats />
-      </Suspense>
-    </>
-  )
-}
-```
-
-Here, `MessageComposer` can be fully hydrated during the initial render of the page, even before `Chats` is mounted and starts to fetch its data.
-
-So by breaking up your component tree into discrete units, Suspense allows React to hydrate your app's server-rendered HTML in chunks, enabling parts of your app to become interactive as fast as possible.
-
-But what about pages that don't use Suspense?
-
-Take this tabs example:
-
-```jsx
-function Page() {
-  const [activeTab, setActiveTab] = useState('home');
-
-  return (
-    <>
-      <TabButton onClick={() => setActiveTab('home')}>
-        Home
-      </TabButton>
-      <TabButton onClick={() => setActiveTab('video')}>
-        Video
-      </TabButton>
-
-      {activeTab === 'home' && (
-        <Home />
-      )}
-      {activeTab === 'video' && (
-        <Video />
-      )}
-    </>
-  )
-}
-```
-
-Here, React must hydrate the entire page all at once. If `Home` or `Video` are slower to render, they could make the tab buttons feel unresponsive during hydration.
-
-Adding Suspense around the active tab would solve this:
-
-```jsx {13,20}
-function Page() {
-  const [activeTab, setActiveTab] = useState('home');
-
-  return (
-    <>
-      <TabButton onClick={() => setActiveTab('home')}>
-        Home
-      </TabButton>
-      <TabButton onClick={() => setActiveTab('video')}>
-        Video
-      </TabButton>
-
-      <Suspense fallback={<Placeholder />}>
-        {activeTab === 'home' && (
-          <Home />
-        )}
-        {activeTab === 'video' && (
-          <Video />
-        )}
-      </Suspense>
-    </>
-  )
-}
-```
-
-...but it would also change the UI, since the `Placeholder` fallback would be displayed on the initial render.
-
-Instead, we can use Activity. Since Activity boundaries show and hide their children, they already naturally divide the component tree into independent units. And just like Suspense, this feature allows them to participate in Selective Hydration.
-
-Let's update our example to use Activity boundaries around the active tab:
-
-```jsx {13-18}
-function Page() {
-  const [activeTab, setActiveTab] = useState('home');
-
-  return (
-    <>
-      <TabButton onClick={() => setActiveTab('home')}>
-        Home
-      </TabButton>
-      <TabButton onClick={() => setActiveTab('video')}>
-        Video
-      </TabButton>
-
-      <Activity mode={activeTab === "home" ? "visible" : "hidden"}>
-        <Home />
-      </Activity>
-      <Activity mode={activeTab === "video" ? "visible" : "hidden"}>
-        <Video />
-      </Activity>
-    </>
-  )
-}
-```
-
-Now our initial server-rendered HTML looks the same as it did in the original version, but thanks to Activity, React can hydrate the tab buttons first, before it even mounts `Home` or `Video`.
-
----
-
-Thus, in addition to hiding and showing content, Activity boundaries help improve your app's performance during hydration by letting React know which parts of your page can become interactive in isolation.
-
-And even if your page doesn't ever hide part of its content, you can still add always-visible Activity boundaries to improve hydration performance:
-
-```jsx
+```js
 function Page() {
   return (
     <>
       <Post />
-
       <Activity>
         <Comments />
       </Activity>
@@ -896,347 +359,88 @@ function Page() {
 }
 ```
 
+</DeepDive>
+
 ---
 
 ## Troubleshooting {/*troubleshooting*/}
 
 ### My hidden components have unwanted side effects {/*my-hidden-components-have-unwanted-side-effects*/}
 
-An Activity boundary hides its content by setting `display: none` on its children and cleaning up any of their Effects. So, most well-behaved React components that properly clean up their side effects will already be robust to being hidden by Activity.
+`<Activity>` hides DOM nodes without removing them. Browser-managed behavior from
+elements such as `<video>`, `<audio>`, and `<iframe>` can therefore continue while
+the boundary is hidden.
 
-But there _are_ some situations where a hidden component behaves differently than an unmounted one. Most notably, since a hidden component's DOM is not destroyed, any side effects from that DOM will persist, even after the component is hidden.
+<Pitfall>
 
-As an example, consider a `<video>` tag. Typically it doesn't require any cleanup, because even if you're playing a video, unmounting the tag stops the video and audio from playing in the browser. Try playing the video and then pressing Home in this demo:
+##### Preserved media can continue playing {/*preserved-media-can-continue-playing*/}
 
-<Sandpack>
+Add the corresponding cleanup to an Effect. For behavior that must stop when React
+hides the boundary, use [`useLayoutEffect`](/reference/react/useLayoutEffect):
 
-```js src/App.js active
-import { useState } from 'react';
-import TabButton from './TabButton.js';
-import Home from './Home.js';
-import Video from './Video.js';
+```js
+import { useLayoutEffect, useRef } from 'react';
 
-export default function App() {
-  const [activeTab, setActiveTab] = useState('video');
-
-  return (
-    <>
-      <TabButton
-        isActive={activeTab === 'home'}
-        onClick={() => setActiveTab('home')}
-      >
-        Home
-      </TabButton>
-      <TabButton
-        isActive={activeTab === 'video'}
-        onClick={() => setActiveTab('video')}
-      >
-        Video
-      </TabButton>
-
-      <hr />
-
-      {activeTab === 'home' && <Home />}
-      {activeTab === 'video' && <Video />}
-    </>
-  );
-}
-```
-
-```js src/TabButton.js hidden
-export default function TabButton({ onClick, children, isActive }) {
-  if (isActive) {
-    return <b>{children}</b>
-  }
-
-  return (
-    <button onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-```
-
-```js src/Home.js
-export default function Home() {
-  return (
-    <p>Welcome to my profile!</p>
-  );
-}
-```
-
-```js src/Video.js
-export default function Video() {
-  return (
-    <video
-      // 'Big Buck Bunny' licensed under CC 3.0 by the Blender foundation. Hosted by archive.org
-      src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
-      controls
-      playsInline
-    />
-
-  );
-}
-```
-
-```css
-body { height: 275px; }
-button { margin-right: 10px }
-b { display: inline-block; margin-right: 10px; }
-.pending { color: #777; }
-video { width: 300px; margin-top: 10px; aspect-ratio: 16/9; }
-```
-
-</Sandpack>
-
-The video stops playing as expected.
-
-Now, let's say we wanted to preserve the timecode where the user last watched, so that when they tab back to the video, it doesn't start over from the beginning again.
-
-This is a great use case for Activity!
-
-Let's update `App` to hide the inactive tab with a hidden Activity boundary instead of unmounting it, and see how the demo behaves this time:
-
-<Sandpack>
-
-```js src/App.js active
-import { Activity, useState } from 'react';
-import TabButton from './TabButton.js';
-import Home from './Home.js';
-import Video from './Video.js';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('video');
-
-  return (
-    <>
-      <TabButton
-        isActive={activeTab === 'home'}
-        onClick={() => setActiveTab('home')}
-      >
-        Home
-      </TabButton>
-      <TabButton
-        isActive={activeTab === 'video'}
-        onClick={() => setActiveTab('video')}
-      >
-        Video
-      </TabButton>
-
-      <hr />
-
-      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
-        <Home />
-      </Activity>
-      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
-        <Video />
-      </Activity>
-    </>
-  );
-}
-```
-
-```js src/TabButton.js hidden
-export default function TabButton({ onClick, children, isActive }) {
-  if (isActive) {
-    return <b>{children}</b>
-  }
-
-  return (
-    <button onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-```
-
-```js src/Home.js
-export default function Home() {
-  return (
-    <p>Welcome to my profile!</p>
-  );
-}
-```
-
-```js src/Video.js
-export default function Video() {
-  return (
-    <video
-      controls
-      playsInline
-      // 'Big Buck Bunny' licensed under CC 3.0 by the Blender foundation. Hosted by archive.org
-      src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
-    />
-
-  );
-}
-```
-
-```css
-body { height: 275px; }
-button { margin-right: 10px }
-b { display: inline-block; margin-right: 10px; }
-.pending { color: #777; }
-video { width: 300px; margin-top: 10px; aspect-ratio: 16/9; }
-```
-
-</Sandpack>
-
-Whoops! The video and audio continue to play even after it's been hidden, because the tab's `<video>` element is still in the DOM.
-
-To fix this, we can add an Effect with a cleanup function that pauses the video:
-
-```jsx {2,4-10,14}
-export default function VideoTab() {
-  const ref = useRef();
+function VideoPlayer({ src, captions }) {
+  const ref = useRef(null);
 
   useLayoutEffect(() => {
-    const videoRef = ref.current;
+    const video = ref.current;
 
     return () => {
-      videoRef.pause()
-    }
+      video.pause();
+    };
   }, []);
 
   return (
-    <video
-      ref={ref}
-      controls
-      playsInline
-      src="..."
-    />
-
+    <video ref={ref} controls src={src}>
+      <track
+        default
+        kind='captions'
+        src={captions}
+        srcLang='en'
+      />
+    </video>
   );
 }
 ```
 
-We call `useLayoutEffect` instead of `useEffect` because conceptually the clean-up code is tied to the component's UI being visually hidden. If we used a regular effect, the code could be delayed by (say) a re-suspending Suspense boundary or a View Transition.
+React runs the cleanup when an enclosing Activity boundary becomes hidden. Because
+the `<video>` node remains in the DOM, its playback position is preserved for when
+the boundary becomes visible again.
 
-Let's see the new behavior. Try playing the video, switching to the Home tab, then back to the Video tab:
+The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from
+`useEffect` can run later if, for example, a Suspense boundary suspends or a View
+Transition is in progress.
 
-<Sandpack>
-
-```js src/App.js active
-import { Activity, useState } from 'react';
-import TabButton from './TabButton.js';
-import Home from './Home.js';
-import Video from './Video.js';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('video');
-
-  return (
-    <>
-      <TabButton
-        isActive={activeTab === 'home'}
-        onClick={() => setActiveTab('home')}
-      >
-        Home
-      </TabButton>
-      <TabButton
-        isActive={activeTab === 'video'}
-        onClick={() => setActiveTab('video')}
-      >
-        Video
-      </TabButton>
-
-      <hr />
-
-      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
-        <Home />
-      </Activity>
-      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
-        <Video />
-      </Activity>
-    </>
-  );
-}
-```
-
-```js src/TabButton.js hidden
-export default function TabButton({ onClick, children, isActive }) {
-  if (isActive) {
-    return <b>{children}</b>
-  }
-
-  return (
-    <button onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-```
-
-```js src/Home.js
-export default function Home() {
-  return (
-    <p>Welcome to my profile!</p>
-  );
-}
-```
-
-```js src/Video.js
-import { useRef, useLayoutEffect } from 'react';
-
-export default function Video() {
-  const ref = useRef();
-
-  useLayoutEffect(() => {
-    const videoRef = ref.current
-
-    return () => {
-      videoRef.pause()
-    };
-  }, [])
-
-  return (
-    <video
-      ref={ref}
-      controls
-      playsInline
-      // 'Big Buck Bunny' licensed under CC 3.0 by the Blender foundation. Hosted by archive.org
-      src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
-    />
-
-  );
-}
-```
-
-```css
-body { height: 275px; }
-button { margin-right: 10px }
-b { display: inline-block; margin-right: 10px; }
-.pending { color: #777; }
-video { width: 300px; margin-top: 10px; aspect-ratio: 16/9; }
-```
-
-</Sandpack>
-
-It works great! Our cleanup function ensures that the video stops playing if it's ever hidden by an Activity boundary, and even better, because the `<video>` tag is never destroyed, the timecode is preserved, and the video itself doesn't need to be initialized or downloaded again when the user switches back to keep watching it.
-
-This is a great example of using Activity to preserve ephemeral DOM state for parts of the UI that become hidden, but the user is likely to interact with again soon.
+</Pitfall>
 
 ---
 
-Our example illustrates that for certain tags like `<video>`, unmounting and hiding have different behavior. If a component renders DOM that has a side effect, and you want to prevent that side effect when an Activity boundary hides it, add an Effect with a return function to clean it up.
+### My hidden components have Effects that are not running {/*my-hidden-components-have-effects-that-arent-running*/}
 
-The most common cases of this will be from the following tags:
+React runs cleanup functions for Effects created with `useEffect` and
+`useLayoutEffect` when an Activity boundary becomes hidden. It runs their setup
+functions again when the boundary becomes visible.
 
-  - `<video>`
-  - `<audio>`
-  - `<iframe>`
+An Effect inside a hidden Activity boundary cannot remain active. Move ongoing
+work that must continue while the UI is hidden to a component outside the boundary,
+or keep the boundary visible.
 
-Typically, though, most of your React components should already be robust to being hidden by an Activity boundary. And conceptually, you should think of "hidden" Activities as being unmounted.
+If an Effect controls an external system, return a cleanup function so hiding the
+boundary disconnects from that system:
 
-To eagerly discover other Effects that don't have proper cleanup, which is important not only for Activity boundaries but for many other behaviors in React, we recommend using [`<StrictMode>`](/reference/react/StrictMode).
+```js
+useEffect(() => {
+  const connection = createConnection();
+  connection.connect();
 
----
+  return () => {
+    connection.disconnect();
+  };
+}, []);
+```
 
-
-### My hidden components have Effects that aren't running {/*my-hidden-components-have-effects-that-arent-running*/}
-
-When an `<Activity>` is "hidden", all its children's Effects are cleaned up. Conceptually, the children are unmounted, but React saves their state for later. This is a feature of Activity because it means subscriptions won't be active for hidden parts of the UI, reducing the amount of work needed for hidden content.
-
-If you're relying on an Effect mounting to clean up a component's side effects, refactor the Effect to do the work in the returned cleanup function instead.
-
-To eagerly find problematic Effects, we recommend adding [`<StrictMode>`](/reference/react/StrictMode) which will eagerly perform Activity unmounts and mounts to catch any unexpected side-effects.
+Use [`<StrictMode>`](/reference/react/StrictMode) to find Effects that do not clean
+up correctly. Strict Mode performs an additional setup and cleanup cycle in
+development.

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -183,13 +183,7 @@ Changing `mode` preserves the state of the children. Removing the boundary or ch
 
 Because Activity boundaries hide their children without removing them, the children's DOM is also preserved. This is useful for maintaining state held by the browser in DOM nodes.
 
-The Contact tab in the following examples contains an uncontrolled `<textarea>`. Enter a draft, switch to the Home tab, and then return to Contact to compare the behavior with and without Activity.
-
-<Recipes titleText="The difference between removing and hiding a form" titleId="examples-preserving-dom-state">
-
-#### Removing the form resets its state {/*removing-the-form-resets-its-state*/}
-
-This version conditionally renders the active tab. Switching to Home removes `<Contact>` and its `<textarea>` from the DOM, so the draft is lost.
+The Contact tab in the following example contains an uncontrolled `<textarea>`. Enter a draft, switch to the Home tab, and then return to Contact. The draft is lost because conditional rendering removes `<Contact>` and its `<textarea>` from the DOM.
 
 <Sandpack>
 
@@ -265,11 +259,7 @@ b {
 
 </Sandpack>
 
-<Solution />
-
-#### Hiding the form preserves its state {/*hiding-the-form-preserves-its-state*/}
-
-This version renders both tabs in Activity boundaries. Switching tabs hides `<Contact>` without removing its DOM nodes, so the draft remains available when the tab becomes visible again.
+To preserve the draft, render both tabs inside Activity boundaries and change their modes. Enter a draft, switch to Home, and then return to Contact. The draft remains because Activity hides `<Contact>` without removing its DOM nodes.
 
 <Sandpack>
 
@@ -348,10 +338,6 @@ b {
 ```
 
 </Sandpack>
-
-<Solution />
-
-</Recipes>
 
 Activity also preserves other browser-managed state, such as scroll position and media playback position. The following examples use the same video player to compare removing and hiding a `<video>` element. Play the video, hide it, show it again, and then select **Play**.
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -341,7 +341,7 @@ b {
 
 Activity also preserves other browser-managed state, such as scroll position and media playback position. The following examples use the same video player to compare removing and hiding a `<video>` element. Play the video, switch to the Home tab, return to the Video tab, and then select **Play**.
 
-<Recipes titleText="The difference between removing and hiding a video" titleId="examples-preserving-media-state">
+<Recipes titleText="The difference between removing and hiding content" titleId="examples-preserving-media-state">
 
 #### Removing the video resets its playback position {/*removing-the-video-resets-its-playback-position*/}
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -179,45 +179,175 @@ Changing `mode` preserves the state of the children. Removing the boundary or ch
 
 An Activity boundary also preserves state held by the browser in DOM nodes.
 
-For example, enter a draft in the contact form, hide it, and then show it again. The `<textarea>` value remains because its DOM node was hidden rather than removed.
+The Contact tab in the following examples contains an uncontrolled `<textarea>`. Enter a draft, switch to the Home tab, and then return to Contact to compare the behavior with and without Activity.
+
+<Recipes titleText="The difference between removing and hiding a form" titleId="examples-preserving-dom-state">
+
+#### Removing the form resets its state {/*removing-the-form-resets-its-state*/}
+
+This version conditionally renders the active tab. Switching to Home removes `<Contact>` and its `<textarea>` from the DOM, so the draft is lost.
 
 <Sandpack>
 
-```js
-import { Activity, useState } from 'react';
+```js src/App.js active
+import { useState } from 'react';
+import Contact from './Contact.js';
+import Home from './Home.js';
+import TabButton from './TabButton.js';
 
 export default function App() {
-  const [isShowingContact, setIsShowingContact] = useState(true);
+  const [activeTab, setActiveTab] = useState('contact');
 
   return (
     <>
-      <button onClick={() => setIsShowingContact(showing => !showing)}>
-        {isShowingContact ? 'Hide' : 'Show'} contact form
-      </button>
-      <Activity mode={isShowingContact ? 'visible' : 'hidden'}>
-        <p>
-          <label htmlFor="message">Message</label>
-          <textarea id="message" />
-        </p>
+      <TabButton
+        isActive={activeTab === 'home'}
+        onClick={() => setActiveTab('home')}
+      >
+        Home
+      </TabButton>
+      <TabButton
+        isActive={activeTab === 'contact'}
+        onClick={() => setActiveTab('contact')}
+      >
+        Contact
+      </TabButton>
+      <hr />
+      {activeTab === 'home' && <Home />}
+      {activeTab === 'contact' && <Contact />}
+    </>
+  );
+}
+```
+
+```js src/TabButton.js hidden
+export default function TabButton({ isActive, onClick, children }) {
+  if (isActive) {
+    return <b>{children}</b>;
+  }
+
+  return <button onClick={onClick}>{children}</button>;
+}
+```
+
+```js src/Home.js hidden
+export default function Home() {
+  return <p>Welcome to my profile!</p>;
+}
+```
+
+```js src/Contact.js hidden
+export default function Contact() {
+  return (
+    <div>
+      <p>Send me a message!</p>
+      <textarea aria-label="Message" />
+      <p>You can find me online here:</p>
+      <ul>
+        <li>admin@mysite.com</li>
+        <li>+123456789</li>
+      </ul>
+    </div>
+  );
+}
+```
+
+```css
+button,
+b {
+  margin-right: 10px;
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+#### Hiding the form preserves its state {/*hiding-the-form-preserves-its-state*/}
+
+This version renders both tabs in Activity boundaries. Switching tabs hides `<Contact>` without removing its DOM nodes, so the draft remains available when the tab becomes visible again.
+
+<Sandpack>
+
+```js src/App.js active
+import { Activity, useState } from 'react';
+import Contact from './Contact.js';
+import Home from './Home.js';
+import TabButton from './TabButton.js';
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('contact');
+
+  return (
+    <>
+      <TabButton
+        isActive={activeTab === 'home'}
+        onClick={() => setActiveTab('home')}
+      >
+        Home
+      </TabButton>
+      <TabButton
+        isActive={activeTab === 'contact'}
+        onClick={() => setActiveTab('contact')}
+      >
+        Contact
+      </TabButton>
+      <hr />
+      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
+        <Home />
+      </Activity>
+      <Activity mode={activeTab === 'contact' ? 'visible' : 'hidden'}>
+        <Contact />
       </Activity>
     </>
   );
 }
 ```
 
-```css
-label,
-textarea {
-  display: block;
+```js src/TabButton.js hidden
+export default function TabButton({ isActive, onClick, children }) {
+  if (isActive) {
+    return <b>{children}</b>;
+  }
+
+  return <button onClick={onClick}>{children}</button>;
 }
-textarea {
-  margin-top: 4px;
+```
+
+```js src/Home.js hidden
+export default function Home() {
+  return <p>Welcome to my profile!</p>;
+}
+```
+
+```js src/Contact.js hidden
+export default function Contact() {
+  return (
+    <div>
+      <p>Send me a message!</p>
+      <textarea aria-label="Message" />
+      <p>You can find me online here:</p>
+      <ul>
+        <li>admin@mysite.com</li>
+        <li>+123456789</li>
+      </ul>
+    </div>
+  );
+}
+```
+
+```css
+button,
+b {
+  margin-right: 10px;
 }
 ```
 
 </Sandpack>
 
-The current value of an uncontrolled field belongs to its DOM node rather than React state. Activity preserves the node, so the value remains available when the boundary becomes visible again.
+<Solution />
+
+</Recipes>
 
 Activity also preserves other browser-managed state, such as scroll position and media playback position. In this example, play the video, hide it, and then show it again. When you play it again, the video continues from the same position.
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -92,6 +92,18 @@ boundary remains mounted.
 
 ## Usage {/*usage*/}
 
+Activity is useful when part of the UI may become hidden and visible again. Unlike
+conditional rendering, hiding an Activity boundary preserves both React state and
+the DOM state of its children. Unlike hiding content only with CSS, Activity also
+cleans up the children's Effects and deprioritizes their updates while they are
+hidden.
+
+Use an Activity boundary when preserving that work is valuable—for example, for a
+tab the user is likely to revisit or a panel that can prepare data in the
+background. If the content is unlikely to become visible again, conditionally
+rendering it may be preferable because unmounting allows React and the browser to
+release its resources.
+
 ### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
 When this condition becomes false, React removes `<Sidebar>` from the tree and
@@ -302,9 +314,10 @@ for DOM behavior that requires explicit cleanup.
 
 ### Pre-rendering content that is likely to become visible {/*pre-rendering-content-thats-likely-to-become-visible*/}
 
-Content inside a hidden Activity boundary renders at a lower priority without
-running Effects created with `useEffect` or `useLayoutEffect`. This allows the
-content to begin loading code and render-time data before it becomes visible:
+An Activity boundary can also prepare content before the user sees it. Content
+inside a hidden boundary renders at a lower priority without running Effects
+created with `useEffect` or `useLayoutEffect`. This lets the content load code and
+render-time data without delaying updates to visible content:
 
 ```js
 <Suspense fallback={<Loading />}>
@@ -318,6 +331,103 @@ If `Posts` suspends while reading code or data, React continues rendering the re
 of the page. If that hidden work completes, switching to the Posts tab can reveal
 the content without waiting for the same work again.
 
+The following example renders the Posts tab in a hidden Activity boundary when the
+page first loads. Wait briefly before selecting **Posts**. The list is available
+immediately because the hidden render started loading it in the background.
+
+<Sandpack>
+
+```js src/App.js active
+import { Activity, Suspense, use, useState } from 'react';
+import { getPosts } from './data.js';
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('home');
+
+  return (
+    <>
+      <div aria-label='Profile sections' role='group'>
+        <button
+          aria-pressed={activeTab === 'home'}
+          onClick={() => setActiveTab('home')}
+        >
+          Home
+        </button>
+        <button
+          aria-pressed={activeTab === 'posts'}
+          onClick={() => setActiveTab('posts')}
+        >
+          Posts
+        </button>
+      </div>
+
+      <Suspense fallback={<h1>Loading posts...</h1>}>
+        <Activity
+          mode={activeTab === 'home' ? 'visible' : 'hidden'}
+        >
+          <Home />
+        </Activity>
+        <Activity
+          mode={activeTab === 'posts' ? 'visible' : 'hidden'}
+        >
+          <Posts />
+        </Activity>
+      </Suspense>
+    </>
+  );
+}
+
+function Home() {
+  return <p>Welcome to my profile!</p>;
+}
+
+function Posts() {
+  const posts = use(getPosts());
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```js src/data.js hidden
+let postsPromise;
+
+export function getPosts() {
+  if (!postsPromise) {
+    postsPromise = loadPosts();
+  }
+  return postsPromise;
+}
+
+async function loadPosts() {
+  // Add a delay so that pre-rendering is easier to observe.
+  await new Promise(resolve => setTimeout(resolve, 1500));
+
+  return Array.from({ length: 5 }, (_, index) => ({
+    id: index,
+    title: 'Post #' + (index + 1),
+  }));
+}
+```
+
+```css
+button {
+  margin-right: 8px;
+}
+```
+
+</Sandpack>
+
+If the user selects Posts before the hidden render finishes, the nearest Suspense
+fallback appears until the data is ready. Activity improves the likely case where
+the background work finishes first; it does not guarantee that the content will
+always be ready.
+
 <Note>
 
 Only code and data read during rendering can load during pre-rendering. Activity
@@ -330,21 +440,30 @@ cached Promise with [`use`](/reference/react/use). See
 
 </Note>
 
-<DeepDive>
+---
 
-#### How does `<Activity>` affect server rendering and hydration? {/*speeding-up-interactions-during-page-load*/}
+### Improving hydration performance {/*speeding-up-interactions-during-page-load*/}
 
-React does not include initially hidden `<Activity>` content in server-rendered HTML.
-On the client, React hydrates the visible content first and renders the hidden
-content later at a lower priority.
+Activity boundaries also divide server-rendered pages into units that React can
+hydrate independently. This is related to the selective hydration behavior of
+[`<Suspense>`](/reference/react/Suspense), but it does not require displaying a
+fallback in the initial UI.
 
-For initially visible `<Activity>` boundaries, React includes the content in the
-server-rendered HTML but can hydrate the boundary independently from surrounding
-content. If the user interacts with the boundary before hydration reaches it,
-React prioritizes hydrating that boundary.
+For example, without a boundary React hydrates this page as one unit:
 
-An always-visible `<Activity>` boundary lets React hydrate that subtree
-independently:
+```js
+function Page() {
+  return (
+    <>
+      <Post />
+      <Comments />
+    </>
+  );
+}
+```
+
+Wrapping `Comments` in an always-visible Activity boundary creates a separate
+hydration unit:
 
 ```js
 function Page() {
@@ -359,7 +478,43 @@ function Page() {
 }
 ```
 
-</DeepDive>
+The boundary is visible because the `mode` prop defaults to `'visible'`. Its
+server-rendered HTML remains visible, but React can hydrate it independently from
+the surrounding page. If the user interacts with that content before React reaches
+it, React prioritizes hydrating the boundary.
+
+You can also use visible and hidden Activity boundaries for tabbed content:
+
+```js
+function Page() {
+  const [activeTab, setActiveTab] = useState('home');
+
+  return (
+    <>
+      <button onClick={() => setActiveTab('home')}>
+        Home
+      </button>
+      <button onClick={() => setActiveTab('video')}>
+        Video
+      </button>
+
+      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
+        <Home />
+      </Activity>
+      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
+        <Video />
+      </Activity>
+    </>
+  );
+}
+```
+
+React does not include initially hidden `<Activity>` content in server-rendered HTML.
+On the client, React hydrates the visible content first and renders the hidden
+content later at a lower priority. Initially visible boundaries are included in the
+server-rendered HTML and can be hydrated independently. This allows the visible tab
+and the controls around it to become interactive without waiting for React to
+render the initially hidden tab.
 
 ---
 
@@ -375,13 +530,85 @@ the boundary is hidden.
 
 ##### Preserved media can continue playing {/*preserved-media-can-continue-playing*/}
 
-Add the corresponding cleanup to an Effect. For behavior that must stop when React
-hides the boundary, use [`useLayoutEffect`](/reference/react/useLayoutEffect):
+Unmounting a `<video>` element stops playback because the browser removes the DOM
+node. Hiding it with Activity preserves the node, so playback continues unless the
+component pauses it explicitly.
+
+Add the corresponding cleanup to an Effect. For behavior that must stop at the
+same time React hides the boundary, use
+[`useLayoutEffect`](/reference/react/useLayoutEffect):
 
 ```js
 import { useLayoutEffect, useRef } from 'react';
 
-function VideoPlayer({ src, captions }) {
+function VideoPlayer({ src }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const video = ref.current;
+
+    return () => {
+      video.pause();
+    };
+  }, []);
+
+  return <video ref={ref} controls src={src} />;
+}
+```
+
+React runs the cleanup when an enclosing Activity boundary becomes hidden. Because
+the `<video>` node remains in the DOM, its playback position is preserved for when
+the boundary becomes visible again.
+
+The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from
+`useEffect` can run later if, for example, a Suspense boundary suspends or a View
+Transition is in progress.
+
+This complete example pauses the video when you switch to Home while preserving
+its playback position. When you return to Video, playback can continue from the
+same position without recreating the element or downloading it again.
+
+<Sandpack>
+
+```js src/App.js active
+import {
+  Activity,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('video');
+
+  return (
+    <>
+      <div aria-label='Media sections' role='group'>
+        <button
+          aria-pressed={activeTab === 'home'}
+          onClick={() => setActiveTab('home')}
+        >
+          Home
+        </button>
+        <button
+          aria-pressed={activeTab === 'video'}
+          onClick={() => setActiveTab('video')}
+        >
+          Video
+        </button>
+      </div>
+
+      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
+        <p>Welcome home!</p>
+      </Activity>
+      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
+        <VideoPlayer />
+      </Activity>
+    </>
+  );
+}
+
+function VideoPlayer() {
   const ref = useRef(null);
 
   useLayoutEffect(() => {
@@ -393,25 +620,30 @@ function VideoPlayer({ src, captions }) {
   }, []);
 
   return (
-    <video ref={ref} controls src={src}>
-      <track
-        default
-        kind='captions'
-        src={captions}
-        srcLang='en'
-      />
-    </video>
+    <video
+      aria-label='Big Buck Bunny video'
+      controls
+      playsInline
+      ref={ref}
+      src='https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4'
+    />
   );
 }
 ```
 
-React runs the cleanup when an enclosing Activity boundary becomes hidden. Because
-the `<video>` node remains in the DOM, its playback position is preserved for when
-the boundary becomes visible again.
+```css
+button {
+  margin-right: 8px;
+}
+video {
+  aspect-ratio: 16 / 9;
+  margin-top: 12px;
+  max-width: 100%;
+  width: 400px;
+}
+```
 
-The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from
-`useEffect` can run later if, for example, a Suspense boundary suspends or a View
-Transition is in progress.
+</Sandpack>
 
 </Pitfall>
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -55,7 +55,7 @@ Insertion Effects created with [`useInsertionEffect`](/reference/react/useInsert
 
 #### Caveats {/*caveats*/}
 
-- Browser behavior associated with preserved DOM nodes can continue while the boundary is hidden. For example, audio and video can continue playing. Use an Effect cleanup function to stop this behavior. [See an example below.](#my-hidden-components-have-unwanted-side-effects)
+- Browser behavior associated with preserved DOM nodes can continue while the boundary is hidden. For example, audio and video can continue playing. Use an Effect cleanup function to stop this behavior. [See an example below.](#my-hidden-component-keeps-playing-audio-or-video)
 - React omits text-only output while an Activity boundary is hidden because a text node cannot receive `display: none`. The text appears when the boundary becomes visible.
 - If an Activity boundary is inside [`<ViewTransition>`](/reference/react/ViewTransition), changing it from hidden to visible as part of an update started with [`startTransition`](/reference/react/startTransition) activates the `enter` animation. Changing it from visible to hidden as part of that update activates the `exit` animation.
 
@@ -65,11 +65,11 @@ Insertion Effects created with [`useInsertionEffect`](/reference/react/useInsert
 
 Activity is useful when part of the UI may become hidden and visible again. Unlike conditional rendering, hiding an Activity boundary preserves both React state and the DOM state of its children. Unlike hiding content only with CSS, Activity also cleans up the children's Effects and deprioritizes their updates while they are hidden.
 
-Use an Activity boundary when preserving that work is valuable—for example, for a tab the user is likely to revisit or a panel that can prepare data in the background. A hidden boundary retains its state and DOM nodes, so it continues using memory. If the content is unlikely to become visible again, conditionally rendering it may be preferable because unmounting allows React and the browser to release its resources.
+Use an Activity boundary when hidden content is likely to become visible again, such as a tab the user may revisit or a panel that can prepare data in the background. A hidden boundary retains its state and DOM nodes, so it continues using memory. If the content is unlikely to become visible again, conditionally rendering it may be preferable because unmounting allows React and the browser to release its resources.
 
-### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
+### Preserving component state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
-When this condition becomes false, React removes `<Sidebar>` from the tree and discards its state:
+With conditional rendering, React removes `<Sidebar>` from the tree when `isShowingSidebar` becomes `false` and discards its state:
 
 ```js
 {isShowingSidebar && <Sidebar />}
@@ -87,25 +87,24 @@ In this example, expand the sidebar, hide it, and show it again. The expanded st
 
 <Sandpack>
 
-```js
+```js src/App.js active
 import { Activity, useState } from 'react';
+import Sidebar from './Sidebar.js';
 
 export default function App() {
   const [isShowingSidebar, setIsShowingSidebar] = useState(true);
 
   return (
-    <div className='layout'>
-      <Activity
-        mode={isShowingSidebar ? 'visible' : 'hidden'}
-      >
+    <div className="layout">
+      <Activity mode={isShowingSidebar ? 'visible' : 'hidden'}>
         <Sidebar />
       </Activity>
 
       <main>
         <button
-          aria-controls='documentation-sidebar'
+          aria-controls="documentation-sidebar"
           aria-expanded={isShowingSidebar}
-          onClick={() => setIsShowingSidebar(s => !s)}
+          onClick={() => setIsShowingSidebar(showing => !showing)}
         >
           {isShowingSidebar ? 'Hide' : 'Show'} sidebar
         </button>
@@ -114,28 +113,29 @@ export default function App() {
     </div>
   );
 }
+```
 
-function Sidebar() {
+```js src/Sidebar.js hidden
+import { useState } from 'react';
+
+export default function Sidebar() {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <nav
-      aria-label='Documentation'
-      id='documentation-sidebar'
-    >
+    <nav aria-label="Documentation" id="documentation-sidebar">
       <button
-        aria-controls='overview-sections'
+        aria-controls="overview-sections"
         aria-expanded={isExpanded}
-        onClick={() => setIsExpanded(e => !e)}
+        onClick={() => setIsExpanded(expanded => !expanded)}
       >
         Overview
-        <span aria-hidden='true' className='indicator'>
+        <span aria-hidden="true" className="indicator">
           {isExpanded ? '−' : '+'}
         </span>
       </button>
 
       {isExpanded && (
-        <ul id='overview-sections'>
+        <ul id="overview-sections">
           <li>Section 1</li>
           <li>Section 2</li>
           <li>Section 3</li>
@@ -161,6 +161,9 @@ nav {
 main {
   padding: 12px;
 }
+main h1 {
+  margin-top: 12px;
+}
 .indicator {
   margin-left: 6px;
 }
@@ -174,9 +177,9 @@ Changing `mode` preserves the state of the children. Removing the boundary or ch
 
 ### Preserving DOM state while content is hidden {/*restoring-the-dom-of-hidden-components*/}
 
-An Activity boundary also preserves state held by the browser in DOM nodes. This includes an uncontrolled input's current value, scroll position, and media playback position.
+An Activity boundary also preserves state held by the browser in DOM nodes.
 
-In this example, enter a draft in the Contact section, switch sections, and then return to Contact. The `<textarea>` value remains because its DOM node was hidden rather than removed.
+For example, enter a draft in the contact form, hide it, and then show it again. The `<textarea>` value remains because its DOM node was hidden rather than removed.
 
 <Sandpack>
 
@@ -184,71 +187,25 @@ In this example, enter a draft in the Contact section, switch sections, and then
 import { Activity, useState } from 'react';
 
 export default function App() {
-  const [activeSection, setActiveSection] = useState('contact');
+  const [isShowingContact, setIsShowingContact] = useState(true);
 
   return (
     <>
-      <div
-        aria-label='Profile sections'
-        className='section-buttons'
-        role='group'
-      >
-        <SectionButton
-          isActive={activeSection === 'home'}
-          onClick={() => setActiveSection('home')}
-        >
-          Home
-        </SectionButton>
-        <SectionButton
-          isActive={activeSection === 'contact'}
-          onClick={() => setActiveSection('contact')}
-        >
-          Contact
-        </SectionButton>
-      </div>
-
-      <Activity
-        mode={activeSection === 'home' ? 'visible' : 'hidden'}
-      >
-        <Home />
-      </Activity>
-      <Activity
-        mode={activeSection === 'contact' ? 'visible' : 'hidden'}
-      >
-        <Contact />
+      <button onClick={() => setIsShowingContact(showing => !showing)}>
+        {isShowingContact ? 'Hide' : 'Show'} contact form
+      </button>
+      <Activity mode={isShowingContact ? 'visible' : 'hidden'}>
+        <p>
+          <label htmlFor="message">Message</label>
+          <textarea id="message" />
+        </p>
       </Activity>
     </>
-  );
-}
-
-function SectionButton({ isActive, onClick, children }) {
-  return (
-    <button aria-pressed={isActive} onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-
-function Home() {
-  return <p>Welcome to my profile!</p>;
-}
-
-function Contact() {
-  return (
-    <p>
-      <label htmlFor='message'>Message</label>
-      <textarea id='message' />
-    </p>
   );
 }
 ```
 
 ```css
-.section-buttons {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 12px;
-}
 label,
 textarea {
   display: block;
@@ -260,7 +217,74 @@ textarea {
 
 </Sandpack>
 
-Preserving DOM state also means that DOM behavior can continue while content is hidden. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects) for DOM behavior that requires explicit cleanup.
+The current value of an uncontrolled field belongs to its DOM node rather than React state. Activity preserves the node, so the value remains available when the boundary becomes visible again.
+
+Activity also preserves other browser-managed state, such as scroll position and media playback position. In this example, play the video, hide it, and then show it again. When you play it again, the video continues from the same position.
+
+<Sandpack>
+
+```js src/App.js active
+import { Activity, useState } from 'react';
+import VideoPlayer from './VideoPlayer.js';
+
+export default function App() {
+  const [isShowingVideo, setIsShowingVideo] = useState(true);
+
+  return (
+    <>
+      <button onClick={() => setIsShowingVideo(showing => !showing)}>
+        {isShowingVideo ? 'Hide' : 'Show'} video
+      </button>
+      <Activity mode={isShowingVideo ? 'visible' : 'hidden'}>
+        <VideoPlayer />
+      </Activity>
+    </>
+  );
+}
+```
+
+```js src/VideoPlayer.js hidden
+import { useLayoutEffect, useRef } from 'react';
+
+export default function VideoPlayer() {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const video = ref.current;
+    return () => video.pause();
+  }, []);
+
+  return (
+    <div className="video-player">
+      <button onClick={() => ref.current.play()}>Play</button>
+      <button onClick={() => ref.current.pause()}>Pause</button>
+      <video ref={ref} width="250">
+        <source
+          src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+          type="video/mp4"
+        />
+      </video>
+    </div>
+  );
+}
+```
+
+```css
+.video-player {
+  margin-top: 10px;
+}
+.video-player button {
+  margin-right: 10px;
+}
+.video-player video {
+  display: block;
+  margin-top: 10px;
+}
+```
+
+</Sandpack>
+
+The ref provides access to the `<video>` DOM node; it does not store the playback position. The `useLayoutEffect` cleanup pauses the video when the boundary becomes hidden. Activity preserves the DOM node and its playback position, but React detaches the ref while the boundary is hidden and reconnects it when the boundary becomes visible. See [Troubleshooting](#my-hidden-component-keeps-playing-audio-or-video) for more about cleaning up browser-managed behavior.
 
 ---
 
@@ -276,99 +300,7 @@ An Activity boundary can also prepare content before the user sees it. Content i
 </Suspense>
 ```
 
-If `Posts` suspends while reading code or data, React continues rendering the rest of the page. If that hidden work completes, switching to the Posts tab can reveal the content without waiting for the same work again.
-
-The following example renders the Posts tab in a hidden Activity boundary when the page first loads. Wait briefly before selecting **Posts**. The list is available immediately because the hidden render started loading it in the background.
-
-<Sandpack>
-
-```js src/App.js active
-import { Activity, Suspense, use, useState } from 'react';
-import { getPosts } from './data.js';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('home');
-
-  return (
-    <>
-      <div aria-label='Profile sections' role='group'>
-        <button
-          aria-pressed={activeTab === 'home'}
-          onClick={() => setActiveTab('home')}
-        >
-          Home
-        </button>
-        <button
-          aria-pressed={activeTab === 'posts'}
-          onClick={() => setActiveTab('posts')}
-        >
-          Posts
-        </button>
-      </div>
-
-      <Suspense fallback={<h1>Loading posts...</h1>}>
-        <Activity
-          mode={activeTab === 'home' ? 'visible' : 'hidden'}
-        >
-          <Home />
-        </Activity>
-        <Activity
-          mode={activeTab === 'posts' ? 'visible' : 'hidden'}
-        >
-          <Posts />
-        </Activity>
-      </Suspense>
-    </>
-  );
-}
-
-function Home() {
-  return <p>Welcome to my profile!</p>;
-}
-
-function Posts() {
-  const posts = use(getPosts());
-
-  return (
-    <ul>
-      {posts.map(post => (
-        <li key={post.id}>{post.title}</li>
-      ))}
-    </ul>
-  );
-}
-```
-
-```js src/data.js hidden
-let postsPromise;
-
-export function getPosts() {
-  if (!postsPromise) {
-    postsPromise = loadPosts();
-  }
-  return postsPromise;
-}
-
-async function loadPosts() {
-  // Add a delay so that pre-rendering is easier to observe.
-  await new Promise(resolve => setTimeout(resolve, 1500));
-
-  return Array.from({ length: 5 }, (_, index) => ({
-    id: index,
-    title: 'Post #' + (index + 1),
-  }));
-}
-```
-
-```css
-button {
-  margin-right: 8px;
-}
-```
-
-</Sandpack>
-
-If the user selects Posts before the hidden render finishes, the nearest Suspense fallback appears until the data is ready. Activity improves the likely case where the background work finishes first; it does not guarantee that the content will always be ready.
+If `Posts` suspends while reading code or data, React continues rendering the rest of the page. If the hidden work finishes before the user selects Posts, React can reveal it without showing the Suspense fallback. Otherwise, the nearest fallback appears until the code or data is ready.
 
 <Note>
 
@@ -446,13 +378,9 @@ React does not include initially hidden `<Activity>` content in server-rendered 
 
 ## Troubleshooting {/*troubleshooting*/}
 
-### My hidden components have unwanted side effects {/*my-hidden-components-have-unwanted-side-effects*/}
+### My hidden component keeps playing audio or video {/*my-hidden-component-keeps-playing-audio-or-video*/}
 
 `<Activity>` hides DOM nodes without removing them. Browser-managed behavior from elements such as `<video>`, `<audio>`, and `<iframe>` can therefore continue while the boundary is hidden.
-
-<Pitfall>
-
-##### Preserved media can continue playing {/*preserved-media-can-continue-playing*/}
 
 Unmounting a `<video>` element stops playback because the browser removes the DOM node. Hiding it with Activity preserves the node, so playback continues unless the component pauses it explicitly.
 
@@ -480,86 +408,7 @@ React runs the cleanup when an enclosing Activity boundary becomes hidden. Becau
 
 The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from `useEffect` can run later if, for example, a Suspense boundary suspends or a View Transition is in progress.
 
-This complete example pauses the video when you switch to Home while preserving its playback position. When you return to Video, playback can continue from the same position without recreating the element or downloading it again.
-
-<Sandpack>
-
-```js src/App.js active
-import {
-  Activity,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('video');
-
-  return (
-    <>
-      <div aria-label='Media sections' role='group'>
-        <button
-          aria-pressed={activeTab === 'home'}
-          onClick={() => setActiveTab('home')}
-        >
-          Home
-        </button>
-        <button
-          aria-pressed={activeTab === 'video'}
-          onClick={() => setActiveTab('video')}
-        >
-          Video
-        </button>
-      </div>
-
-      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
-        <p>Welcome home!</p>
-      </Activity>
-      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
-        <VideoPlayer />
-      </Activity>
-    </>
-  );
-}
-
-function VideoPlayer() {
-  const ref = useRef(null);
-
-  useLayoutEffect(() => {
-    const video = ref.current;
-
-    return () => {
-      video.pause();
-    };
-  }, []);
-
-  return (
-    <video
-      aria-label='Big Buck Bunny video'
-      controls
-      playsInline
-      ref={ref}
-      src='https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4'
-    />
-  );
-}
-```
-
-```css
-button {
-  margin-right: 8px;
-}
-video {
-  aspect-ratio: 16 / 9;
-  margin-top: 12px;
-  max-width: 100%;
-  width: 400px;
-}
-```
-
-</Sandpack>
-
-</Pitfall>
+The video example above includes this cleanup while demonstrating that Activity preserves the `<video>` element's playback position.
 
 ---
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -521,7 +521,97 @@ An Activity boundary can also prepare content before the user sees it. Content i
 
 If `Posts` suspends while reading code or data, React continues rendering the rest of the page while the hidden work proceeds.
 
-The following example renders both tabs inside Activity boundaries. `<Posts>` reads a cached Promise with [`use`](/reference/react/use), so React begins loading the posts while its boundary is hidden. Wait briefly before selecting **Posts**. If the hidden render has finished, the list appears immediately.
+The Posts tab in the following example reads a cached Promise with [`use`](/reference/react/use). Select **Posts** to see the Suspense fallback while the data loads. Because conditional rendering does not mount `<Posts>` until its tab is active, it cannot begin loading the posts ahead of time.
+
+<Sandpack>
+
+```js src/App.js active
+import { Suspense, useState } from 'react';
+import Home from './Home.js';
+import Posts from './Posts.js';
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('home');
+
+  return (
+    <>
+      <div aria-label="Profile sections" role="group">
+        <button
+          aria-pressed={activeTab === 'home'}
+          onClick={() => setActiveTab('home')}
+        >
+          Home
+        </button>
+        <button
+          aria-pressed={activeTab === 'posts'}
+          onClick={() => setActiveTab('posts')}
+        >
+          Posts
+        </button>
+      </div>
+
+      <Suspense fallback={<h1>Loading posts...</h1>}>
+        {activeTab === 'home' && <Home />}
+        {activeTab === 'posts' && <Posts />}
+      </Suspense>
+    </>
+  );
+}
+```
+
+```js src/Posts.js
+import { use } from 'react';
+import { getPosts } from './data.js';
+
+export default function Posts() {
+  const posts = use(getPosts());
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```js src/Home.js hidden
+export default function Home() {
+  return <p>Welcome to my profile!</p>;
+}
+```
+
+```js src/data.js hidden
+let postsPromise;
+
+export function getPosts() {
+  if (!postsPromise) {
+    postsPromise = loadPosts();
+  }
+  return postsPromise;
+}
+
+async function loadPosts() {
+  // Add a delay so that loading is easier to observe.
+  await new Promise(resolve => setTimeout(resolve, 1500));
+
+  return Array.from({ length: 5 }, (_, index) => ({
+    id: index,
+    title: 'Post #' + (index + 1),
+  }));
+}
+```
+
+```css
+button {
+  margin-right: 8px;
+}
+```
+
+</Sandpack>
+
+To start loading the posts before the user selects the tab, render both tabs inside Activity boundaries. React begins rendering `<Posts>` while its boundary is hidden. Wait briefly before selecting **Posts**. If the hidden render has finished, the list appears immediately.
 
 <Sandpack>
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -67,7 +67,7 @@ Activity is useful when part of the UI may become hidden and visible again. Unli
 
 Use an Activity boundary when preserving that work is valuable—for example, for a tab the user is likely to revisit or a panel that can prepare data in the background. A hidden boundary retains its state and DOM nodes, so it continues using memory. If the content is unlikely to become visible again, conditionally rendering it may be preferable because unmounting allows React and the browser to release its resources.
 
-### Preserving component state while content is hidden {/*restoring-the-state-of-hidden-components*/}
+### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
 When this condition becomes false, React removes `<Sidebar>` from the tree and discards its state:
 
@@ -105,7 +105,7 @@ export default function App() {
         <button
           aria-controls='documentation-sidebar'
           aria-expanded={isShowingSidebar}
-          onClick={() => setIsShowingSidebar(showing => !showing)}
+          onClick={() => setIsShowingSidebar(s => !s)}
         >
           {isShowingSidebar ? 'Hide' : 'Show'} sidebar
         </button>
@@ -119,11 +119,14 @@ function Sidebar() {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <nav aria-label='Documentation' id='documentation-sidebar'>
+    <nav
+      aria-label='Documentation'
+      id='documentation-sidebar'
+    >
       <button
         aria-controls='overview-sections'
         aria-expanded={isExpanded}
-        onClick={() => setIsExpanded(expanded => !expanded)}
+        onClick={() => setIsExpanded(e => !e)}
       >
         Overview
         <span aria-hidden='true' className='indicator'>
@@ -166,185 +169,6 @@ main {
 </Sandpack>
 
 Changing `mode` preserves the state of the children. Removing the boundary or changing a child's type, key, or position can [reset its state](/learn/preserving-and-resetting-state).
-
----
-
-### Preserving state while navigating {/*preserving-state-while-navigating*/}
-
-When this condition becomes false, React removes `<VideoList>` from the tree and discards its state:
-
-```js
-{selectedVideo === null && <VideoList />}
-```
-
-Render the component inside an Activity boundary to preserve its state while it is hidden:
-
-```js
-<Activity mode={selectedVideo === null ? 'visible' : 'hidden'}>
-  <VideoList />
-</Activity>
-```
-
-In this example, filter the video list, open a result, and then go back. The search text and filtered results are preserved because the list remains mounted inside the hidden Activity boundary.
-
-<Sandpack>
-
-```js
-import { Activity, useState } from 'react';
-
-const videos = [
-  {
-    id: 1,
-    title: 'React Keynote',
-    description: 'The latest news from the React team.',
-  },
-  {
-    id: 2,
-    title: 'Building with Actions',
-    description: 'Handle mutations and pending states with Actions.',
-  },
-  {
-    id: 3,
-    title: 'Animating View Transitions',
-    description: 'Create polished transitions between screens.',
-  },
-  {
-    id: 4,
-    title: 'Understanding Server Components',
-    description: 'Render components ahead of time on the server.',
-  },
-];
-
-export default function App() {
-  const [selectedVideo, setSelectedVideo] = useState(null);
-
-  return (
-    <main>
-      <Activity
-        mode={selectedVideo === null ? 'visible' : 'hidden'}
-      >
-        <VideoList onSelect={setSelectedVideo} />
-      </Activity>
-
-      {selectedVideo !== null && (
-        <VideoDetails
-          onBack={() => setSelectedVideo(null)}
-          video={selectedVideo}
-        />
-      )}
-    </main>
-  );
-}
-
-function VideoList({ onSelect }) {
-  const [searchText, setSearchText] = useState('');
-  const visibleVideos = videos.filter(video => {
-    const text = `${video.title} ${video.description}`;
-    return text.toLowerCase().includes(searchText.toLowerCase());
-  });
-
-  return (
-    <section>
-      <h1>Videos</h1>
-      <label htmlFor='search'>Search videos</label>
-      <input
-        id='search'
-        onChange={event => setSearchText(event.target.value)}
-        placeholder='Try "React"'
-        type='search'
-        value={searchText}
-      />
-
-      <ul className='videos'>
-        {visibleVideos.map(video => (
-          <li key={video.id}>
-            <button onClick={() => onSelect(video)}>
-              <strong>{video.title}</strong>
-              <span>{video.description}</span>
-            </button>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-function VideoDetails({ video, onBack }) {
-  return (
-    <section>
-      <button className='back' onClick={onBack}>
-        Back
-      </button>
-      <div className='thumbnail' aria-hidden='true'>
-        ▶
-      </div>
-      <h1>{video.title}</h1>
-      <p>{video.description}</p>
-    </section>
-  );
-}
-```
-
-```css
-body {
-  margin: 0;
-  padding: 16px;
-  font-family: system-ui;
-}
-main {
-  max-width: 520px;
-}
-label,
-input {
-  display: block;
-}
-input {
-  box-sizing: border-box;
-  margin: 8px 0 16px;
-  padding: 8px;
-  width: 100%;
-}
-.videos {
-  display: grid;
-  gap: 8px;
-  list-style: none;
-  padding: 0;
-}
-.videos button {
-  background: #f5f5f5;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  cursor: pointer;
-  padding: 12px;
-  text-align: left;
-  width: 100%;
-}
-.videos strong,
-.videos span {
-  display: block;
-}
-.videos span {
-  color: #555;
-  margin-top: 4px;
-}
-.back {
-  margin-bottom: 12px;
-}
-.thumbnail {
-  align-items: center;
-  aspect-ratio: 16 / 9;
-  background: #282c34;
-  border-radius: 8px;
-  color: white;
-  display: flex;
-  font-size: 48px;
-  justify-content: center;
-}
-```
-
-</Sandpack>
-
-The search field is controlled by `VideoList` state. Hiding the list preserves that React state when the user opens a video. The next example shows a different case: state stored by the browser in an uncontrolled field.
 
 ---
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -69,13 +69,15 @@ Use an Activity boundary when hidden content is likely to become visible again, 
 
 ### Preserving component state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
-With conditional rendering, React removes `<Sidebar>` from the tree when `isShowingSidebar` becomes `false` and discards its state:
+Conditional rendering mounts or unmounts a component as its condition changes:
 
 ```js
 {isShowingSidebar && <Sidebar />}
 ```
 
-Render the component inside an Activity boundary to preserve its state while it is hidden:
+Unmounting `<Sidebar>` destroys its internal state. As a result, its state resets each time it is shown.
+
+To preserve the state between hides, keep `<Sidebar>` mounted inside an Activity boundary and change the boundary's `mode`:
 
 ```js
 <Activity mode={isShowingSidebar ? 'visible' : 'hidden'}>
@@ -83,7 +85,9 @@ Render the component inside an Activity boundary to preserve its state while it 
 </Activity>
 ```
 
-In this example, expand the sidebar, hide it, and show it again. The expanded state is preserved.
+When the boundary becomes visible again, `<Sidebar>` resumes with its previous state.
+
+The following example has a sidebar with an expandable Overview section and a button that hides and shows the sidebar. To verify that its state is preserved, expand the Overview section, hide the sidebar, and then show it again. The Overview section remains expanded.
 
 <Sandpack>
 
@@ -177,7 +181,7 @@ Changing `mode` preserves the state of the children. Removing the boundary or ch
 
 ### Preserving DOM state while content is hidden {/*restoring-the-dom-of-hidden-components*/}
 
-An Activity boundary also preserves state held by the browser in DOM nodes.
+Because Activity boundaries hide their children without removing them, the children's DOM is also preserved. This is useful for maintaining state held by the browser in DOM nodes.
 
 The Contact tab in the following examples contains an uncontrolled `<textarea>`. Enter a draft, switch to the Home tab, and then return to Contact to compare the behavior with and without Activity.
 
@@ -349,7 +353,80 @@ b {
 
 </Recipes>
 
-Activity also preserves other browser-managed state, such as scroll position and media playback position. In this example, play the video, hide it, and then show it again. When you play it again, the video continues from the same position.
+Activity also preserves other browser-managed state, such as scroll position and media playback position. The following examples use the same video player to compare removing and hiding a `<video>` element. Play the video, hide it, show it again, and then select **Play**.
+
+<Recipes titleText="The difference between removing and hiding a video" titleId="examples-preserving-media-state">
+
+#### Removing the video resets its playback position {/*removing-the-video-resets-its-playback-position*/}
+
+This version conditionally renders the video player. Hiding it removes the `<video>` element from the DOM, so playback starts from the beginning when you show it again.
+
+<Sandpack>
+
+```js src/App.js active
+import { useState } from 'react';
+import VideoPlayer from './VideoPlayer.js';
+
+export default function App() {
+  const [isShowingVideo, setIsShowingVideo] = useState(true);
+
+  return (
+    <>
+      <button onClick={() => setIsShowingVideo(showing => !showing)}>
+        {isShowingVideo ? 'Hide' : 'Show'} video
+      </button>
+      {isShowingVideo && <VideoPlayer />}
+    </>
+  );
+}
+```
+
+```js src/VideoPlayer.js hidden
+import { useLayoutEffect, useRef } from 'react';
+
+export default function VideoPlayer() {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const video = ref.current;
+    return () => video.pause();
+  }, []);
+
+  return (
+    <div className="video-player">
+      <button onClick={() => ref.current.play()}>Play</button>
+      <button onClick={() => ref.current.pause()}>Pause</button>
+      <video ref={ref} width="250">
+        <source
+          src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+          type="video/mp4"
+        />
+      </video>
+    </div>
+  );
+}
+```
+
+```css
+.video-player {
+  margin-top: 10px;
+}
+.video-player button {
+  margin-right: 10px;
+}
+.video-player video {
+  display: block;
+  margin-top: 10px;
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+#### Hiding the video preserves its playback position {/*hiding-the-video-preserves-its-playback-position*/}
+
+This version renders the video player inside an Activity boundary. Hiding it preserves the `<video>` element, so playback continues from the same position when you show it and select **Play** again.
 
 <Sandpack>
 
@@ -414,7 +491,11 @@ export default function VideoPlayer() {
 
 </Sandpack>
 
-The ref provides access to the `<video>` DOM node; it does not store the playback position. The `useLayoutEffect` cleanup pauses the video when the boundary becomes hidden. Activity preserves the DOM node and its playback position, but React detaches the ref while the boundary is hidden and reconnects it when the boundary becomes visible. See [Troubleshooting](#my-hidden-component-keeps-playing-audio-or-video) for more about cleaning up browser-managed behavior.
+<Solution />
+
+</Recipes>
+
+The ref provides access to the `<video>` DOM node. It does not store the playback position. The `useLayoutEffect` cleanup pauses the video when the player is removed or its Activity boundary becomes hidden. Activity preserves the DOM node and its playback position, but React detaches the ref while the boundary is hidden and reconnects it when the boundary becomes visible. See [Troubleshooting](#my-hidden-component-keeps-playing-audio-or-video) for more about cleaning up browser-managed behavior.
 
 ---
 
@@ -430,7 +511,207 @@ An Activity boundary can also prepare content before the user sees it. Content i
 </Suspense>
 ```
 
-If `Posts` suspends while reading code or data, React continues rendering the rest of the page. If the hidden work finishes before the user selects Posts, React can reveal it without showing the Suspense fallback. Otherwise, the nearest fallback appears until the code or data is ready.
+If `Posts` suspends while reading code or data, React continues rendering the rest of the page while the hidden work proceeds.
+
+The following examples compare rendering the Posts tab on demand with pre-rendering it in a hidden Activity boundary. Both versions read the same cached Promise with [`use`](/reference/react/use).
+
+<Recipes titleText="The difference between rendering and pre-rendering a tab" titleId="examples-pre-rendering">
+
+#### Rendering the tab on demand shows a fallback {/*rendering-the-tab-on-demand-shows-a-fallback*/}
+
+This version does not mount `<Posts>` until its tab is active. Select **Posts** to see the Suspense fallback while the data loads.
+
+<Sandpack>
+
+```js src/App.js active
+import { Suspense, useState } from 'react';
+import Home from './Home.js';
+import Posts from './Posts.js';
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('home');
+
+  return (
+    <>
+      <div aria-label="Profile sections" role="group">
+        <button
+          aria-pressed={activeTab === 'home'}
+          onClick={() => setActiveTab('home')}
+        >
+          Home
+        </button>
+        <button
+          aria-pressed={activeTab === 'posts'}
+          onClick={() => setActiveTab('posts')}
+        >
+          Posts
+        </button>
+      </div>
+
+      <Suspense fallback={<h1>Loading posts...</h1>}>
+        {activeTab === 'home' && <Home />}
+        {activeTab === 'posts' && <Posts />}
+      </Suspense>
+    </>
+  );
+}
+```
+
+```js src/Posts.js
+import { use } from 'react';
+import { getPosts } from './data.js';
+
+export default function Posts() {
+  const posts = use(getPosts());
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```js src/Home.js hidden
+export default function Home() {
+  return <p>Welcome to my profile!</p>;
+}
+```
+
+```js src/data.js hidden
+let postsPromise;
+
+export function getPosts() {
+  if (!postsPromise) {
+    postsPromise = loadPosts();
+  }
+  return postsPromise;
+}
+
+async function loadPosts() {
+  // Add a delay so that loading is easier to observe.
+  await new Promise(resolve => setTimeout(resolve, 1500));
+
+  return Array.from({ length: 5 }, (_, index) => ({
+    id: index,
+    title: 'Post #' + (index + 1),
+  }));
+}
+```
+
+```css
+button {
+  margin-right: 8px;
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+#### Pre-rendering the tab can avoid the fallback {/*pre-rendering-the-tab-can-avoid-the-fallback*/}
+
+This version renders both tabs inside Activity boundaries. React begins rendering `<Posts>` while its boundary is hidden. Wait briefly before selecting **Posts**. The list appears immediately because the hidden render started loading it in the background.
+
+<Sandpack>
+
+```js src/App.js active
+import { Activity, Suspense, useState } from 'react';
+import Home from './Home.js';
+import Posts from './Posts.js';
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('home');
+
+  return (
+    <>
+      <div aria-label="Profile sections" role="group">
+        <button
+          aria-pressed={activeTab === 'home'}
+          onClick={() => setActiveTab('home')}
+        >
+          Home
+        </button>
+        <button
+          aria-pressed={activeTab === 'posts'}
+          onClick={() => setActiveTab('posts')}
+        >
+          Posts
+        </button>
+      </div>
+
+      <Suspense fallback={<h1>Loading posts...</h1>}>
+        <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
+          <Home />
+        </Activity>
+        <Activity mode={activeTab === 'posts' ? 'visible' : 'hidden'}>
+          <Posts />
+        </Activity>
+      </Suspense>
+    </>
+  );
+}
+```
+
+```js src/Posts.js
+import { use } from 'react';
+import { getPosts } from './data.js';
+
+export default function Posts() {
+  const posts = use(getPosts());
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```js src/Home.js hidden
+export default function Home() {
+  return <p>Welcome to my profile!</p>;
+}
+```
+
+```js src/data.js hidden
+let postsPromise;
+
+export function getPosts() {
+  if (!postsPromise) {
+    postsPromise = loadPosts();
+  }
+  return postsPromise;
+}
+
+async function loadPosts() {
+  // Add a delay so that pre-rendering is easier to observe.
+  await new Promise(resolve => setTimeout(resolve, 1500));
+
+  return Array.from({ length: 5 }, (_, index) => ({
+    id: index,
+    title: 'Post #' + (index + 1),
+  }));
+}
+```
+
+```css
+button {
+  margin-right: 8px;
+}
+```
+
+</Sandpack>
+
+<Solution />
+
+</Recipes>
+
+If the user selects Posts before the hidden render finishes, the Suspense fallback appears until the data is ready. Pre-rendering can reduce the loading time, but it does not guarantee that the content will always be ready.
 
 <Note>
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -67,7 +67,7 @@ Activity is useful when part of the UI may become hidden and visible again. Unli
 
 Use an Activity boundary when preserving that work is valuable—for example, for a tab the user is likely to revisit or a panel that can prepare data in the background. A hidden boundary retains its state and DOM nodes, so it continues using memory. If the content is unlikely to become visible again, conditionally rendering it may be preferable because unmounting allows React and the browser to release its resources.
 
-### Preserving state in a hidden sidebar {/*restoring-the-state-of-hidden-components*/}
+### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
 When this condition becomes false, React removes `<Sidebar>` from the tree and discards its state:
 
@@ -172,11 +172,11 @@ Changing `mode` preserves the state of the children. Removing the boundary or ch
 
 ---
 
-### Preserving DOM state in an input {/*restoring-the-dom-of-hidden-components*/}
+### Preserving DOM state while content is hidden {/*restoring-the-dom-of-hidden-components*/}
 
 An Activity boundary also preserves state held by the browser in DOM nodes. This includes an uncontrolled input's current value, scroll position, and media playback position.
 
-In this example, enter a draft, hide the contact form, and then show it again. The `<textarea>` value remains because its DOM node was hidden rather than removed.
+In this example, enter a draft in the Contact section, switch sections, and then return to Contact. The `<textarea>` value remains because its DOM node was hidden rather than removed.
 
 <Sandpack>
 
@@ -184,27 +184,71 @@ In this example, enter a draft, hide the contact form, and then show it again. T
 import { Activity, useState } from 'react';
 
 export default function App() {
-  const [isShowingContact, setIsShowingContact] = useState(true);
+  const [activeSection, setActiveSection] = useState('contact');
 
   return (
     <>
-      <button
-        onClick={() => setIsShowingContact(showing => !showing)}
+      <div
+        aria-label='Profile sections'
+        className='section-buttons'
+        role='group'
       >
-        {isShowingContact ? 'Hide' : 'Show'} contact form
-      </button>
-      <Activity mode={isShowingContact ? 'visible' : 'hidden'}>
-        <p>
-          <label htmlFor='message'>Message</label>
-          <textarea id='message' />
-        </p>
+        <SectionButton
+          isActive={activeSection === 'home'}
+          onClick={() => setActiveSection('home')}
+        >
+          Home
+        </SectionButton>
+        <SectionButton
+          isActive={activeSection === 'contact'}
+          onClick={() => setActiveSection('contact')}
+        >
+          Contact
+        </SectionButton>
+      </div>
+
+      <Activity
+        mode={activeSection === 'home' ? 'visible' : 'hidden'}
+      >
+        <Home />
+      </Activity>
+      <Activity
+        mode={activeSection === 'contact' ? 'visible' : 'hidden'}
+      >
+        <Contact />
       </Activity>
     </>
+  );
+}
+
+function SectionButton({ isActive, onClick, children }) {
+  return (
+    <button aria-pressed={isActive} onClick={onClick}>
+      {children}
+    </button>
+  );
+}
+
+function Home() {
+  return <p>Welcome to my profile!</p>;
+}
+
+function Contact() {
+  return (
+    <p>
+      <label htmlFor='message'>Message</label>
+      <textarea id='message' />
+    </p>
   );
 }
 ```
 
 ```css
+.section-buttons {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
 label,
 textarea {
   display: block;
@@ -217,70 +261,6 @@ textarea {
 </Sandpack>
 
 Preserving DOM state also means that DOM behavior can continue while content is hidden. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects) for DOM behavior that requires explicit cleanup.
-
----
-
-### Preserving video playback while content is hidden {/*preserving-video-playback-while-content-is-hidden*/}
-
-Browser-managed state in DOM nodes also includes a video's playback position. Play the video, hide it, and then show it again. The video pauses while hidden and returns at the same playback position.
-
-<Sandpack>
-
-```js
-import {
-  Activity,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
-
-export default function App() {
-  const [isShowingVideo, setIsShowingVideo] = useState(true);
-
-  return (
-    <>
-      <button onClick={() => setIsShowingVideo(showing => !showing)}>
-        {isShowingVideo ? 'Hide' : 'Show'} video
-      </button>
-      <Activity mode={isShowingVideo ? 'visible' : 'hidden'}>
-        <VideoPlayer />
-      </Activity>
-    </>
-  );
-}
-
-function VideoPlayer() {
-  const ref = useRef(null);
-
-  useLayoutEffect(() => {
-    const video = ref.current;
-    return () => video.pause();
-  }, []);
-
-  return (
-    <video
-      aria-label='Big Buck Bunny video'
-      controls
-      playsInline
-      ref={ref}
-      src='https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4'
-    />
-  );
-}
-```
-
-```css
-video {
-  aspect-ratio: 16 / 9;
-  margin-top: 12px;
-  max-width: 100%;
-  width: 400px;
-}
-```
-
-</Sandpack>
-
-The cleanup pauses playback when the boundary becomes hidden. Because Activity preserves the `<video>` DOM node, it does not reset the playback position. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects) for why the cleanup is necessary.
 
 ---
 
@@ -500,7 +480,84 @@ React runs the cleanup when an enclosing Activity boundary becomes hidden. Becau
 
 The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from `useEffect` can run later if, for example, a Suspense boundary suspends or a View Transition is in progress.
 
-See [Preserving video playback while content is hidden](#preserving-video-playback-while-content-is-hidden) for a complete example.
+This complete example pauses the video when you switch to Home while preserving its playback position. When you return to Video, playback can continue from the same position without recreating the element or downloading it again.
+
+<Sandpack>
+
+```js src/App.js active
+import {
+  Activity,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('video');
+
+  return (
+    <>
+      <div aria-label='Media sections' role='group'>
+        <button
+          aria-pressed={activeTab === 'home'}
+          onClick={() => setActiveTab('home')}
+        >
+          Home
+        </button>
+        <button
+          aria-pressed={activeTab === 'video'}
+          onClick={() => setActiveTab('video')}
+        >
+          Video
+        </button>
+      </div>
+
+      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
+        <p>Welcome home!</p>
+      </Activity>
+      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
+        <VideoPlayer />
+      </Activity>
+    </>
+  );
+}
+
+function VideoPlayer() {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const video = ref.current;
+
+    return () => {
+      video.pause();
+    };
+  }, []);
+
+  return (
+    <video
+      aria-label='Big Buck Bunny video'
+      controls
+      playsInline
+      ref={ref}
+      src='https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4'
+    />
+  );
+}
+```
+
+```css
+button {
+  margin-right: 8px;
+}
+video {
+  aspect-ratio: 16 / 9;
+  margin-top: 12px;
+  max-width: 100%;
+  width: 400px;
+}
+```
+
+</Sandpack>
 
 </Pitfall>
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -67,7 +67,7 @@ Activity is useful when part of the UI may become hidden and visible again. Unli
 
 Use an Activity boundary when preserving that work is valuable—for example, for a tab the user is likely to revisit or a panel that can prepare data in the background. A hidden boundary retains its state and DOM nodes, so it continues using memory. If the content is unlikely to become visible again, conditionally rendering it may be preferable because unmounting allows React and the browser to release its resources.
 
-### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
+### Preserving component state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
 When this condition becomes false, React removes `<Sidebar>` from the tree and discards its state:
 
@@ -105,7 +105,7 @@ export default function App() {
         <button
           aria-controls='documentation-sidebar'
           aria-expanded={isShowingSidebar}
-          onClick={() => setIsShowingSidebar(s => !s)}
+          onClick={() => setIsShowingSidebar(showing => !showing)}
         >
           {isShowingSidebar ? 'Hide' : 'Show'} sidebar
         </button>
@@ -119,14 +119,11 @@ function Sidebar() {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <nav
-      aria-label='Documentation'
-      id='documentation-sidebar'
-    >
+    <nav aria-label='Documentation' id='documentation-sidebar'>
       <button
         aria-controls='overview-sections'
         aria-expanded={isExpanded}
-        onClick={() => setIsExpanded(e => !e)}
+        onClick={() => setIsExpanded(expanded => !expanded)}
       >
         Overview
         <span aria-hidden='true' className='indicator'>
@@ -169,6 +166,185 @@ main {
 </Sandpack>
 
 Changing `mode` preserves the state of the children. Removing the boundary or changing a child's type, key, or position can [reset its state](/learn/preserving-and-resetting-state).
+
+---
+
+### Preserving state while navigating {/*preserving-state-while-navigating*/}
+
+When this condition becomes false, React removes `<VideoList>` from the tree and discards its state:
+
+```js
+{selectedVideo === null && <VideoList />}
+```
+
+Render the component inside an Activity boundary to preserve its state while it is hidden:
+
+```js
+<Activity mode={selectedVideo === null ? 'visible' : 'hidden'}>
+  <VideoList />
+</Activity>
+```
+
+In this example, filter the video list, open a result, and then go back. The search text and filtered results are preserved because the list remains mounted inside the hidden Activity boundary.
+
+<Sandpack>
+
+```js
+import { Activity, useState } from 'react';
+
+const videos = [
+  {
+    id: 1,
+    title: 'React Keynote',
+    description: 'The latest news from the React team.',
+  },
+  {
+    id: 2,
+    title: 'Building with Actions',
+    description: 'Handle mutations and pending states with Actions.',
+  },
+  {
+    id: 3,
+    title: 'Animating View Transitions',
+    description: 'Create polished transitions between screens.',
+  },
+  {
+    id: 4,
+    title: 'Understanding Server Components',
+    description: 'Render components ahead of time on the server.',
+  },
+];
+
+export default function App() {
+  const [selectedVideo, setSelectedVideo] = useState(null);
+
+  return (
+    <main>
+      <Activity
+        mode={selectedVideo === null ? 'visible' : 'hidden'}
+      >
+        <VideoList onSelect={setSelectedVideo} />
+      </Activity>
+
+      {selectedVideo !== null && (
+        <VideoDetails
+          onBack={() => setSelectedVideo(null)}
+          video={selectedVideo}
+        />
+      )}
+    </main>
+  );
+}
+
+function VideoList({ onSelect }) {
+  const [searchText, setSearchText] = useState('');
+  const visibleVideos = videos.filter(video => {
+    const text = `${video.title} ${video.description}`;
+    return text.toLowerCase().includes(searchText.toLowerCase());
+  });
+
+  return (
+    <section>
+      <h1>Videos</h1>
+      <label htmlFor='search'>Search videos</label>
+      <input
+        id='search'
+        onChange={event => setSearchText(event.target.value)}
+        placeholder='Try "React"'
+        type='search'
+        value={searchText}
+      />
+
+      <ul className='videos'>
+        {visibleVideos.map(video => (
+          <li key={video.id}>
+            <button onClick={() => onSelect(video)}>
+              <strong>{video.title}</strong>
+              <span>{video.description}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function VideoDetails({ video, onBack }) {
+  return (
+    <section>
+      <button className='back' onClick={onBack}>
+        Back
+      </button>
+      <div className='thumbnail' aria-hidden='true'>
+        ▶
+      </div>
+      <h1>{video.title}</h1>
+      <p>{video.description}</p>
+    </section>
+  );
+}
+```
+
+```css
+body {
+  margin: 0;
+  padding: 16px;
+  font-family: system-ui;
+}
+main {
+  max-width: 520px;
+}
+label,
+input {
+  display: block;
+}
+input {
+  box-sizing: border-box;
+  margin: 8px 0 16px;
+  padding: 8px;
+  width: 100%;
+}
+.videos {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+}
+.videos button {
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  cursor: pointer;
+  padding: 12px;
+  text-align: left;
+  width: 100%;
+}
+.videos strong,
+.videos span {
+  display: block;
+}
+.videos span {
+  color: #555;
+  margin-top: 4px;
+}
+.back {
+  margin-bottom: 12px;
+}
+.thumbnail {
+  align-items: center;
+  aspect-ratio: 16 / 9;
+  background: #282c34;
+  border-radius: 8px;
+  color: white;
+  display: flex;
+  font-size: 48px;
+  justify-content: center;
+}
+```
+
+</Sandpack>
+
+The search field is controlled by `VideoList` state. Hiding the list preserves that React state when the user opens a video. The next example shows a different case: state stored by the browser in an uncontrolled field.
 
 ---
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -67,7 +67,7 @@ Activity is useful when part of the UI may become hidden and visible again. Unli
 
 Use an Activity boundary when preserving that work is valuable—for example, for a tab the user is likely to revisit or a panel that can prepare data in the background. A hidden boundary retains its state and DOM nodes, so it continues using memory. If the content is unlikely to become visible again, conditionally rendering it may be preferable because unmounting allows React and the browser to release its resources.
 
-### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
+### Preserving state in a hidden sidebar {/*restoring-the-state-of-hidden-components*/}
 
 When this condition becomes false, React removes `<Sidebar>` from the tree and discards its state:
 
@@ -172,11 +172,11 @@ Changing `mode` preserves the state of the children. Removing the boundary or ch
 
 ---
 
-### Preserving DOM state while content is hidden {/*restoring-the-dom-of-hidden-components*/}
+### Preserving DOM state in an input {/*restoring-the-dom-of-hidden-components*/}
 
 An Activity boundary also preserves state held by the browser in DOM nodes. This includes an uncontrolled input's current value, scroll position, and media playback position.
 
-In this example, enter a draft in the Contact section, switch sections, and then return to Contact. The `<textarea>` value remains because its DOM node was hidden rather than removed.
+In this example, enter a draft, hide the contact form, and then show it again. The `<textarea>` value remains because its DOM node was hidden rather than removed.
 
 <Sandpack>
 
@@ -184,71 +184,27 @@ In this example, enter a draft in the Contact section, switch sections, and then
 import { Activity, useState } from 'react';
 
 export default function App() {
-  const [activeSection, setActiveSection] = useState('contact');
+  const [isShowingContact, setIsShowingContact] = useState(true);
 
   return (
     <>
-      <div
-        aria-label='Profile sections'
-        className='section-buttons'
-        role='group'
+      <button
+        onClick={() => setIsShowingContact(showing => !showing)}
       >
-        <SectionButton
-          isActive={activeSection === 'home'}
-          onClick={() => setActiveSection('home')}
-        >
-          Home
-        </SectionButton>
-        <SectionButton
-          isActive={activeSection === 'contact'}
-          onClick={() => setActiveSection('contact')}
-        >
-          Contact
-        </SectionButton>
-      </div>
-
-      <Activity
-        mode={activeSection === 'home' ? 'visible' : 'hidden'}
-      >
-        <Home />
-      </Activity>
-      <Activity
-        mode={activeSection === 'contact' ? 'visible' : 'hidden'}
-      >
-        <Contact />
+        {isShowingContact ? 'Hide' : 'Show'} contact form
+      </button>
+      <Activity mode={isShowingContact ? 'visible' : 'hidden'}>
+        <p>
+          <label htmlFor='message'>Message</label>
+          <textarea id='message' />
+        </p>
       </Activity>
     </>
-  );
-}
-
-function SectionButton({ isActive, onClick, children }) {
-  return (
-    <button aria-pressed={isActive} onClick={onClick}>
-      {children}
-    </button>
-  );
-}
-
-function Home() {
-  return <p>Welcome to my profile!</p>;
-}
-
-function Contact() {
-  return (
-    <p>
-      <label htmlFor='message'>Message</label>
-      <textarea id='message' />
-    </p>
   );
 }
 ```
 
 ```css
-.section-buttons {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 12px;
-}
 label,
 textarea {
   display: block;
@@ -261,6 +217,70 @@ textarea {
 </Sandpack>
 
 Preserving DOM state also means that DOM behavior can continue while content is hidden. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects) for DOM behavior that requires explicit cleanup.
+
+---
+
+### Preserving video playback while content is hidden {/*preserving-video-playback-while-content-is-hidden*/}
+
+Browser-managed state in DOM nodes also includes a video's playback position. Play the video, hide it, and then show it again. The video pauses while hidden and returns at the same playback position.
+
+<Sandpack>
+
+```js
+import {
+  Activity,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export default function App() {
+  const [isShowingVideo, setIsShowingVideo] = useState(true);
+
+  return (
+    <>
+      <button onClick={() => setIsShowingVideo(showing => !showing)}>
+        {isShowingVideo ? 'Hide' : 'Show'} video
+      </button>
+      <Activity mode={isShowingVideo ? 'visible' : 'hidden'}>
+        <VideoPlayer />
+      </Activity>
+    </>
+  );
+}
+
+function VideoPlayer() {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const video = ref.current;
+    return () => video.pause();
+  }, []);
+
+  return (
+    <video
+      aria-label='Big Buck Bunny video'
+      controls
+      playsInline
+      ref={ref}
+      src='https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4'
+    />
+  );
+}
+```
+
+```css
+video {
+  aspect-ratio: 16 / 9;
+  margin-top: 12px;
+  max-width: 100%;
+  width: 400px;
+}
+```
+
+</Sandpack>
+
+The cleanup pauses playback when the boundary becomes hidden. Because Activity preserves the `<video>` DOM node, it does not reset the playback position. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects) for why the cleanup is necessary.
 
 ---
 
@@ -480,84 +500,7 @@ React runs the cleanup when an enclosing Activity boundary becomes hidden. Becau
 
 The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from `useEffect` can run later if, for example, a Suspense boundary suspends or a View Transition is in progress.
 
-This complete example pauses the video when you switch to Home while preserving its playback position. When you return to Video, playback can continue from the same position without recreating the element or downloading it again.
-
-<Sandpack>
-
-```js src/App.js active
-import {
-  Activity,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
-
-export default function App() {
-  const [activeTab, setActiveTab] = useState('video');
-
-  return (
-    <>
-      <div aria-label='Media sections' role='group'>
-        <button
-          aria-pressed={activeTab === 'home'}
-          onClick={() => setActiveTab('home')}
-        >
-          Home
-        </button>
-        <button
-          aria-pressed={activeTab === 'video'}
-          onClick={() => setActiveTab('video')}
-        >
-          Video
-        </button>
-      </div>
-
-      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
-        <p>Welcome home!</p>
-      </Activity>
-      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
-        <VideoPlayer />
-      </Activity>
-    </>
-  );
-}
-
-function VideoPlayer() {
-  const ref = useRef(null);
-
-  useLayoutEffect(() => {
-    const video = ref.current;
-
-    return () => {
-      video.pause();
-    };
-  }, []);
-
-  return (
-    <video
-      aria-label='Big Buck Bunny video'
-      controls
-      playsInline
-      ref={ref}
-      src='https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4'
-    />
-  );
-}
-```
-
-```css
-button {
-  margin-right: 8px;
-}
-video {
-  aspect-ratio: 16 / 9;
-  margin-top: 12px;
-  max-width: 100%;
-  width: 400px;
-}
-```
-
-</Sandpack>
+See [Preserving video playback while content is hidden](#preserving-video-playback-while-content-is-hidden) for a complete example.
 
 </Pitfall>
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -339,13 +339,13 @@ b {
 
 </Sandpack>
 
-Activity also preserves other browser-managed state, such as scroll position and media playback position. The following examples use the same video player to compare removing and hiding a `<video>` element. Play the video, hide it, show it again, and then select **Play**.
+Activity also preserves other browser-managed state, such as scroll position and media playback position. The following examples use the same video player to compare removing and hiding a `<video>` element. Play the video, switch to the Home tab, return to the Video tab, and then select **Play**.
 
 <Recipes titleText="The difference between removing and hiding a video" titleId="examples-preserving-media-state">
 
 #### Removing the video resets its playback position {/*removing-the-video-resets-its-playback-position*/}
 
-This version conditionally renders the video player. Hiding it removes the `<video>` element from the DOM, so playback starts from the beginning when you show it again.
+This version conditionally renders the active tab. Switching to Home removes the `<video>` element from the DOM, so playback starts from the beginning when you return to Video.
 
 <Sandpack>
 
@@ -354,14 +354,24 @@ import { useState } from 'react';
 import VideoPlayer from './VideoPlayer.js';
 
 export default function App() {
-  const [isShowingVideo, setIsShowingVideo] = useState(true);
+  const [activeTab, setActiveTab] = useState('video');
 
   return (
     <>
-      <button onClick={() => setIsShowingVideo(showing => !showing)}>
-        {isShowingVideo ? 'Hide' : 'Show'} video
+      <button
+        aria-pressed={activeTab === 'home'}
+        onClick={() => setActiveTab('home')}
+      >
+        Home
       </button>
-      {isShowingVideo && <VideoPlayer />}
+      <button
+        aria-pressed={activeTab === 'video'}
+        onClick={() => setActiveTab('video')}
+      >
+        Video
+      </button>
+      {activeTab === 'home' && <p>Welcome to my profile!</p>}
+      {activeTab === 'video' && <VideoPlayer />}
     </>
   );
 }
@@ -394,11 +404,11 @@ export default function VideoPlayer() {
 ```
 
 ```css
+button {
+  margin-right: 10px;
+}
 .video-player {
   margin-top: 10px;
-}
-.video-player button {
-  margin-right: 10px;
 }
 .video-player video {
   display: block;
@@ -412,7 +422,7 @@ export default function VideoPlayer() {
 
 #### Hiding the video preserves its playback position {/*hiding-the-video-preserves-its-playback-position*/}
 
-This version renders the video player inside an Activity boundary. Hiding it preserves the `<video>` element, so playback continues from the same position when you show it and select **Play** again.
+This version renders both tabs inside Activity boundaries. Switching to Home hides the `<video>` element without removing it, so playback continues from the same position when you return to Video and select **Play** again.
 
 <Sandpack>
 
@@ -421,14 +431,26 @@ import { Activity, useState } from 'react';
 import VideoPlayer from './VideoPlayer.js';
 
 export default function App() {
-  const [isShowingVideo, setIsShowingVideo] = useState(true);
+  const [activeTab, setActiveTab] = useState('video');
 
   return (
     <>
-      <button onClick={() => setIsShowingVideo(showing => !showing)}>
-        {isShowingVideo ? 'Hide' : 'Show'} video
+      <button
+        aria-pressed={activeTab === 'home'}
+        onClick={() => setActiveTab('home')}
+      >
+        Home
       </button>
-      <Activity mode={isShowingVideo ? 'visible' : 'hidden'}>
+      <button
+        aria-pressed={activeTab === 'video'}
+        onClick={() => setActiveTab('video')}
+      >
+        Video
+      </button>
+      <Activity mode={activeTab === 'home' ? 'visible' : 'hidden'}>
+        <p>Welcome to my profile!</p>
+      </Activity>
+      <Activity mode={activeTab === 'video' ? 'visible' : 'hidden'}>
         <VideoPlayer />
       </Activity>
     </>
@@ -463,11 +485,11 @@ export default function VideoPlayer() {
 ```
 
 ```css
+button {
+  margin-right: 10px;
+}
 .video-player {
   margin-top: 10px;
-}
-.video-player button {
-  margin-right: 10px;
 }
 .video-player video {
   display: block;

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -181,7 +181,7 @@ Changing `mode` preserves the state of the children. Removing the boundary or ch
 
 ### Preserving DOM state while content is hidden {/*restoring-the-dom-of-hidden-components*/}
 
-Because Activity boundaries hide their children without removing them, the children's DOM is also preserved. This is useful for maintaining state held by the browser in DOM nodes.
+In React DOM, an Activity boundary hides its children without removing their DOM nodes. This preserves state held by the browser in those nodes.
 
 The Contact tab in the following example contains an uncontrolled `<textarea>`. Enter a draft, switch to the Home tab, and then return to Contact. The draft is lost because conditional rendering removes `<Contact>` and its `<textarea>` from the DOM.
 
@@ -345,7 +345,7 @@ Activity also preserves other browser-managed state, such as scroll position and
 
 #### Removing the video resets its playback position {/*removing-the-video-resets-its-playback-position*/}
 
-This version conditionally renders the active tab. Switching to Home removes the `<video>` element from the DOM, so playback starts from the beginning when you return to Video.
+The following example conditionally renders the active tab. Play the video, switch to Home, return to Video, and then select **Play**. Switching to Home removes the `<video>` element from the DOM, so playback starts from the beginning.
 
 <Sandpack>
 
@@ -422,7 +422,7 @@ button {
 
 #### Hiding the video preserves its playback position {/*hiding-the-video-preserves-its-playback-position*/}
 
-This version renders both tabs inside Activity boundaries. Switching to Home hides the `<video>` element without removing it, so playback continues from the same position when you return to Video and select **Play** again.
+The following example renders both tabs inside Activity boundaries. Play the video, switch to Home, return to Video, and then select **Play**. Switching to Home hides the `<video>` element without removing it, so playback continues from the same position.
 
 <Sandpack>
 
@@ -509,7 +509,7 @@ The ref provides access to the `<video>` DOM node. It does not store the playbac
 
 ### Pre-rendering content that is likely to become visible {/*pre-rendering-content-thats-likely-to-become-visible*/}
 
-An Activity boundary can also prepare content before the user sees it. Content inside a hidden boundary renders at a lower priority without running Effects created with `useEffect` or `useLayoutEffect`. This lets the content load code and render-time data without delaying updates to visible content:
+You can use an Activity boundary to prepare content before the user sees it. Content inside a hidden boundary renders at a lower priority without running Effects created with `useEffect` or `useLayoutEffect`. This lets the content load code and render-time data without delaying updates to visible content:
 
 ```js
 <Suspense fallback={<Loading />}>
@@ -719,7 +719,7 @@ The data source must integrate with Suspense. For example, the component can rea
 
 ### Improving hydration performance {/*speeding-up-interactions-during-page-load*/}
 
-Activity boundaries also divide server-rendered pages into units that React can hydrate independently. This is related to the selective hydration behavior of [`<Suspense>`](/reference/react/Suspense), but it does not require displaying a fallback in the initial UI.
+During hydration, Activity boundaries divide server-rendered pages into units that React can hydrate independently. This is related to the selective hydration behavior of [`<Suspense>`](/reference/react/Suspense), but it does not require displaying a fallback in the initial UI.
 
 For example, without a boundary React hydrates this page as one unit:
 
@@ -813,7 +813,7 @@ React runs the cleanup when an enclosing Activity boundary becomes hidden. Becau
 
 The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from `useEffect` can run later if, for example, a Suspense boundary suspends or a View Transition is in progress.
 
-The video example above includes this cleanup while demonstrating that Activity preserves the `<video>` element's playback position.
+The [video comparison](#examples-preserving-media-state) includes this cleanup while demonstrating that Activity preserves the `<video>` element's playback position.
 
 ---
 

--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -38,83 +38,44 @@ import { Activity } from 'react';
 
 An Activity boundary supports two modes:
 
-- In `visible` mode, React renders the children and runs the setup functions for
-  their `useEffect` and `useLayoutEffect` calls.
-- In `hidden` mode, React hides the children and runs the cleanup functions for
-  their `useEffect` and `useLayoutEffect` calls. React preserves their state and
-  renders updates at a lower priority than updates to visible content.
+- In `visible` mode, React renders the children, attaches their refs, and runs the setup functions for their `useEffect` and `useLayoutEffect` calls.
+- In `hidden` mode, React hides the children, detaches their refs, and runs the cleanup functions for their `useEffect` and `useLayoutEffect` calls. React preserves their state and renders updates at a lower priority than updates to visible content.
 
-When a hidden Activity boundary becomes visible, React reveals its children with
-their previous state and runs their Effect setup functions again.
+When a hidden Activity boundary becomes visible, React reveals its children with their previous state and runs their Effect setup functions again.
 
-In React DOM, hiding an Activity boundary applies `display: none` to the nearest
-DOM elements inside the boundary. React preserves those elements while the
-boundary remains mounted.
+In React DOM, hiding an Activity boundary applies `display: none` to the nearest DOM elements inside the boundary. React preserves those elements while the boundary remains mounted.
+
+Insertion Effects created with [`useInsertionEffect`](/reference/react/useInsertionEffect) remain connected while an Activity boundary is hidden because styles may still be needed by the preserved DOM.
 
 #### Props {/*props*/}
 
-* `children`: The UI rendered by the Activity boundary. `children` can be any
-  [React node](/reference/react/isValidElement#react-elements-vs-react-nodes).
-* **optional** `mode`: Either `'visible'` or `'hidden'`. Defaults to `'visible'`.
-  See [Modes](#modes) for the behavior of each value.
-* **optional** `name`: A string that identifies the Activity boundary in React
-  Developer Tools.
+* `children`: The UI rendered by the Activity boundary. `children` can be any [React node](/reference/react/isValidElement#react-elements-vs-react-nodes).
+* **optional** `mode`: Either `'visible'` or `'hidden'`. Defaults to `'visible'`. See [Modes](#modes) for the behavior of each value.
+* **optional** `name`: A string that identifies the Activity boundary in React Developer Tools.
 
 #### Caveats {/*caveats*/}
 
-- Hiding an Activity boundary retains its state and DOM nodes, so React does not
-  reclaim all memory associated with the hidden subtree.
-- Browser behavior associated with preserved DOM nodes can continue while the
-  boundary is hidden. For example, audio and video can continue playing. Use an
-  Effect cleanup function to stop this behavior.
-  [See an example below.](#my-hidden-components-have-unwanted-side-effects)
-- React runs cleanup functions for Effects created with `useEffect` and
-  `useLayoutEffect` when an Activity boundary becomes hidden. Insertion Effects
-  created with
-  [`useInsertionEffect`](/reference/react/useInsertionEffect)
-  remain connected because styles may still be needed by the preserved DOM.
-- React detaches refs in a hidden Activity boundary and reattaches them when the
-  boundary becomes visible.
-- Content initially rendered inside `<Activity mode="hidden">` is not included in
-  server-rendered HTML. React renders it on the client at a lower priority after
-  hydrating visible content.
-- React omits text-only output while an Activity boundary is hidden because a text
-  node cannot receive `display: none`. The text appears when the boundary becomes
-  visible.
-- If an Activity boundary is inside
-  [`<ViewTransition>`](/reference/react/ViewTransition),
-  changing it from hidden to visible as part of an update started with
-  [`startTransition`](/reference/react/startTransition) activates the `enter`
-  animation. Changing it from visible to hidden as part of that update activates
-  the `exit` animation.
+- Browser behavior associated with preserved DOM nodes can continue while the boundary is hidden. For example, audio and video can continue playing. Use an Effect cleanup function to stop this behavior. [See an example below.](#my-hidden-components-have-unwanted-side-effects)
+- React omits text-only output while an Activity boundary is hidden because a text node cannot receive `display: none`. The text appears when the boundary becomes visible.
+- If an Activity boundary is inside [`<ViewTransition>`](/reference/react/ViewTransition), changing it from hidden to visible as part of an update started with [`startTransition`](/reference/react/startTransition) activates the `enter` animation. Changing it from visible to hidden as part of that update activates the `exit` animation.
 
 ---
 
 ## Usage {/*usage*/}
 
-Activity is useful when part of the UI may become hidden and visible again. Unlike
-conditional rendering, hiding an Activity boundary preserves both React state and
-the DOM state of its children. Unlike hiding content only with CSS, Activity also
-cleans up the children's Effects and deprioritizes their updates while they are
-hidden.
+Activity is useful when part of the UI may become hidden and visible again. Unlike conditional rendering, hiding an Activity boundary preserves both React state and the DOM state of its children. Unlike hiding content only with CSS, Activity also cleans up the children's Effects and deprioritizes their updates while they are hidden.
 
-Use an Activity boundary when preserving that work is valuable—for example, for a
-tab the user is likely to revisit or a panel that can prepare data in the
-background. If the content is unlikely to become visible again, conditionally
-rendering it may be preferable because unmounting allows React and the browser to
-release its resources.
+Use an Activity boundary when preserving that work is valuable—for example, for a tab the user is likely to revisit or a panel that can prepare data in the background. A hidden boundary retains its state and DOM nodes, so it continues using memory. If the content is unlikely to become visible again, conditionally rendering it may be preferable because unmounting allows React and the browser to release its resources.
 
 ### Preserving state while content is hidden {/*restoring-the-state-of-hidden-components*/}
 
-When this condition becomes false, React removes `<Sidebar>` from the tree and
-discards its state:
+When this condition becomes false, React removes `<Sidebar>` from the tree and discards its state:
 
 ```js
 {isShowingSidebar && <Sidebar />}
 ```
 
-Render the component inside an Activity boundary to preserve its state while it is
-hidden:
+Render the component inside an Activity boundary to preserve its state while it is hidden:
 
 ```js
 <Activity mode={isShowingSidebar ? 'visible' : 'hidden'}>
@@ -122,8 +83,7 @@ hidden:
 </Activity>
 ```
 
-In this example, expand the sidebar, hide it, and show it again. The expanded state
-is preserved.
+In this example, expand the sidebar, hide it, and show it again. The expanded state is preserved.
 
 <Sandpack>
 
@@ -208,21 +168,15 @@ main {
 
 </Sandpack>
 
-Changing `mode` preserves the state of the children. Removing the boundary or
-changing a child's type, key, or position can
-[reset its state](/learn/preserving-and-resetting-state).
+Changing `mode` preserves the state of the children. Removing the boundary or changing a child's type, key, or position can [reset its state](/learn/preserving-and-resetting-state).
 
 ---
 
 ### Preserving DOM state while content is hidden {/*restoring-the-dom-of-hidden-components*/}
 
-An Activity boundary also preserves state held by the browser in DOM nodes. This
-includes an uncontrolled input's current value, scroll position, and media
-playback position.
+An Activity boundary also preserves state held by the browser in DOM nodes. This includes an uncontrolled input's current value, scroll position, and media playback position.
 
-In this example, enter a draft in the Contact section, switch sections, and then
-return to Contact. The `<textarea>` value remains because its DOM node was hidden
-rather than removed.
+In this example, enter a draft in the Contact section, switch sections, and then return to Contact. The `<textarea>` value remains because its DOM node was hidden rather than removed.
 
 <Sandpack>
 
@@ -306,18 +260,13 @@ textarea {
 
 </Sandpack>
 
-Preserving DOM state also means that DOM behavior can continue while content is
-hidden. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects)
-for DOM behavior that requires explicit cleanup.
+Preserving DOM state also means that DOM behavior can continue while content is hidden. See [Troubleshooting](#my-hidden-components-have-unwanted-side-effects) for DOM behavior that requires explicit cleanup.
 
 ---
 
 ### Pre-rendering content that is likely to become visible {/*pre-rendering-content-thats-likely-to-become-visible*/}
 
-An Activity boundary can also prepare content before the user sees it. Content
-inside a hidden boundary renders at a lower priority without running Effects
-created with `useEffect` or `useLayoutEffect`. This lets the content load code and
-render-time data without delaying updates to visible content:
+An Activity boundary can also prepare content before the user sees it. Content inside a hidden boundary renders at a lower priority without running Effects created with `useEffect` or `useLayoutEffect`. This lets the content load code and render-time data without delaying updates to visible content:
 
 ```js
 <Suspense fallback={<Loading />}>
@@ -327,13 +276,9 @@ render-time data without delaying updates to visible content:
 </Suspense>
 ```
 
-If `Posts` suspends while reading code or data, React continues rendering the rest
-of the page. If that hidden work completes, switching to the Posts tab can reveal
-the content without waiting for the same work again.
+If `Posts` suspends while reading code or data, React continues rendering the rest of the page. If that hidden work completes, switching to the Posts tab can reveal the content without waiting for the same work again.
 
-The following example renders the Posts tab in a hidden Activity boundary when the
-page first loads. Wait briefly before selecting **Posts**. The list is available
-immediately because the hidden render started loading it in the background.
+The following example renders the Posts tab in a hidden Activity boundary when the page first loads. Wait briefly before selecting **Posts**. The list is available immediately because the hidden render started loading it in the background.
 
 <Sandpack>
 
@@ -423,20 +368,13 @@ button {
 
 </Sandpack>
 
-If the user selects Posts before the hidden render finishes, the nearest Suspense
-fallback appears until the data is ready. Activity improves the likely case where
-the background work finishes first; it does not guarantee that the content will
-always be ready.
+If the user selects Posts before the hidden render finishes, the nearest Suspense fallback appears until the data is ready. Activity improves the likely case where the background work finishes first; it does not guarantee that the content will always be ready.
 
 <Note>
 
-Only code and data read during rendering can load during pre-rendering. Activity
-does not run Effects in hidden content, so data fetched inside an Effect does not
-load until the boundary becomes visible.
+Only code and data read during rendering can load during pre-rendering. Activity does not run Effects in hidden content, so data fetched inside an Effect does not load until the boundary becomes visible.
 
-The data source must integrate with Suspense. For example, the component can read a
-cached Promise with [`use`](/reference/react/use). See
-[what activates a Suspense boundary](/reference/react/Suspense#what-activates-a-suspense-boundary).
+The data source must integrate with Suspense. For example, the component can read a cached Promise with [`use`](/reference/react/use). See [what activates a Suspense boundary](/reference/react/Suspense#what-activates-a-suspense-boundary).
 
 </Note>
 
@@ -444,10 +382,7 @@ cached Promise with [`use`](/reference/react/use). See
 
 ### Improving hydration performance {/*speeding-up-interactions-during-page-load*/}
 
-Activity boundaries also divide server-rendered pages into units that React can
-hydrate independently. This is related to the selective hydration behavior of
-[`<Suspense>`](/reference/react/Suspense), but it does not require displaying a
-fallback in the initial UI.
+Activity boundaries also divide server-rendered pages into units that React can hydrate independently. This is related to the selective hydration behavior of [`<Suspense>`](/reference/react/Suspense), but it does not require displaying a fallback in the initial UI.
 
 For example, without a boundary React hydrates this page as one unit:
 
@@ -462,8 +397,7 @@ function Page() {
 }
 ```
 
-Wrapping `Comments` in an always-visible Activity boundary creates a separate
-hydration unit:
+Wrapping `Comments` in an always-visible Activity boundary creates a separate hydration unit:
 
 ```js
 function Page() {
@@ -478,10 +412,7 @@ function Page() {
 }
 ```
 
-The boundary is visible because the `mode` prop defaults to `'visible'`. Its
-server-rendered HTML remains visible, but React can hydrate it independently from
-the surrounding page. If the user interacts with that content before React reaches
-it, React prioritizes hydrating the boundary.
+The boundary is visible because the `mode` prop defaults to `'visible'`. Its server-rendered HTML remains visible, but React can hydrate it independently from the surrounding page. If the user interacts with that content before React reaches it, React prioritizes hydrating the boundary.
 
 You can also use visible and hidden Activity boundaries for tabbed content:
 
@@ -509,12 +440,7 @@ function Page() {
 }
 ```
 
-React does not include initially hidden `<Activity>` content in server-rendered HTML.
-On the client, React hydrates the visible content first and renders the hidden
-content later at a lower priority. Initially visible boundaries are included in the
-server-rendered HTML and can be hydrated independently. This allows the visible tab
-and the controls around it to become interactive without waiting for React to
-render the initially hidden tab.
+React does not include initially hidden `<Activity>` content in server-rendered HTML. On the client, React hydrates the visible content first and renders the hidden content later at a lower priority. Initially visible boundaries are included in the server-rendered HTML and can be hydrated independently. This allows the visible tab and the controls around it to become interactive without waiting for React to render the initially hidden tab.
 
 ---
 
@@ -522,21 +448,15 @@ render the initially hidden tab.
 
 ### My hidden components have unwanted side effects {/*my-hidden-components-have-unwanted-side-effects*/}
 
-`<Activity>` hides DOM nodes without removing them. Browser-managed behavior from
-elements such as `<video>`, `<audio>`, and `<iframe>` can therefore continue while
-the boundary is hidden.
+`<Activity>` hides DOM nodes without removing them. Browser-managed behavior from elements such as `<video>`, `<audio>`, and `<iframe>` can therefore continue while the boundary is hidden.
 
 <Pitfall>
 
 ##### Preserved media can continue playing {/*preserved-media-can-continue-playing*/}
 
-Unmounting a `<video>` element stops playback because the browser removes the DOM
-node. Hiding it with Activity preserves the node, so playback continues unless the
-component pauses it explicitly.
+Unmounting a `<video>` element stops playback because the browser removes the DOM node. Hiding it with Activity preserves the node, so playback continues unless the component pauses it explicitly.
 
-Add the corresponding cleanup to an Effect. For behavior that must stop at the
-same time React hides the boundary, use
-[`useLayoutEffect`](/reference/react/useLayoutEffect):
+Add the corresponding cleanup to an Effect. For behavior that must stop at the same time React hides the boundary, use [`useLayoutEffect`](/reference/react/useLayoutEffect):
 
 ```js
 import { useLayoutEffect, useRef } from 'react';
@@ -556,17 +476,11 @@ function VideoPlayer({ src }) {
 }
 ```
 
-React runs the cleanup when an enclosing Activity boundary becomes hidden. Because
-the `<video>` node remains in the DOM, its playback position is preserved for when
-the boundary becomes visible again.
+React runs the cleanup when an enclosing Activity boundary becomes hidden. Because the `<video>` node remains in the DOM, its playback position is preserved for when the boundary becomes visible again.
 
-The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from
-`useEffect` can run later if, for example, a Suspense boundary suspends or a View
-Transition is in progress.
+The `useLayoutEffect` cleanup runs as part of hiding the UI. A cleanup from `useEffect` can run later if, for example, a Suspense boundary suspends or a View Transition is in progress.
 
-This complete example pauses the video when you switch to Home while preserving
-its playback position. When you return to Video, playback can continue from the
-same position without recreating the element or downloading it again.
+This complete example pauses the video when you switch to Home while preserving its playback position. When you return to Video, playback can continue from the same position without recreating the element or downloading it again.
 
 <Sandpack>
 
@@ -651,16 +565,11 @@ video {
 
 ### My hidden components have Effects that are not running {/*my-hidden-components-have-effects-that-arent-running*/}
 
-React runs cleanup functions for Effects created with `useEffect` and
-`useLayoutEffect` when an Activity boundary becomes hidden. It runs their setup
-functions again when the boundary becomes visible.
+React runs cleanup functions for Effects created with `useEffect` and `useLayoutEffect` when an Activity boundary becomes hidden. It runs their setup functions again when the boundary becomes visible.
 
-An Effect inside a hidden Activity boundary cannot remain active. Move ongoing
-work that must continue while the UI is hidden to a component outside the boundary,
-or keep the boundary visible.
+An Effect inside a hidden Activity boundary cannot remain active. Move ongoing work that must continue while the UI is hidden to a component outside the boundary, or keep the boundary visible.
 
-If an Effect controls an external system, return a cleanup function so hiding the
-boundary disconnects from that system:
+If an Effect controls an external system, return a cleanup function so hiding the boundary disconnects from that system:
 
 ```js
 useEffect(() => {
@@ -673,6 +582,4 @@ useEffect(() => {
 }, []);
 ```
 
-Use [`<StrictMode>`](/reference/react/StrictMode) to find Effects that do not clean
-up correctly. Strict Mode performs an additional setup and cleanup cycle in
-development.
+Use [`<StrictMode>`](/reference/react/StrictMode) to find Effects that do not clean up correctly. Strict Mode performs an additional setup and cleanup cycle in development.


### PR DESCRIPTION
## Summary


- restructures the <Activity> page as a lookup-oriented API reference with explicit modes, props, and caveats
- preserves the useful explanations from the earlier Activity documentation while keeping the writing in API-reference voice
- retains the expandable sidebar, presents the contact-form DOM-state and Posts-tab pre-rendering examples step by step, and keeps a before-and-after switcher for flower-video playback position
- keeps the pre-rendering, hydration, and Effect-cleanup guidance while documenting ref, server-rendering, text-only output, View Transition, memory, and React Developer Tools behavior
- standardizes example spacing and keeps supporting code out of the primary code tabs where possible

## Validation

- yarn eslint src/content/reference/react/Activity.md
- yarn lint-heading-ids
- yarn tsc
- verified the sidebar and both variants of the form, video, and pre-rendering examples at localhost:3034
- confirmed that the local page reports no browser errors
