### PR TITLE
Document Strict Mode hydration behavior in React 19.3

### DIFF
--- a/src/content/blog/2026/09/09/react-19-3.md
+++ b/src/content/blog/2026/09/09/react-19-3.md
@@ -1907,6 +1907,7 @@ This is especially useful for Contexts that solely exist to allow Server Compone
 
 Other notable changes
 - `react`: Render Transitions independently instead of entangling them into a single render, so a slow Transition no longer holds up unrelated ones [#37290](https://github.com/react/react/pull/37290)
+- `react-dom`: Double invoke Effects in Strict Mode during hydration, matching client-rendered roots [#35961](https://github.com/react/react/pull/35961)
 - `react`: Add a warning when `use` is used incorrectly in a conditional [#37104](https://github.com/react/react/pull/37104)
 - `react`: Rename "form state" to "action state" in `useActionState` error messages [#35790](https://github.com/react/react/pull/35790)
 - `react-dom`: Add support for `onFullscreenChange` and `onFullscreenError` events [#34621](https://github.com/react/react/pull/34621)


### PR DESCRIPTION
## Summary

- document that React 19.3 double-invokes Effects in Strict Mode during hydration
- clarify that this matches the existing behavior for client-rendered roots
- link to the underlying React change

## Verification

- yarn lint-heading-ids
- yarn deadlinks