### PR TITLE
Clarify error handling for standalone startTransition

### DIFF
--- a/src/content/reference/react/startTransition.md
+++ b/src/content/reference/react/startTransition.md
@@ -92,14 +92,7 @@ With a Transition, your UI stays responsive in the middle of a re-render. For ex
 
 <Note>
 
-`startTransition` is very similar to
-[`useTransition`](/reference/react/useTransition), except that it does not
-provide the `isPending` flag to track whether a Transition is ongoing. The
-standalone function is also not associated with a component, so if the function
-passed to it throws an error or returns a rejected Promise, React reports the
-error as uncaught. You can call `startTransition` when `useTransition` is not
-available. For example, `startTransition` works outside components, such as from
-a data library.
+`startTransition` is very similar to [`useTransition`](/reference/react/useTransition), except that it does not provide the `isPending` flag to track whether a Transition is ongoing. The standalone function is also not associated with a component, so if the function passed to it throws an error or returns a rejected Promise, React reports the error with [`reportError`](https://developer.mozilla.org/en-US/docs/Web/API/Window/reportError). You can call `startTransition` when `useTransition` is not available. For example, `startTransition` works outside components, such as from a data library.
 
 [Learn about Transitions and see examples on the `useTransition` page.](/reference/react/useTransition)
 

--- a/src/content/reference/react/startTransition.md
+++ b/src/content/reference/react/startTransition.md
@@ -53,14 +53,7 @@ function TabContainer() {
 
 * You can wrap an update into a Transition only if you have access to the `set` function of that state. If you want to start a Transition in response to some prop or a custom Hook return value, try [`useDeferredValue`](/reference/react/useDeferredValue) instead.
 
-* The function you pass to `startTransition` is called immediately, marking all
-  state updates that happen while it executes as Transitions. If you try to
-  perform state updates in a `setTimeout`, for example, they won't be marked as
-  Transitions. If the function throws an error or returns a rejected Promise,
-  React reports the error as uncaught because the standalone `startTransition`
-  function is not associated with a component. [Learn how to display errors
-  from `useTransition` with an Error
-  Boundary.](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary)
+* The function you pass to `startTransition` is called immediately, marking all state updates that happen while it executes as Transitions. If you try to perform state updates in a `setTimeout`, for example, they won't be marked as Transitions.
 
 * You must wrap any state updates after any async requests in another `startTransition` to mark them as Transitions. This is a known limitation that we will fix in the future (see [Troubleshooting](/reference/react/useTransition#react-doesnt-treat-my-state-update-after-await-as-a-transition)).
 
@@ -99,11 +92,14 @@ With a Transition, your UI stays responsive in the middle of a re-render. For ex
 
 <Note>
 
-The standalone `startTransition` and the function returned by
-[`useTransition`](/reference/react/useTransition) both mark state updates as
-Transitions. Unlike `useTransition`, the standalone function does not provide
-the `isPending` flag. It is not a Hook, so you can call it outside components.
-[See Caveats.](#caveats)
+`startTransition` is very similar to
+[`useTransition`](/reference/react/useTransition), except that it does not
+provide the `isPending` flag to track whether a Transition is ongoing. The
+standalone function is also not associated with a component, so if the function
+passed to it throws an error or returns a rejected Promise, React reports the
+error as uncaught. You can call `startTransition` when `useTransition` is not
+available. For example, `startTransition` works outside components, such as from
+a data library.
 
 [Learn about Transitions and see examples on the `useTransition` page.](/reference/react/useTransition)
 

--- a/src/content/reference/react/startTransition.md
+++ b/src/content/reference/react/startTransition.md
@@ -51,17 +51,17 @@ function TabContainer() {
 
 * `startTransition` does not provide a way to track whether a Transition is pending. To show a pending indicator while the Transition is ongoing, you need [`useTransition`](/reference/react/useTransition) instead.
 
-* The standalone `startTransition` function is not associated with a component.
-  If the `action` throws an error or returns a rejected Promise, React reports
-  the error as uncaught, and an Error Boundary does not handle it. In contrast,
-  the `startTransition` function returned by
-  [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary)
-  is associated with a component, so the nearest Error Boundary can handle
-  these errors.
-
 * You can wrap an update into a Transition only if you have access to the `set` function of that state. If you want to start a Transition in response to some prop or a custom Hook return value, try [`useDeferredValue`](/reference/react/useDeferredValue) instead.
 
-* The function you pass to `startTransition` is called immediately, marking all state updates that happen while it executes as Transitions. If you try to perform state updates in a `setTimeout`, for example, they won't be marked as Transitions.
+* The function you pass to `startTransition` is called immediately, marking all
+  state updates that happen while it executes as Transitions. If you try to
+  perform state updates in a `setTimeout`, for example, they won't be marked as
+  Transitions. If the function throws an error or returns a rejected Promise,
+  React reports the error as uncaught. Unlike the `startTransition` function
+  returned by
+  [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary),
+  the standalone `startTransition` function is not associated with a component,
+  so an Error Boundary does not handle these errors.
 
 * You must wrap any state updates after any async requests in another `startTransition` to mark them as Transitions. This is a known limitation that we will fix in the future (see [Troubleshooting](/reference/react/useTransition#react-doesnt-treat-my-state-update-after-await-as-a-transition)).
 
@@ -103,9 +103,11 @@ With a Transition, your UI stays responsive in the middle of a re-render. For ex
 The standalone `startTransition` and the function returned by
 [`useTransition`](/reference/react/useTransition) both mark state updates as
 Transitions. The standalone function does not provide the `isPending` flag and
-is not associated with a component, so an Error Boundary cannot handle errors
-from its Action. Unlike `useTransition`, the standalone `startTransition` is not
-a Hook and can be called outside components. [See Caveats.](#caveats)
+is not associated with a component. If the function passed to it throws an
+error or returns a rejected Promise, React reports the error as uncaught instead
+of allowing an Error Boundary to handle it. Unlike `useTransition`, the
+standalone `startTransition` is not a Hook and can be called outside components.
+[See Caveats.](#caveats)
 
 [Learn about Transitions and see examples on the `useTransition` page.](/reference/react/useTransition)
 

--- a/src/content/reference/react/startTransition.md
+++ b/src/content/reference/react/startTransition.md
@@ -57,11 +57,10 @@ function TabContainer() {
   state updates that happen while it executes as Transitions. If you try to
   perform state updates in a `setTimeout`, for example, they won't be marked as
   Transitions. If the function throws an error or returns a rejected Promise,
-  React reports the error as uncaught. Unlike the `startTransition` function
-  returned by
-  [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary),
-  the standalone `startTransition` function is not associated with a component,
-  so an Error Boundary does not handle these errors.
+  React reports the error as uncaught because the standalone `startTransition`
+  function is not associated with a component. [Learn how to display errors
+  from `useTransition` with an Error
+  Boundary.](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary)
 
 * You must wrap any state updates after any async requests in another `startTransition` to mark them as Transitions. This is a known limitation that we will fix in the future (see [Troubleshooting](/reference/react/useTransition#react-doesnt-treat-my-state-update-after-await-as-a-transition)).
 
@@ -102,11 +101,8 @@ With a Transition, your UI stays responsive in the middle of a re-render. For ex
 
 The standalone `startTransition` and the function returned by
 [`useTransition`](/reference/react/useTransition) both mark state updates as
-Transitions. The standalone function does not provide the `isPending` flag and
-is not associated with a component. If the function passed to it throws an
-error or returns a rejected Promise, React reports the error as uncaught instead
-of allowing an Error Boundary to handle it. Unlike `useTransition`, the
-standalone `startTransition` is not a Hook and can be called outside components.
+Transitions. Unlike `useTransition`, the standalone function does not provide
+the `isPending` flag. It is not a Hook, so you can call it outside components.
 [See Caveats.](#caveats)
 
 [Learn about Transitions and see examples on the `useTransition` page.](/reference/react/useTransition)

--- a/src/content/reference/react/startTransition.md
+++ b/src/content/reference/react/startTransition.md
@@ -53,10 +53,11 @@ function TabContainer() {
 
 * The standalone `startTransition` function is not associated with a component.
   If the `action` throws an error or returns a rejected Promise, React reports
-  the error as uncaught, and an Error Boundary does not handle it. To let the
-  nearest Error Boundary handle these errors, use the `startTransition`
-  function returned by
-  [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary).
+  the error as uncaught, and an Error Boundary does not handle it. In contrast,
+  the `startTransition` function returned by
+  [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary)
+  is associated with a component, so the nearest Error Boundary can handle
+  these errors.
 
 * You can wrap an update into a Transition only if you have access to the `set` function of that state. If you want to start a Transition in response to some prop or a custom Hook return value, try [`useDeferredValue`](/reference/react/useDeferredValue) instead.
 
@@ -99,11 +100,12 @@ With a Transition, your UI stays responsive in the middle of a re-render. For ex
 
 <Note>
 
-`startTransition` does not provide the `isPending` flag. Call it from code that
-cannot call Hooks, such as data-library code outside a component. Unlike the
-function returned by [`useTransition`](/reference/react/useTransition), the
-standalone `startTransition` is not associated with a component. As a result,
-an Error Boundary cannot handle errors from its Action. [See Caveats.](#caveats)
+The standalone `startTransition` and the function returned by
+[`useTransition`](/reference/react/useTransition) both mark state updates as
+Transitions. The standalone function does not provide the `isPending` flag and
+is not associated with a component, so an Error Boundary cannot handle errors
+from its Action. Unlike `useTransition`, the standalone `startTransition` is not
+a Hook and can be called outside components. [See Caveats.](#caveats)
 
 [Learn about Transitions and see examples on the `useTransition` page.](/reference/react/useTransition)
 

--- a/src/content/reference/react/startTransition.md
+++ b/src/content/reference/react/startTransition.md
@@ -51,6 +51,8 @@ function TabContainer() {
 
 * `startTransition` does not provide a way to track whether a Transition is pending. To show a pending indicator while the Transition is ongoing, you need [`useTransition`](/reference/react/useTransition) instead.
 
+* The standalone `startTransition` function is not associated with a component. If the `action` throws an error or returns a rejected Promise, React reports the error as uncaught instead of sending it to an Error Boundary. To send errors to the nearest Error Boundary, use the `startTransition` function returned by [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-an-error-boundary).
+
 * You can wrap an update into a Transition only if you have access to the `set` function of that state. If you want to start a Transition in response to some prop or a custom Hook return value, try [`useDeferredValue`](/reference/react/useDeferredValue) instead.
 
 * The function you pass to `startTransition` is called immediately, marking all state updates that happen while it executes as Transitions. If you try to perform state updates in a `setTimeout`, for example, they won't be marked as Transitions.
@@ -92,7 +94,7 @@ With a Transition, your UI stays responsive in the middle of a re-render. For ex
 
 <Note>
 
-`startTransition` is very similar to [`useTransition`](/reference/react/useTransition), except that it does not provide the `isPending` flag to track whether a Transition is ongoing. You can call `startTransition` when `useTransition` is not available. For example, `startTransition` works outside components, such as from a data library.
+Unlike the `startTransition` function returned by [`useTransition`](/reference/react/useTransition), the standalone `startTransition` does not provide the `isPending` flag and is not associated with a component. This means React cannot identify which Error Boundary should handle errors thrown by the `action`, so it reports them as uncaught. You can call the standalone `startTransition` when `useTransition` is not available, such as from a data library outside a component.
 
 [Learn about Transitions and see examples on the `useTransition` page.](/reference/react/useTransition)
 

--- a/src/content/reference/react/startTransition.md
+++ b/src/content/reference/react/startTransition.md
@@ -51,7 +51,12 @@ function TabContainer() {
 
 * `startTransition` does not provide a way to track whether a Transition is pending. To show a pending indicator while the Transition is ongoing, you need [`useTransition`](/reference/react/useTransition) instead.
 
-* The standalone `startTransition` function is not associated with a component. If the `action` throws an error or returns a rejected Promise, React reports the error as uncaught instead of sending it to an Error Boundary. To send errors to the nearest Error Boundary, use the `startTransition` function returned by [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-an-error-boundary).
+* The standalone `startTransition` function is not associated with a component.
+  If the `action` throws an error or returns a rejected Promise, React reports
+  the error as uncaught, and an Error Boundary does not handle it. To let the
+  nearest Error Boundary handle these errors, use the `startTransition`
+  function returned by
+  [`useTransition`](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary).
 
 * You can wrap an update into a Transition only if you have access to the `set` function of that state. If you want to start a Transition in response to some prop or a custom Hook return value, try [`useDeferredValue`](/reference/react/useDeferredValue) instead.
 
@@ -94,7 +99,11 @@ With a Transition, your UI stays responsive in the middle of a re-render. For ex
 
 <Note>
 
-Unlike the `startTransition` function returned by [`useTransition`](/reference/react/useTransition), the standalone `startTransition` does not provide the `isPending` flag and is not associated with a component. This means React cannot identify which Error Boundary should handle errors thrown by the `action`, so it reports them as uncaught. You can call the standalone `startTransition` when `useTransition` is not available, such as from a data library outside a component.
+`startTransition` does not provide the `isPending` flag. Call it from code that
+cannot call Hooks, such as data-library code outside a component. Unlike the
+function returned by [`useTransition`](/reference/react/useTransition), the
+standalone `startTransition` is not associated with a component. As a result,
+an Error Boundary cannot handle errors from its Action. [See Caveats.](#caveats)
 
 [Learn about Transitions and see examples on the `useTransition` page.](/reference/react/useTransition)
 

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -1744,8 +1744,8 @@ This is a JavaScript limitation due to React losing the scope of the async conte
 ### I want to call `useTransition` from outside a component {/*i-want-to-call-usetransition-from-outside-a-component*/}
 
 You can't call `useTransition` outside a component because it's a Hook. In this
-case, use the standalone [`startTransition`](/reference/react/startTransition)
-function instead. It marks state updates as Transitions but does not provide the
+case, the standalone [`startTransition`](/reference/react/startTransition)
+function can mark state updates as Transitions. It does not provide the
 `isPending` flag. Because the standalone function is not associated with a
 component, an Error Boundary cannot handle errors from its Action.
 

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -1567,7 +1567,7 @@ main {
 
 ### Displaying an error to users with an error boundary {/*displaying-an-error-to-users-with-error-boundary*/}
 
-If a function passed to `startTransition` throws an error, you can display an error to your user with an [error boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary). To use an error boundary, wrap the component where you are calling the `useTransition` in an error boundary. Once the function passed to `startTransition` errors, the fallback for the error boundary will be displayed.
+The `startTransition` function returned by `useTransition` is associated with the component that called the Hook. If a function passed to it throws an error, React sends the error to the nearest [error boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary). Wrap the component that calls `useTransition` in an error boundary to display a fallback when an Action throws.
 
 <Sandpack>
 
@@ -1738,7 +1738,7 @@ This is a JavaScript limitation due to React losing the scope of the async conte
 
 ### I want to call `useTransition` from outside a component {/*i-want-to-call-usetransition-from-outside-a-component*/}
 
-You can't call `useTransition` outside a component because it's a Hook. In this case, use the standalone [`startTransition`](/reference/react/startTransition) method instead. It works the same way, but it doesn't provide the `isPending` indicator.
+You can't call `useTransition` outside a component because it's a Hook. In this case, use the standalone [`startTransition`](/reference/react/startTransition) function instead. It can mark state updates as Transitions, but it is not associated with a component. This means it cannot provide an `isPending` indicator or send errors to the nearest Error Boundary.
 
 ---
 

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -1567,12 +1567,7 @@ main {
 
 ### Displaying an error to users with an error boundary {/*displaying-an-error-to-users-with-error-boundary*/}
 
-The `startTransition` function returned by `useTransition` is associated with
-the component that called the Hook. If the Action passed to `startTransition`
-throws an error or returns a rejected Promise, the nearest
-[Error Boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary)
-can handle the error. Wrap the component that calls `useTransition` in an Error
-Boundary to display a fallback for these errors.
+If a function passed to `startTransition` throws an error or returns a rejected Promise, you can display an error to your user with an [error boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary). To use an error boundary, wrap the component where you are calling the `useTransition` in an error boundary. Once the function passed to `startTransition` errors, the fallback for the error boundary will be displayed.
 
 <Sandpack>
 

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -1567,7 +1567,12 @@ main {
 
 ### Displaying an error to users with an error boundary {/*displaying-an-error-to-users-with-error-boundary*/}
 
-The `startTransition` function returned by `useTransition` is associated with the component that called the Hook. If a function passed to it throws an error, React sends the error to the nearest [error boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary). Wrap the component that calls `useTransition` in an error boundary to display a fallback when an Action throws.
+The `startTransition` function returned by `useTransition` is associated with
+the component that called the Hook. If the Action passed to `startTransition`
+throws an error or returns a rejected Promise, the nearest
+[Error Boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary)
+can handle the error. Wrap the component that calls `useTransition` in an Error
+Boundary to display a fallback for these errors.
 
 <Sandpack>
 
@@ -1738,7 +1743,11 @@ This is a JavaScript limitation due to React losing the scope of the async conte
 
 ### I want to call `useTransition` from outside a component {/*i-want-to-call-usetransition-from-outside-a-component*/}
 
-You can't call `useTransition` outside a component because it's a Hook. In this case, use the standalone [`startTransition`](/reference/react/startTransition) function instead. It can mark state updates as Transitions, but it is not associated with a component. This means it cannot provide an `isPending` indicator or send errors to the nearest Error Boundary.
+You can't call `useTransition` outside a component because it's a Hook. In this
+case, use the standalone [`startTransition`](/reference/react/startTransition)
+function instead. It marks state updates as Transitions but does not provide the
+`isPending` flag. Because the standalone function is not associated with a
+component, an Error Boundary cannot handle errors from its Action.
 
 ---
 

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -1742,7 +1742,7 @@ You can't call `useTransition` outside a component because it's a Hook. In this
 case, the standalone [`startTransition`](/reference/react/startTransition)
 function can mark state updates as Transitions. It does not provide the
 `isPending` flag. Because the standalone function is not associated with a
-component, an Error Boundary cannot handle errors from its Action.
+component, an Error Boundary cannot handle errors from its Transition.
 
 ---
 


### PR DESCRIPTION
## Summary

- document the pending-state, component-association, and error-handling differences between the standalone `startTransition` function and the function returned by `useTransition`
- clarify that errors from a standalone Action are reported as uncaught, while errors from an Action passed to the hook-returned function can be handled by the component's nearest Error Boundary
- note that the standalone function is not a Hook and can also be called outside components

## Validation

- `yarn eslint src/content/reference/react/startTransition.md src/content/reference/react/useTransition.md`
- `yarn lint-heading-ids`
- `yarn tsc`
- `git diff --check`
