### PR TITLE
Use stable React 19.3 in Sandpacks

### DIFF
--- a/src/components/MDX/Sandpack/template.ts
+++ b/src/components/MDX/Sandpack/template.ts
@@ -35,8 +35,8 @@ root.render(
           eject: 'react-scripts eject',
         },
         dependencies: {
-          react: '19.3.0-canary-f1f7ed2a-20260904',
-          'react-dom': '19.3.0-canary-f1f7ed2a-20260904',
+          react: '^19.3.0',
+          'react-dom': '^19.3.0',
           'react-scripts': '^5.0.0',
         },
       },

--- a/src/components/MDX/Sandpack/templateRSC.ts
+++ b/src/components/MDX/Sandpack/templateRSC.ts
@@ -91,8 +91,8 @@ export const templateRSC: SandpackFiles = {
         version: '0.0.0',
         main: '/src/index.js',
         dependencies: {
-          react: '19.3.0-canary-f1f7ed2a-20260904',
-          'react-dom': '19.3.0-canary-f1f7ed2a-20260904',
+          react: '19.3.0',
+          'react-dom': '19.3.0',
         },
       },
       null,

--- a/src/content/blog/2026/09/09/react-19-3.md
+++ b/src/content/blog/2026/09/09/react-19-3.md
@@ -211,8 +211,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -546,8 +546,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -797,8 +797,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1048,8 +1048,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1301,8 +1301,8 @@ img {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1476,8 +1476,8 @@ export default function InView({ onChange, children }) {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1651,8 +1651,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1791,8 +1791,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react-dom/browser.md
+++ b/src/content/reference/react-dom/browser.md
@@ -189,8 +189,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -356,8 +356,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -511,8 +511,8 @@ export default function App() {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -620,8 +620,8 @@ label {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -716,8 +716,8 @@ p {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -828,8 +828,8 @@ export default function Card({ title }) {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1018,8 +1018,8 @@ export default function Card({ title, className }) {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2515,8 +2515,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   },
   "scripts": {
@@ -2880,8 +2880,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -3038,8 +3038,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -3171,8 +3171,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -3388,8 +3388,8 @@ hr {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -425,8 +425,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -565,8 +565,8 @@ function Counter() {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -789,8 +789,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1023,8 +1023,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1224,8 +1224,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1486,8 +1486,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1717,8 +1717,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -1963,8 +1963,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -2292,8 +2292,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -2518,8 +2518,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }
@@ -2763,8 +2763,8 @@ button:hover {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   }
 }

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -1461,8 +1461,8 @@ iframe {
 ```json package.json hidden
 {
   "dependencies": {
-    "react": "19.3.0-canary-f1f7ed2a-20260904",
-    "react-dom": "19.3.0-canary-f1f7ed2a-20260904",
+    "react": "^19.3.0",
+    "react-dom": "^19.3.0",
     "react-scripts": "latest"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Replace the temporary September 4 canary pins with stable React 19.3 in the shared and page-specific Sandpacks.
- Use exact version 19.3.0 for the RSC Sandpack.
- Keep the historical 2025 React Labs post on its original canary.

## Verification

- [x] yarn lint-heading-ids
- [x] yarn deadlinks
- [ ] React 19.3 release-post Sandpacks resolve and render
- [ ] Browser and ViewTransition reference Sandpacks resolve and render
- [ ] RSC Sandpacks resolve and render

This is a draft while the Sandpack dependency resolver catches up. As of September 9, standard Sandpacks report Cannot find module react from /src/index.js, and RSC Sandpacks report the same error from /src/rsc-client.js.