### PR TITLE
Fix Server Function signature and two typos in 'use server' reference

### DIFF
--- a/src/content/reference/rsc/use-server.md
+++ b/src/content/reference/rsc/use-server.md
@@ -5,7 +5,7 @@ titleForTitleTag: "'use server' directive"
 
 <RSC>
 
-`'use server'` is for use with [using React Server Components](/reference/rsc/server-components).
+`'use server'` is for use with [React Server Components](/reference/rsc/server-components).
 
 </RSC>
 
@@ -139,7 +139,7 @@ To update the UI based on the result of a Server Function while supporting progr
 // requestUsername.js
 'use server';
 
-export default async function requestUsername(formData) {
+export default async function requestUsername(prevState, formData) {
   const username = formData.get('username');
   if (canRequest(username)) {
     // ...
@@ -199,7 +199,7 @@ function LikeButton() {
   return (
     <>
       <p>Total Likes: {likeCount}</p>
-      <button onClick={onClick} disabled={isPending}>Like</button>;
+      <button onClick={onClick} disabled={isPending}>Like</button>
     </>
   );
 }


### PR DESCRIPTION
Three small fixes to `src/content/reference/rsc/use-server.md`, all still present on `main`.

Closes #7644.

**1. `requestUsername` has the wrong signature for `useActionState`.** It is defined as `requestUsername(formData)` but passed to `useActionState(requestUsername, null, 'n/a')`. React calls the action with the previous state first, so `formData` receives `null` and `formData.get('username')` throws.

The `useActionState` reference already documents this exact mistake under ["My Action cannot read form data"](https://react.dev/reference/react/useActionState#action-cannot-read-form-data) and prescribes `function action(prevState, formData)`. This applies that, using the `prevState` naming its examples use.

Note that the earlier `requestUsername(formData)` in the "Server Functions in forms" section is intentionally left unchanged — that one is passed directly to `<form action>`, where `FormData` genuinely is the first argument.

Same fix as #6685 (2024), which can no longer merge: it targets `src/content/reference/react/use-server.md`, and the page has since moved to `reference/rsc/`. Credit to @alexandreferreirafr for finding it first.

**2. Stray `;` inside JSX** in the `LikeButton` example. It sits in the fragment's children rather than after a statement, so it is JSX text and renders a literal `;` after the button. The `<p>` on the line above has no `;` — this is a typo, not a departure from the "Use semicolons" style rule in CONTRIBUTING.

**3. "for use with using React Server Components"** in the RSC banner. The sibling `use-client.md` banner reads "for use with [React Server Components]"; this matches it. Reported in #7644 and fixed in #7645, which no longer applies cleanly because the link target changed after it was opened. Credit to @nayounsang.

No line counts change, so no code-block line highlighting is affected.
