### PR TITLE
Fix unused useState import in lifecycle effects example

### DIFF
--- a/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/src/content/learn/lifecycle-of-reactive-effects.md
@@ -1375,7 +1375,7 @@ export default function App() {
 ```
 
 ```js {expectedErrors: {'react-compiler': [8]}} src/ChatRoom.js active
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
 export default function ChatRoom({ roomId, createConnection }) {
   useEffect(() => {


### PR DESCRIPTION
Removed the unused `useState` import from the `ChatRoom.js` example in the Lifecycle of Reactive Effects documentation.

This fixes the unused import mentioned in issue #8231.
