### PR TITLE
docs: clarify that useState setter triggers a re-render in Quick Start

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -336,7 +336,7 @@ function MyButton() {
 }
 ```
 
-React will call your component function again. This time, `count` will be `1`. Then it will be `2`. And so on.
+Calling `setCount()` tells React that its state has changed, which triggers a re-render. React will call your component function again. This time, `count` will be `1`. Then it will be `2`. And so on.
 
 If you render the same component multiple times, each will get its own state. Click each button separately:
 


### PR DESCRIPTION
## Description

In the "Updating the screen" section of the Quick Start guide, `useState` is introduced with a counter button example. The guide calls `setCount(count + 1)` and immediately follows with stating that React will call the component function again, without explicitly mentioning that calling the state setter triggers a re-render.

This PR adds a concise sentence explaining that calling the setter function tells React that state has changed and triggers a re-render, clarifying why the component function is re-executed for readers transitioning from plain JavaScript.

Closes #8655

## How was this tested?

- Verified that the explanation reads naturally in context.
- Checked git diff to ensure no unrelated markdown or formatting changes were made.